### PR TITLE
imageObj.getBytes fails for CAIRO/SVG output format

### DIFF
--- a/mapcairo.c
+++ b/mapcairo.c
@@ -840,6 +840,18 @@ int saveImageCairo(imageObj *img, mapObj *map, FILE *fp, outputFormatObj *format
   return MS_SUCCESS;
 }
 
+unsigned char* saveImageBufferCairo(imageObj *img, int *size_ptr, outputFormatObj *format)
+{
+  cairo_renderer *r = CAIRO_RENDERER(img);
+  unsigned char *data;
+  assert(!strcasecmp(img->format->driver,"cairo/pdf") || !strcasecmp(img->format->driver,"cairo/svg"));
+  cairo_surface_finish (r->surface);
+  data = msSmallMalloc(r->outputStream->size);
+  memcpy(data,r->outputStream->data,r->outputStream->size);
+  *size_ptr = (int)r->outputStream->size;
+  return data;
+}
+
 void *msCreateTileEllipseCairo(double width, double height, double angle,
                                colorObj *c, colorObj *bc, colorObj *oc, double ow)
 {
@@ -1252,6 +1264,7 @@ inline int populateRendererVTableCairoVector( rendererVTableObj *renderer )
   renderer->renderLineTiled = NULL;
   renderer->createImage=&createImageCairo;
   renderer->saveImage=&saveImageCairo;
+  renderer->saveImageBuffer = &saveImageBufferCairo;
   renderer->getRasterBufferHandle=&getRasterBufferHandleCairo;
   renderer->renderPolygon=&renderPolygonCairo;
   renderer->renderGlyphs=&renderGlyphsCairo;


### PR DESCRIPTION
**Reporter: panzel**
**Date: 2012/01/05 - 20:58**
**Trac URL:** http://trac.osgeo.org/mapserver/ticket/4145
Under SWIG/C#, the MapServer 6.0.1 imageObj.GetBytes() method fails if the imagetype is 'svg' and the outputformat is specified by:

```
  OUTPUTFORMAT
    NAME "svg"
    DRIVER CAIRO/SVG
    MIMETYPE "image/svg+xml"
    IMAGEMODE RGB
    EXTENSION "svg"
  END
```

By comparison, it succeeds with imagetype 'png' with:

```
  OUTPUTFORMAT
    NAME "png"
    DRIVER AGG/PNG
    MIMETYPE "image/png"
    IMAGEMODE RGB
    EXTENSION "png"
    FORMATOPTION "GAMMA=0.75"
  END
```

The short-term work-around is to use imageObj.save, which works with 'svg'.

I've attached two map files (m11.map, m12.map) that show the png/svg cases, and a C# file (Program.cs) that reads a map file and creates an output file. When run with m12.map (the svg case), the output is:

```
Drawing map: 'MS' using imageObj.getBytes
GetBytes: getBytes: General error message. Failed to get image
 buffer;msSaveImageBuffer(): General error message. Unsupported image type
```

The C# code is copied almost intact from Tamas' http://mapserver.sourcearchive.com/documentation/5.2.0/getbytes_8cs-source.html. The original missed a "{0}" in the catch block's WriteLine statement.

This may be related to an older ticket: Ticket #3201, "GetBytes(), Write() on ImageObj results in error when parsing mapfile with AGG renderer in C# mapscript."
