### PR TITLE
Fix ANGLE FOLLOW after AUTO2 fixes

### DIFF
--- a/mapprimitive.c
+++ b/mapprimitive.c
@@ -1707,21 +1707,16 @@ void msPolylineLabelPointLineString(shapeObj *p, int min_length, int repeat_dist
         (*labelpoints)[index]->y = t * (p->line[i].point[k+1].y - p->line[i].point[k].y) + p->line[i].point[k].y;
       }
 
-      if (anglemode == MS_AUTO2) {
+      if(anglemode != MS_NONE) {
         theta = atan2(p->line[i].point[j].x - p->line[i].point[j-1].x, p->line[i].point[j].y - p->line[i].point[j-1].y);
-        *(*angles)[index] = (MS_RAD_TO_DEG*theta) - 90;
-      } else {
-        theta = asin(MS_ABS(p->line[i].point[j].x - p->line[i].point[j-1].x)/sqrt((((p->line[i].point[j].x - p->line[i].point[j-1].x)*(p->line[i].point[j].x - p->line[i].point[j-1].x)) + ((p->line[i].point[j].y - p->line[i].point[j-1].y)*(p->line[i].point[j].y - p->line[i].point[j-1].y)))));
-        if(p->line[i].point[j-1].x < p->line[i].point[j].x) { /* i.e. to the left */
-          if(p->line[i].point[j-1].y < p->line[i].point[j].y) /* i.e. below */
-            *(*angles)[index] = -(90.0 - MS_RAD_TO_DEG*theta);
-          else
-            *(*angles)[index] = (90.0 - MS_RAD_TO_DEG*theta);
-        } else {
-          if(p->line[i].point[j-1].y < p->line[i].point[j].y) /* i.e. below */
-            *(*angles)[index] = (90.0 - MS_RAD_TO_DEG*theta);
-          else
-            *(*angles)[index] = -(90.0 - MS_RAD_TO_DEG*theta);
+        if(anglemode == MS_AUTO2) {
+          *(*angles)[index] = (MS_RAD_TO_DEG*theta) - 90;
+        } else { /* AUTO, FOLLOW */
+          if(p->line[i].point[j-1].x < p->line[i].point[j].x) { /* i.e. to the left */
+            *(*angles)[index] = (MS_RAD_TO_DEG*theta) - 90;
+          } else {
+            *(*angles)[index] = (MS_RAD_TO_DEG*theta) + 90;
+          }
         }
       }
 


### PR DESCRIPTION
The changes in #4476 modified the behavior of ANGLE FOLLOW. See text labels here:
https://dl.dropbox.com/u/2633201/issues/mapserver/oneway_autonew_large_4476.png

The pull request changes the code to the old bahavior, and only adds a special case for AUTO2:
https://dl.dropbox.com/u/2633201/issues/mapserver/oneway_autonew_large_newpull.png

/cc @tbonfort
