### PR TITLE
PHP/Mapscript: no way to unset a template of a layer

### DIFF
--- a/mapscript/php/class.c
+++ b/mapscript/php/class.c
@@ -216,6 +216,11 @@ PHP_METHOD(classObj, __set)
 
   php_class = (php_class_object *) zend_object_store_get_object(zobj TSRMLS_CC);
 
+  /* special case for "template" which we want to set to NULL and not an empty string */
+  if(Z_TYPE_P(value)==IS_NULL && !strcmp(property,"template")) {
+    msFree(php_class->class->template);
+    php_class->class->template = NULL;
+  } else
   IF_SET_STRING("name", php_class->class->name, value)
   else IF_SET_STRING("title", php_class->class->title, value)
     else IF_SET_LONG("type", php_class->class->type, value)

--- a/mapscript/php/layer.c
+++ b/mapscript/php/layer.c
@@ -343,6 +343,11 @@ PHP_METHOD(layerObj, __set)
 
   php_layer = (php_layer_object *) zend_object_store_get_object(zobj TSRMLS_CC);
 
+  /* special case for "template" which we want to set to NULL and not an empty string */
+  if(Z_TYPE_P(value)==IS_NULL && !strcmp(property,"template")) {
+    msFree(php_layer->layer->template);
+    php_layer->layer->template = NULL;
+  } else
   IF_SET_LONG("status", php_layer->layer->status, value)
   else IF_SET_LONG("debug",  php_layer->layer->debug, value)
     else IF_SET_STRING("classitem", php_layer->layer->classitem, value)


### PR DESCRIPTION
I think it is no more possible to unset the template property of a layer using PHP/mapscript:

<?php
$map = new mapObj('your_path/your_mapfile.map');
$layer = $map->getLayer(0);
$layer ->set('template', null);
$map->save('your_path/your_new_mapfile.map');
?>

The layer new mapfile contains:
TEMPLATE ""
whereas with MS 5.x it doesn't contains this line.

Edit : I can't set milestome (MS 6.0.1) and labels, sorry...
