### PR TITLE
Python MapScript broken with SWIG 2.0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,12 @@ mapscript/python/build/
 mapscript/python/mapscript.py
 mapscript/python/mapscript_wrap.c
 mapscript/php/php_mapscript.la
+mapscript/java/edu
+mapscript/java/javamapscript_wrap.c
+mapscript/java/libjavamapscript.la
+mapscript/java/mapscript.jar
+mapscript/perl/MYMETA.yml
+mapscript/perl/Makefile.old
 mapscriptvars
 mapserv
 mapserver-config

--- a/maperror.h
+++ b/maperror.h
@@ -94,13 +94,13 @@ extern "C" {
 #define  MS_DLL_EXPORT
 #endif
 
-  typedef struct error_obj {
+  typedef struct errorObj {
     int code;
     char routine[ROUTINELENGTH];
     char message[MESSAGELENGTH];
     int isreported;
 #ifndef SWIG
-    struct error_obj *next;
+    struct errorObj *next;
 #endif
   } errorObj;
 
@@ -120,8 +120,8 @@ extern "C" {
   MS_DLL_EXPORT char *msGetErrorCodeString(int code);
   MS_DLL_EXPORT char *msAddErrorDisplayString(char *source, errorObj *error);
 
-  struct map_obj;
-  MS_DLL_EXPORT void msWriteErrorImage(struct map_obj *map, char *filename, int blank);
+  struct mapObj;
+  MS_DLL_EXPORT void msWriteErrorImage(struct mapObj *map, char *filename, int blank);
 
 #endif /* SWIG */
 

--- a/mapscript/java/javamodule.i
+++ b/mapscript/java/javamodule.i
@@ -211,12 +211,12 @@ RFC-24 implementation follows
         return clazz;
 }
                 
-%typemap(javacode) layerObj %{
+%typemap(javacode) struct layerObj %{
         /* parent reference, RFC-24 item 3.2 */
         mapObj map=null;
 %}
 
-%typemap(javacode) classObj %{
+%typemap(javacode) struct classObj %{
         /* parent reference, RFC-24 item 3.2 */
         layerObj layer=null;
 %}

--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -38,7 +38,7 @@
 #endif
 
 #ifdef SWIGJAVA
-%ignore layer_obj::extent;
+%ignore layerObj::extent;
 #endif
 
 %{

--- a/mapscript/ruby/extconf.rb
+++ b/mapscript/ruby/extconf.rb
@@ -13,7 +13,8 @@ mapscriptvars.close
 $CFLAGS = ""
 $CPPFLAGS = make_inc + " -idirafter $(rubylibdir)/$(arch) " + make_define
 $LDFLAGS += " -fPIC"
-$LOCAL_LIBS += " -L../../.libs/ " + " -lmapserver " + make_static_libs
+#$LOCAL_LIBS += " -L../../.libs/ " + " -lmapserver " + make_static_libs
+$LOCAL_LIBS += " -L../../.libs/ " + " -lmapserver "
 
 # if the source file 'mapscript_wrap.c' is missing nothing works
 # this is a workaround !!

--- a/mapserver.h
+++ b/mapserver.h
@@ -172,10 +172,12 @@ typedef ms_uint32 *     ms_bitarray;
 extern "C" {
 #endif
 
+// hide from swig or ruby will choke on the __FUNCTION__ name
+#ifndef SWIG
   /* Memory allocation check utility */
-
 #ifndef __FUNCTION__
 #   define __FUNCTION__ "MapServer"
+#endif
 #endif
 
 #define MS_CHECK_ALLOC(var, size, retval)     \
@@ -599,7 +601,7 @@ extern "C" {
 #endif
 
 #ifndef SWIG
-    struct map_obj *map;
+    struct mapObj *map;
 #endif
   } fontSetObj;
 
@@ -832,7 +834,7 @@ extern "C" {
 #ifdef SWIG
     %immutable;
 #endif /* SWIG */
-    struct map_obj *map;
+    struct mapObj *map;
 #ifdef SWIG
     %mutable;
 #endif /* SWIG */
@@ -1056,7 +1058,7 @@ extern "C" {
   /*      basic symbolization and classification information              */
   /************************************************************************/
 
-  typedef struct class_obj {
+  typedef struct classObj {
 #ifndef SWIG
     expressionObj expression; /* the expression to be matched */
 #endif
@@ -1112,7 +1114,7 @@ extern "C" {
     %immutable;
 #endif /* SWIG */
     int refcount;
-    struct layer_obj *layer;
+    struct layerObj *layer;
 #ifdef SWIG
     %mutable;
 #endif /* SWIG */
@@ -1255,7 +1257,7 @@ extern "C" {
 #ifndef SWIG
     int refcount;
     symbolObj** symbol;
-    struct map_obj *map;
+    struct mapObj *map;
     fontSetObj *fontset; /* a pointer to the main mapObj version */
     struct imageCacheObj *imagecache;
 #endif /* not SWIG */
@@ -1279,7 +1281,7 @@ extern "C" {
 #ifdef SWIG
     %immutable;
 #endif /* SWIG */
-    struct map_obj *map;
+    struct mapObj *map;
 #ifdef SWIG
     %mutable;
 #endif /* SWIG */
@@ -1340,7 +1342,7 @@ extern "C" {
 #ifdef SWIG
     %immutable;
 #endif /* SWIG */
-    struct map_obj *map;
+    struct mapObj *map;
 #ifdef SWIG
     %mutable;
 #endif /* SWIG */
@@ -1443,7 +1445,7 @@ extern "C" {
   /*      base unit of a map.                                             */
   /************************************************************************/
 
-  typedef struct layer_obj {
+  typedef struct layerObj {
 
     char *classitem; /* .DBF item to be used for symbol lookup */
 
@@ -1467,7 +1469,7 @@ extern "C" {
     int numclasses;
     int maxclasses;
     int index;
-    struct map_obj *map;
+    struct mapObj *map;
 #ifdef SWIG
     %mutable;
 #endif /* SWIG */
@@ -1615,7 +1617,7 @@ extern "C" {
   /************************************************************************/
 
   /* MAP OBJECT -  */
-  typedef struct map_obj { /* structure for a map */
+  typedef struct mapObj { /* structure for a map */
     char *name; /* small identifier for naming etc. */
     int status; /* is map creation on or off */
     int height, width;

--- a/mapsymbol.h
+++ b/mapsymbol.h
@@ -163,7 +163,7 @@ typedef struct {
   /*
   ** Pointer to his map
   */
-  struct map_obj *map;
+  struct mapObj *map;
 #endif /* SWIG */
   /*
   ** MS_SYMBOL_VECTOR and MS_SYMBOL_ELLIPSE options


### PR DESCRIPTION
When using SWIG 2.0.5 for building Python MapScript it reports "AttributeError: No constructor defined" when trying to initialize a new mapObj. Using SWIG 2.0.4 works though.
