### PR TITLE
Encode wider spectrum of non-ASCII characters when filling templates

### DIFF
--- a/mapstring.c
+++ b/mapstring.c
@@ -1135,7 +1135,7 @@ char *msEncodeHTMLEntities(const char *string)
 
   for(i=0, c=string; *c != '\0'; c++) {
     /* Need to realloc buffer? */
-    if (i+8 > buflen) {
+    if (i+6 > buflen) {
       /* If we had to realloc then this string must contain several */
       /* entities... so let's go with twice the previous buffer size */
       buflen *= 2;
@@ -1143,10 +1143,29 @@ char *msEncodeHTMLEntities(const char *string)
       MS_CHECK_ALLOC(newstring, buflen+1, NULL);
     }
 
-    if( (unsigned char)*c > 127 || *c == '&' || *c == '<' || *c == '>' || *c == '"' || *c == '\'' ) {
-      i += snprintf(newstring+i, buflen-i, "&#%i;", (unsigned char)*c);
-    } else {
-      newstring[i++] = *c;
+    switch(*c) {
+      case '&':
+        strcpy(newstring+i, "&amp;");
+        i += 5;
+        break;
+      case '<':
+        strcpy(newstring+i, "&lt;");
+        i += 4;
+        break;
+      case '>':
+        strcpy(newstring+i, "&gt;");
+        i += 4;
+        break;
+      case '"':
+        strcpy(newstring+i, "&quot;");
+        i += 6;
+        break;
+      case '\'':
+        strcpy(newstring+i, "&#39;"); /* changed from &apos; and i += 6 (bug 1040) */
+        i += 5;
+        break;
+      default:
+        newstring[i++] = *c;
     }
   }
 

--- a/mapstring.c
+++ b/mapstring.c
@@ -1135,7 +1135,7 @@ char *msEncodeHTMLEntities(const char *string)
 
   for(i=0, c=string; *c != '\0'; c++) {
     /* Need to realloc buffer? */
-    if (i+6 > buflen) {
+    if (i+8 > buflen) {
       /* If we had to realloc then this string must contain several */
       /* entities... so let's go with twice the previous buffer size */
       buflen *= 2;
@@ -1143,29 +1143,10 @@ char *msEncodeHTMLEntities(const char *string)
       MS_CHECK_ALLOC(newstring, buflen+1, NULL);
     }
 
-    switch(*c) {
-      case '&':
-        strcpy(newstring+i, "&amp;");
-        i += 5;
-        break;
-      case '<':
-        strcpy(newstring+i, "&lt;");
-        i += 4;
-        break;
-      case '>':
-        strcpy(newstring+i, "&gt;");
-        i += 4;
-        break;
-      case '"':
-        strcpy(newstring+i, "&quot;");
-        i += 6;
-        break;
-      case '\'':
-        strcpy(newstring+i, "&#39;"); /* changed from &apos; and i += 6 (bug 1040) */
-        i += 5;
-        break;
-      default:
-        newstring[i++] = *c;
+    if( (unsigned char)*c > 127 || *c == '&' || *c == '<' || *c == '>' || *c == '"' || *c == '\'' ) {
+      i += snprintf(newstring+i, buflen-i, "&#%i;", (unsigned char)*c);
+    } else {
+      newstring[i++] = *c;
     }
   }
 

--- a/maptemplate.c
+++ b/maptemplate.c
@@ -4222,7 +4222,7 @@ int msReturnNestedTemplateQuery(mapservObj* mapserv, char* pszMimeType, char **p
   } else if(mapserv->sendheaders) {
     encoding = msOWSLookupMetadata(&(mapserv->map->web.metadata), "MO", "encoding");
     if (encoding)
-      msIO_setHeader("Content-type", "%s charset=%s", pszMimeType, encoding);
+      msIO_setHeader("Content-type", "%s; charset=%s", pszMimeType, encoding);
     else
       msIO_setHeader("Content-type", "%s", pszMimeType);
 

--- a/maptemplate.c
+++ b/maptemplate.c
@@ -4222,9 +4222,10 @@ int msReturnNestedTemplateQuery(mapservObj* mapserv, char* pszMimeType, char **p
   } else if(mapserv->sendheaders) {
     encoding = msOWSLookupMetadata(&(mapserv->map->web.metadata), "MO", "encoding");
     if (encoding)
-      snprintf(buffer, sizeof(buffer), "; charset=%s", encoding);
+      msIO_setHeader("Content-type", "%s charset=%s", pszMimeType, encoding);
+    else
+      msIO_setHeader("Content-type", "%s", pszMimeType);
 
-    msIO_setHeader("Content-type", "%s%s", pszMimeType, buffer);
     msIO_sendHeaders();
   }
 

--- a/maptemplate.c
+++ b/maptemplate.c
@@ -4113,7 +4113,8 @@ int msReturnNestedTemplateQuery(mapservObj* mapserv, char* pszMimeType, char **p
 {
   int status;
   int i,j,k;
-  char buffer[1024];
+  char buffer[1024] = "";
+  const char *encoding;
   int nBufferSize =0;
   int nCurrentSize = 0;
   int nExpandBuffer = 0;
@@ -4219,7 +4220,11 @@ int msReturnNestedTemplateQuery(mapservObj* mapserv, char* pszMimeType, char **p
     strcat((*papszBuffer), buffer);
     nCurrentSize += strlen(buffer);
   } else if(mapserv->sendheaders) {
-    msIO_setHeader("Content-type",pszMimeType);
+    encoding = msOWSLookupMetadata(&(mapserv->map->web.metadata), "MO", "encoding");
+    if (encoding)
+      snprintf(buffer, sizeof(buffer), "; charset=%s", encoding);
+
+    msIO_setHeader("Content-type", "%s%s", pszMimeType, buffer);
     msIO_sendHeaders();
   }
 


### PR DESCRIPTION
For cascaded GetfeatureInfo requests, non-ASCII characters may sometimes not be readable due to incorrect handling of encoding by the client. To avoid this, this patch does not only encode a few characters to html entities but all above 127 to its numerical representation.