### PR TITLE
fix raster classification on colormapped rasters (#4316)

### DIFF
--- a/mapdrawgdal.c
+++ b/mapdrawgdal.c
@@ -611,6 +611,7 @@ int msDrawRasterLayerGDAL(mapObj *map, layerObj *layer, imageObj *image,
         color_count = MIN(256,GDALGetColorEntryCount(hColorMap));
         for(i=0; i < color_count; i++) {
             colorObj pixel;
+            int colormap_index;
             GDALColorEntry sEntry;
 
             GDALGetColorEntryAsRGB( hColorMap, i, &sEntry );
@@ -618,13 +619,11 @@ int msDrawRasterLayerGDAL(mapObj *map, layerObj *layer, imageObj *image,
             pixel.red = sEntry.c1;
             pixel.green = sEntry.c2;
             pixel.blue = sEntry.c3;
-#ifdef USE_GD
-            pixel.pen = i;
-#endif
+            colormap_index = i;
         
             if(!MS_COMPARE_COLORS(pixel, layer->offsite))
             {
-                c = msGetClass(layer, &pixel);
+                c = msGetClass(layer, &pixel, colormap_index);
             
                 if(c == -1)/* doesn't belong to any class, so handle like offsite*/
                 {

--- a/mapraster.c
+++ b/mapraster.c
@@ -168,11 +168,11 @@ static int msGetClass_String( layerObj *layer, colorObj *color, const char *pixe
 /*                             msGetClass()                             */
 /************************************************************************/
 
-int msGetClass(layerObj *layer, colorObj *color )
+int msGetClass(layerObj *layer, colorObj *color, int colormap_index)
 {
-    char pixel_value[100];
+    char pixel_value[12];
 
-    snprintf( pixel_value, sizeof(pixel_value), "%03d%03d%03d", color->red, color->green, color->blue );
+    snprintf( pixel_value, sizeof(pixel_value), "%d", colormap_index );
 
     return msGetClass_String( layer, color, pixel_value );
 }

--- a/mapserver.h
+++ b/mapserver.h
@@ -2336,7 +2336,7 @@ MS_DLL_EXPORT int msDrawRasterLayerLow(mapObj *map, layerObj *layer, imageObj *i
 #ifdef USE_GD
 MS_DLL_EXPORT int msAddColorGD(mapObj *map, gdImagePtr img, int cmt, int r, int g, int b);
 #endif
-MS_DLL_EXPORT int msGetClass(layerObj *layer, colorObj *color);
+MS_DLL_EXPORT int msGetClass(layerObj *layer, colorObj *color, int colormap_index);
 MS_DLL_EXPORT int msGetClass_FloatRGB(layerObj *layer, float fValue,
                                       int red, int green, int blue );
 


### PR DESCRIPTION
Classification code used colorObj->pen to specify the current
colortable entry's index. "pen" is GD specific and was removed
when GD support was rendered optional, so the msGetClass function
is now modified to not rely on it.

cc @warmerdam

this commit fixes #4316
