### PR TITLE
Line symbol (dashed line + symbol) construction issues in mapserver 6

### DIFF
--- a/mapscript/php/class.c
+++ b/mapscript/php/class.c
@@ -216,6 +216,11 @@ PHP_METHOD(classObj, __set)
 
   php_class = (php_class_object *) zend_object_store_get_object(zobj TSRMLS_CC);
 
+  /* special case for "template" which we want to set to NULL and not an empty string */
+  if(Z_TYPE_P(value)==IS_NULL && !strcmp(property,"template")) {
+    msFree(php_class->class->template);
+    php_class->class->template = NULL;
+  } else
   IF_SET_STRING("name", php_class->class->name, value)
   else IF_SET_STRING("title", php_class->class->title, value)
     else IF_SET_LONG("type", php_class->class->type, value)

--- a/mapscript/php/layer.c
+++ b/mapscript/php/layer.c
@@ -343,6 +343,11 @@ PHP_METHOD(layerObj, __set)
 
   php_layer = (php_layer_object *) zend_object_store_get_object(zobj TSRMLS_CC);
 
+  /* special case for "template" which we want to set to NULL and not an empty string */
+  if(Z_TYPE_P(value)==IS_NULL && !strcmp(property,"template")) {
+    msFree(php_layer->layer->template);
+    php_layer->layer->template = NULL;
+  } else
   IF_SET_LONG("status", php_layer->layer->status, value)
   else IF_SET_LONG("debug",  php_layer->layer->debug, value)
     else IF_SET_STRING("classitem", php_layer->layer->classitem, value)


### PR DESCRIPTION
I'm trying to construct line symbols with mapserver 6. We have a land use map with different sorts of pipelines and power lines that need to be displayed as dashed lines and small pixmap symbols on top of them (a small circle with a Z inside it for electricity etc.). This doesn't appear to work the same way it used to. I noticed that I can make the pixmap symbols appear under the dashed line, but not on top of the line. As if this wasn't strange enough for me, the same doesn't work for vector symbols at all (this is also a bit of an issue, as I would need this to work for other features, such as ferry lines). I'm attaching an image to help explain and illustrate the problem.

http://dl.dropbox.com/u/15767795/line_issue2.png

Has anyone else dealt with this sort of thing? Any (workaround) solutions, or do I just have to sit tight and wait for the next release of mapserver (assuming this is something that is being addressed)?

edit: Also, by background is in Environmental Sciences, so go easy with the potential tech-talk :)
