### PR TITLE
POSITION AUTO for point labels shouldn't choose from UC and LC first

### DIFF
--- a/mapdraw.c
+++ b/mapdraw.c
@@ -2976,14 +2976,14 @@ int msDrawLabelCache(imageObj *image, mapObj *map)
                   positions[2]=MS_CC;
                   npositions = 3;
                 } else {
-                  positions[0]=MS_UC;
-                  positions[1]=MS_LC;
-                  positions[2]=MS_CR;
-                  positions[3]=MS_CL;
-                  positions[4]=MS_UR;
-                  positions[5]=MS_UL;
-                  positions[6]=MS_LR;
-                  positions[7]=MS_LL;
+                  positions[0]=MS_UR;
+                  positions[1]=MS_UL;
+                  positions[2]=MS_LR;
+                  positions[3]=MS_LL;
+                  positions[4]=MS_CR;
+                  positions[5]=MS_CL;
+                  positions[6]=MS_UC;
+                  positions[7]=MS_LC;
                   npositions = 8;
                 }
 


### PR DESCRIPTION
All,

I think it is cartographically incorrect to have UC and LC as the first two options for labeling points.  As I mentioned on the dev list, from the cartography classes I have taken, and from some research I did after realizing that UC and LC are now the first options, I believe the order should be:

UR, UL, LR, LL, CR, CL, UC, LC

or

UR, LR, UL, LL, CR, RL, UC, LC
