### PR TITLE
fribidi library is not thread safe

### DIFF
--- a/mapstring.c
+++ b/mapstring.c
@@ -1608,8 +1608,13 @@ char *msGetEncodedString(const char *string, const char *encoding)
   size_t len, bufsize, bufleft, iconv_status;
 
 #ifdef USE_FRIBIDI
-  if(fribidi_parse_charset ((char*)encoding))
-    return msGetFriBidiEncodedString(string, encoding);
+  msAcquireLock(TLOCK_FRIBIDI);
+  if(fribidi_parse_charset ((char*)encoding)) {
+    int ret = msGetFriBidiEncodedString(string, encoding);
+    msReleaseLock(TLOCK_FRIBIDI);
+    return ret;
+  }
+  msReleaseLock(TLOCK_FRIBIDI);
 #endif
   len = strlen(string);
 

--- a/mapthread.h
+++ b/mapthread.h
@@ -66,6 +66,7 @@ extern "C" {
 #define TLOCK_DEBUGOBJ  13
 #define TLOCK_OGR       14
 #define TLOCK_TIME      15
+#define TLOCK_FRIBIDI   16
 
 #define TLOCK_STATIC_MAX 20
 #define TLOCK_MAX       100


### PR DESCRIPTION
**Reporter: tbonfort**
**Date: 2011/10/06 - 11:46**
**Trac URL:** http://trac.osgeo.org/mapserver/ticket/4044
there should be a thread mutex around the fribidi calls, as fribidi is not thread safe.
