### PR TITLE
Enable file based empty templates

### DIFF
--- a/mapserver.h
+++ b/mapserver.h
@@ -32,10 +32,10 @@
 /*
 ** MapServer version - to be updated for every release
 */
-#define MS_VERSION "6.2-beta3"
+#define MS_VERSION "6.3-dev"
 
 #define MS_VERSION_MAJOR    6
-#define MS_VERSION_MINOR    2
+#define MS_VERSION_MINOR    3
 #define MS_VERSION_REV      0
 
 #define MS_VERSION_NUM (MS_VERSION_MAJOR*10000+MS_VERSION_MINOR*100+MS_VERSION_REV)

--- a/mapserver.h
+++ b/mapserver.h
@@ -32,10 +32,10 @@
 /*
 ** MapServer version - to be updated for every release
 */
-#define MS_VERSION "6.3-dev"
+#define MS_VERSION "6.2-beta3"
 
 #define MS_VERSION_MAJOR    6
-#define MS_VERSION_MINOR    3
+#define MS_VERSION_MINOR    2
 #define MS_VERSION_REV      0
 
 #define MS_VERSION_NUM (MS_VERSION_MAJOR*10000+MS_VERSION_MINOR*100+MS_VERSION_REV)

--- a/mapservutil.c
+++ b/mapservutil.c
@@ -1116,17 +1116,7 @@ int msCGIDispatchBrowseRequest(mapservObj *mapserv)
     if(msReturnTemplateQuery(mapserv, mapserv->map->web.queryformat, NULL) != MS_SUCCESS)
       return MS_FAILURE;
   } else {
-    if(TEMPLATE_TYPE(mapserv->map->web.template) == MS_FILE) { /* if thers's an html template, then use it */
-      if(mapserv->sendheaders) {
-        msIO_setHeader("Content-type",mapserv->map->web.browseformat); /* write MIME header */
-        msIO_sendHeaders();
-      }
-      if(msReturnPage(mapserv, mapserv->map->web.template, BROWSE, NULL) != MS_SUCCESS)
-        return MS_FAILURE;
-    } else {
-      if(msReturnURL(mapserv, mapserv->map->web.template, BROWSE) != MS_SUCCESS)
-        return MS_FAILURE;
-    }
+    if((status = msReturnPageOrUrl(mapserv, mapserv->map->web.template, BROWSE, NULL)) != MS_SUCCESS) return MS_FAILURE;
   }
   return MS_SUCCESS;
 }

--- a/maptemplate.c
+++ b/maptemplate.c
@@ -189,11 +189,7 @@ int checkWebScale(mapservObj *mapserv)
 
   if((mapserv->map->scaledenom < mapserv->map->web.minscaledenom) && (mapserv->map->web.minscaledenom > 0)) {
     if(mapserv->map->web.mintemplate) { /* use the template provided */
-      if(TEMPLATE_TYPE(mapserv->map->web.mintemplate) == MS_FILE) {
-        if((status = msReturnPage(mapserv, mapserv->map->web.mintemplate, BROWSE, NULL)) != MS_SUCCESS) return status;
-      } else {
-        if((status = msReturnURL(mapserv, mapserv->map->web.mintemplate, BROWSE)) != MS_SUCCESS) return status;
-      }
+      if((status = msReturnPageOrUrl(mapserv, mapserv->map->web.mintemplate, BROWSE, NULL)) != MS_SUCCESS) return status;
     } else { /* force zoom = 1 (i.e. pan) */
       mapserv->fZoom = mapserv->Zoom = 1;
       mapserv->ZoomDirection = 0;
@@ -208,11 +204,7 @@ int checkWebScale(mapservObj *mapserv)
   } else {
     if((mapserv->map->scaledenom > mapserv->map->web.maxscaledenom) && (mapserv->map->web.maxscaledenom > 0)) {
       if(mapserv->map->web.maxtemplate) { /* use the template provided */
-        if(TEMPLATE_TYPE(mapserv->map->web.maxtemplate) == MS_FILE) {
-          if((status = msReturnPage(mapserv, mapserv->map->web.maxtemplate, BROWSE, NULL)) != MS_SUCCESS) return status;
-        } else {
-          if((status = msReturnURL(mapserv, mapserv->map->web.maxtemplate, BROWSE)) != MS_SUCCESS) return status;
-        }
+        if((status = msReturnPageOrUrl(mapserv, mapserv->map->web.maxtemplate, BROWSE, NULL)) != MS_SUCCESS) return status;
       } else { /* force zoom = 1 (i.e. pan) */
         mapserv->fZoom = mapserv->Zoom = 1;
         mapserv->ZoomDirection = 0;
@@ -4130,6 +4122,28 @@ int msReturnURL(mapservObj* ms, char* url, int mode)
   free(tmpurl);
 
   return MS_SUCCESS;
+}
+
+int msReturnPageOrUrl(mapservObj* ms, char* template, int mode, char **papszBuffer)
+{
+  const char *encoding;
+
+  if( !template ) 
+    return MS_FAILURE;
+
+  if( TEMPLATE_TYPE(template) == MS_FILE ) {
+    if(ms->sendheaders) {
+      encoding = msOWSLookupMetadata(&(ms->map->web.metadata), "MO", "encoding");
+      if (encoding)
+        msIO_setHeader("Content-type","%s; charset=%s", ms->map->web.browseformat, encoding);
+      else
+        msIO_setHeader("Content-type","%s", ms->map->web.browseformat);
+      msIO_sendHeaders();
+    }
+    return msReturnPage(ms, template, BROWSE, papszBuffer);
+  } else {
+    return msReturnURL(ms, template, BROWSE);
+  }
 }
 
 /*

--- a/maptemplate.h
+++ b/maptemplate.h
@@ -154,6 +154,7 @@ MS_DLL_EXPORT int setExtent(mapservObj *msObj);
 
 MS_DLL_EXPORT int msReturnPage(mapservObj* msObj, char* , int, char **);
 MS_DLL_EXPORT int msReturnURL(mapservObj* msObj, char*, int);
+MS_DLL_EXPORT int msReturnPageOrUrl(mapservObj* msObj, char* , int, char **);
 MS_DLL_EXPORT int msReturnNestedTemplateQuery(mapservObj* msObj, char* pszMimeType, char **papszBuffer);
 MS_DLL_EXPORT int msReturnTemplateQuery(mapservObj *msObj, char* pszMimeType,  char **papszBuffer);
 MS_DLL_EXPORT int msReturnOpenLayersPage(mapservObj *mapserv);

--- a/mapwms.c
+++ b/mapwms.c
@@ -4085,7 +4085,7 @@ int msWMSFeatureInfo(mapObj *map, int nVersion, char **names, char **values, int
     msObj->mappnt.y = point.y;
 
     if (query_status == MS_NOTFOUND && msObj->map->web.empty) {
-      if(msReturnURL(msObj, msObj->map->web.empty, BROWSE) != MS_SUCCESS)
+      if(msReturnPageOrUrl(msObj, msObj->map->web.empty, BROWSE, NULL) != MS_SUCCESS)
         return msWMSException(map, nVersion, NULL, wms_exception_format);
     } else if (msReturnTemplateQuery(msObj, (char *)info_format, NULL) != MS_SUCCESS)
       return msWMSException(map, nVersion, NULL, wms_exception_format);


### PR DESCRIPTION
Currently, the EMPTY templates may point to an url only. This request enables this template to be a file, too and summarizes a few calls into a new function  msReturnPageOrUrl. Existing code was changed only under the condition that both cases - file and url as templates - were already handled. However, in comparison to the current state, the content-type will be set additionally.