### PR TITLE
WCS Server - Map Level Projection Object Potential Bug

### DIFF
--- a/mapwcs.c
+++ b/mapwcs.c
@@ -1617,6 +1617,15 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
 
   /* make sure the layer is on */
   lp->status = MS_ON;
+  
+  /* If the layer has no projection set, set it to the map's projection (#4079) */
+  if(lp->projection.numargs <=0) {
+    char *map_original_srs = msGetProjectionString(&(map->projection));
+    if (msLoadProjectionString(&(lp->projection), map_original_srs) != 0) {
+      msSetError( MS_WCSERR, "Error when setting map projection to a layer with no projection", "msWCSGetCoverage()" );
+      return msWCSException(map, NULL, NULL, params->version);
+    }
+  }
 
   /* we need the coverage metadata, since things like numbands may not be available otherwise */
   status = msWCSGetCoverageMetadata(lp, &cm);


### PR DESCRIPTION
**Reporter: loisg00**
**Date: 2011/11/14 - 15:27**
**Trac URL:** http://trac.osgeo.org/mapserver/ticket/4079
Hi,

The issue was first described here : http://lists.osgeo.org/pipermail/mapserver-users/2011-November/070672.html

You might want to take a look if you are in need of any information I could have missed. I'll try to cover everything here, of course.

OS : Windows XP
MapServer version : 6.0.1, prebuilt from MS4W.

> MapServer version 6.0.1 OUTPUT=GIF OUTPUT=PNG OUTPUT=JPEG OUTPUT=KML
> SUPPORTS=PR
> OJ SUPPORTS=AGG SUPPORTS=CAIRO SUPPORTS=FREETYPE SUPPORTS=ICONV
> SUPPORTS=FRIBIDI
>  SUPPORTS=WMS_SERVER SUPPORTS=WMS_CLIENT SUPPORTS=WFS_SERVER
> SUPPORTS=WFS_CLIENT
>  SUPPORTS=WCS_SERVER SUPPORTS=SOS_SERVER SUPPORTS=FASTCGI SUPPORTS=THREADS
> SUPPO
> RTS=GEOS INPUT=JPEG INPUT=POSTGIS INPUT=OGR INPUT=GDAL INPUT=SHAPEFILE

Faulty MapFile :
http://lists.osgeo.org/pipermail/mapserver-users/attachments/20111104/78e5fa24/2011102811-0001.obj

Some GetCoverage requests along with their result :

http://localhost/cgi-bin/mapserv.exe?SERVICE=WCS&map=D:/Guillaume/ProjetCourantsGlaces/WCSproblem/2011102811.map&COVERAGE=thelayer&VERSION=1.0.0&REQUEST=GetCoverage&BBOX=-67.5,48.922499263758255,-64.6875,50.736455137010665&CRS=EPSG:4326&WIDTH=256&HEIGHT=256&FORMAT=GTiff

(with or without "&RESPONSE_CRS=EPSG:4326", the native projection)
Gives the following error :

<?xml version='1.0' encoding="ISO-8859-1" ?>
<ServiceExceptionReport version="1.2.0"
xmlns="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/wcs/1.0.0/OGC-exception.xsd">
  <ServiceException code="NoApplicableCode" locator="bbox">msWCSGetCoverage(): WCS server error. Requested BBOX (-178.835708198757,2803.05273104522,179.552848002437,2906.98474680556) is outside requested coverage BBOX (-70,45,-55,52)
  </ServiceException>
</ServiceExceptionReport>

Notice how the Requested BBOX in the error doesn't make sense.

Adding "&RESPONSE_CRS=EPSG:900913" (or 3857) instead to the request should logically still give an error, because the BBOX itself isn't changed (it's the response_CRS, not the CRS...). Yet, it returns a geotiff. The file is all black (0 0 0), though :

http://lists.osgeo.org/pipermail/mapserver-users/attachments/20111104/78e5fa24/wcsoutput-0001.tif

My inability to create a correct GeoTiff output was the original issue. Rahkonen Jukka found the solution :
Adding a projection object to the layer level allowed me to get a good GeoTiff, similar to the one obtained with a WMS request (http://lists.osgeo.org/pipermail/mapserver-users/attachments/20111104/78e5fa24/wmsoutput-0001.tif).

  PROJECTION
     'init=epsg:4326'
  END

However, this is an unexpected behaviour. The Map level projection object should be used when the layer is lacking one. I've been asked to create a ticket regarding the issue.

http://lists.osgeo.org/pipermail/mapserver-users/2011-November/070700.html

Although the original problem was about GeoTiff, it can probably be extended to other output formats.

The HDF5 source file can be found here :
http://lists.osgeo.org/pipermail/mapserver-users/attachments/20111104/78e5fa24/data-0001.obj

The problem may or may not be specific to this input format. I don't know how MapServer handles this.

Logs produced by MapServer for several requests seen in this ticket are here :
http://lists.osgeo.org/pipermail/mapserver-users/attachments/20111104/78e5fa24/mapserv_errors-0001.obj

I tried to fit in as much information as I could. I'm sorry if I forgot something or haven't respected conventions I was unaware of. You can contact me if you need to at loiselle.guillaume@gmail.com .

Guillaume Loiselle

P.S. The "New Ticket" link found in the sentence "To enter an issue use the New Ticket button." from http://trac.osgeo.org/mapserver/ redirects to http://trac.osgeo.org/mapserver/mapserver/newticket, which is wrong and gives this error :

Error: Not Found

No handler matched request to /mapserver/newticket

The correct URL is http://trac.osgeo.org/mapserver/newticket. Is there a metaticket system to create tickets on ticket issues? :p
