### PR TITLE
A small fix to a php mapscript exception message (#4279)

### DIFF
--- a/mapscript/php/php_mapscript.c
+++ b/mapscript/php/php_mapscript.c
@@ -140,7 +140,7 @@ PHP_FUNCTION(ms_newMapObj)
 
     if (map == NULL)
     {
-        mapscript_throw_mapserver_exception("Failed to open map file \"%s\"" TSRMLS_CC,  filename);
+        mapscript_throw_mapserver_exception("Failed to open map file \"%s\", or map file error." TSRMLS_CC,  filename);
         return;
     }
 
@@ -171,7 +171,7 @@ PHP_FUNCTION(ms_newMapObjFromString)
 
     if (map == NULL)
     {
-        mapscript_throw_mapserver_exception("Failed to open map file \"%s\"" TSRMLS_CC,  string);
+        mapscript_throw_mapserver_exception("Failed to open map file \"%s\", or map file error." TSRMLS_CC,  string);
         return;
     }
 


### PR DESCRIPTION
The PHP mapscript exception message that is given when there is a problem opening a map file could give a better description of the problem.  This is the suggestion I made in issue #4279.
