### PR TITLE
fix mapscript builds for recent swig versions backport to branch-6-0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ legend
 libmapserver.a
 mapscript/csharp/Makefile
 mapscript/java/Makefile
+mapscript/java/edu
+mapscript/java/javamapscript_wrap.c
+mapscript/java/libjavamapscript.la
+mapscript/java/mapscript.jar
+mapscript/perl/MYMETA.yml
+mapscript/perl/Makefile.old
 mapscriptvars
 mapserv
 mapserver-config

--- a/maperror.h
+++ b/maperror.h
@@ -94,13 +94,13 @@ extern "C" {
 #define  MS_DLL_EXPORT
 #endif
 
-typedef struct error_obj {
+typedef struct errorObj {
   int code;
   char routine[ROUTINELENGTH];
   char message[MESSAGELENGTH];
   int isreported;
 #ifndef SWIG
-  struct error_obj *next;
+  struct errorObj *next;
 #endif
 } errorObj;
 
@@ -120,8 +120,8 @@ MS_DLL_EXPORT void msWriteErrorXML(FILE *stream);
 MS_DLL_EXPORT char *msGetErrorCodeString(int code);
 MS_DLL_EXPORT char *msAddErrorDisplayString(char *source, errorObj *error);
 
-struct map_obj;
-MS_DLL_EXPORT void msWriteErrorImage(struct map_obj *map, char *filename, int blank);
+struct mapObj;
+MS_DLL_EXPORT void msWriteErrorImage(struct mapObj *map, char *filename, int blank);
 
 #endif /* SWIG */
 

--- a/mapscript/java/javamodule.i
+++ b/mapscript/java/javamodule.i
@@ -211,12 +211,12 @@ RFC-24 implementation follows
         return clazz;
 }
                 
-%typemap(javacode) layerObj %{
+%typemap(javacode) struct layerObj %{
         /* parent reference, RFC-24 item 3.2 */
         mapObj map=null;
 %}
 
-%typemap(javacode) classObj %{
+%typemap(javacode) struct classObj %{
         /* parent reference, RFC-24 item 3.2 */
         layerObj layer=null;
 %}

--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -38,7 +38,7 @@
 #endif
 
 #ifdef SWIGJAVA
-%ignore layer_obj::extent;
+%ignore layerObj::extent;
 #endif
 
 %{

--- a/mapscript/ruby/extconf.rb
+++ b/mapscript/ruby/extconf.rb
@@ -13,7 +13,9 @@ mapscriptvars.close
 $CFLAGS = ""
 $CPPFLAGS = make_inc + " -idirafter $(rubylibdir)/$(arch) " + make_define
 $LDFLAGS += " -fPIC"
-$LOCAL_LIBS += " -L../.. " + make_libs + " " + make_static_libs
+# Backporting of bug 4325
+#$LOCAL_LIBS += " -L../.. " + make_libs + " " + make_static_libs
+$LOCAL_LIBS += " -L../.. " + make_libs + " -lmapserver "
 
 # if the source file 'mapscript_wrap.c' is missing nothing works
 # this is a workaround !!

--- a/mapserver.h
+++ b/mapserver.h
@@ -182,12 +182,13 @@ typedef ms_uint32 *     ms_bitarray;
 extern "C" {
 #endif
 
+// hide from swig or ruby will choke on the __FUNCTION__ name
+#ifndef SWIG
 /* Memory allocation check utility */
-
 #ifndef __FUNCTION__
 #   define __FUNCTION__ "MapServer"
 #endif
-
+#endif
 #define MS_CHECK_ALLOC(var, size, retval)     \
     if (!var) {   \
         msSetError(MS_MEMERR, "%s: %d: Out of memory allocating %u bytes.\n", __FUNCTION__, \
@@ -583,7 +584,7 @@ typedef struct {
 #endif
 
 #ifndef SWIG
-    struct map_obj *map;
+    struct mapObj *map;
 #endif
 } fontSetObj;
 
@@ -813,7 +814,7 @@ typedef struct {
 #ifdef SWIG
 %immutable;
 #endif /* SWIG */
-  struct map_obj *map;
+  struct mapObj *map;
 #ifdef SWIG
 %mutable;
 #endif /* SWIG */
@@ -988,7 +989,7 @@ typedef struct {
 /*      basic symbolization and classification information              */
 /************************************************************************/
 
-typedef struct class_obj{
+typedef struct classObj{
 #ifndef SWIG
   expressionObj expression; /* the expression to be matched */
 #endif
@@ -1039,7 +1040,7 @@ typedef struct class_obj{
 %immutable;
 #endif /* SWIG */
   int refcount;
-  struct layer_obj *layer;
+  struct layerObj *layer;
 #ifdef SWIG
 %mutable;
 #endif /* SWIG */
@@ -1181,7 +1182,7 @@ typedef struct {
 #ifndef SWIG
   int refcount;
   symbolObj** symbol;
-  struct map_obj *map;
+  struct mapObj *map;
   fontSetObj *fontset; /* a pointer to the main mapObj version */
   struct imageCacheObj *imagecache;
 #endif /* not SWIG */
@@ -1205,7 +1206,7 @@ typedef struct {
 #ifdef SWIG
 %immutable;
 #endif /* SWIG */
-  struct map_obj *map;
+  struct mapObj *map;
 #ifdef SWIG
 %mutable;
 #endif /* SWIG */
@@ -1266,7 +1267,7 @@ typedef struct {
 #ifdef SWIG
 %immutable;
 #endif /* SWIG */
-  struct map_obj *map;
+  struct mapObj *map;
 #ifdef SWIG
 %mutable;
 #endif /* SWIG */
@@ -1330,7 +1331,7 @@ typedef struct layerVTable layerVTableObj;
 /*      base unit of a map.                                             */
 /************************************************************************/
 
-typedef struct layer_obj {
+typedef struct layerObj {
 
   char *classitem; /* .DBF item to be used for symbol lookup */
 
@@ -1354,7 +1355,7 @@ typedef struct layer_obj {
   int numclasses;
   int maxclasses;
   int index;
-  struct map_obj *map;
+  struct mapObj *map;
 #ifdef SWIG
 %mutable;
 #endif /* SWIG */
@@ -1496,7 +1497,7 @@ typedef struct layer_obj {
 /************************************************************************/
 
 /* MAP OBJECT -  */
-typedef struct map_obj{ /* structure for a map */
+typedef struct mapObj{ /* structure for a map */
   char *name; /* small identifier for naming etc. */
   int status; /* is map creation on or off */
   int height, width;

--- a/mapsymbol.h
+++ b/mapsymbol.h
@@ -156,7 +156,7 @@ typedef struct {
   /*
   ** Pointer to his map
   */
-  struct map_obj *map;
+  struct mapObj *map;
 #endif /* SWIG */
   /*
   ** MS_SYMBOL_VECTOR and MS_SYMBOL_ELLIPSE options


### PR DESCRIPTION
fixes from bug 4325 backported to version 6.0
build tested okay with swig 1.3.40 to swig 2.0.7

Results can be followed (in a few hours) at
https://build.opensuse.org/project/show?project=home%3Abruno_friedmann%3Amapserver6
