### PR TITLE
Invalid vector symbol size calculation for horizontal lines

### DIFF
--- a/mapsymbol.c
+++ b/mapsymbol.c
@@ -89,7 +89,7 @@ double msSymbolGetDefaultSize(symbolObj *s)
 #endif
       break;
     default: /* vector and ellipses, scalable */
-      size = s->sizey;
+      size = (s->sizey<=0)?s->sizex:s->sizey;
       break;
   }
 


### PR DESCRIPTION
Using the UV test in msautotest, we can see that the use of POLAROFFSET seems to be broken for some arrows. I need to investigate in this before 6.2 release. Perhaps this is simply a mapfile issue, but need to be sure. A test also need to be added for POLAROFFSET @tbonfort 
