### PR TITLE
Correct wgs84 bbox in WFS GetCapabilties

### DIFF
--- a/mapows.c
+++ b/mapows.c
@@ -1968,6 +1968,23 @@ int msOWSPrintEncodeParamList(FILE *stream, const char *name,
 
 
 /*
+** msOWSProjectToWGS84()
+**
+** Reprojects the extent to WGS84.
+**
+*/
+void msOWSProjectToWGS84(projectionObj *srcproj, rectObj *ext)
+{
+  if (srcproj->numargs > 0 && !pj_is_latlong(srcproj->proj)) {
+    projectionObj wgs84;
+    msInitProjection(&wgs84);
+    msLoadProjectionString(&wgs84, "+proj=longlat +ellps=WGS84 +datum=WGS84");
+    msProjectRect(srcproj, &wgs84, ext);
+    msFreeProjection(&wgs84);
+  }
+}
+
+/*
 ** msOWSPrintEX_GeographicBoundingBox()
 **
 ** Print a EX_GeographicBoundingBox tag for WMS1.3.0
@@ -1983,14 +2000,7 @@ void msOWSPrintEX_GeographicBoundingBox(FILE *stream, const char *tabspace,
   ext = *extent;
 
   /* always project to lat long */
-  if (srcproj->numargs > 0 && !pj_is_latlong(srcproj->proj)) {
-    projectionObj wgs84;
-    msInitProjection(&wgs84);
-    msLoadProjectionString(&wgs84, "+proj=longlat +datum=WGS84");
-    msProjectRect(srcproj, &wgs84, &ext);
-    msFreeProjection(&wgs84);
-  }
-
+  msOWSProjectToWGS84(srcproj, &ext);
 
   msIO_fprintf(stream, "%s<%s>\n", tabspace, pszTag);
   msIO_fprintf(stream, "%s    <westBoundLongitude>%g</westBoundLongitude>\n", tabspace, ext.minx);
@@ -2020,16 +2030,8 @@ void msOWSPrintLatLonBoundingBox(FILE *stream, const char *tabspace,
   ext = *extent;
 
   if (nService == OWS_WMS) { /* always project to lat long */
-    if (srcproj->numargs > 0 && !pj_is_latlong(srcproj->proj)) {
-      projectionObj wgs84;
-      msInitProjection(&wgs84);
-      msLoadProjectionString(&wgs84, "+proj=longlat +datum=WGS84");
-      msProjectRect(srcproj, &wgs84, &ext);
-      msFreeProjection(&wgs84);
-    }
-  }
-
-  if (nService == OWS_WFS) {
+    msOWSProjectToWGS84(srcproj, &ext);
+  } else if (nService == OWS_WFS) { /* called from wfs 1.0.0 only: project to map srs, if set */
     pszTag = "LatLongBoundingBox";
     if (wfsproj) {
       if (msProjectionsDiffer(srcproj, wfsproj) == MS_TRUE)

--- a/mapows.h
+++ b/mapows.h
@@ -246,6 +246,7 @@ int msOWSPrintEncodeParamList(FILE *stream, const char *name,
                               char delimiter, const char *startTag,
                               const char *endTag, const char *format,
                               const char *default_value);
+void msOWSProjectToWGS84(projectionObj *srcproj, rectObj *ext);
 void msOWSPrintLatLonBoundingBox(FILE *stream, const char *tabspace,
                                  rectObj *extent, projectionObj *srcproj,
                                  projectionObj *wfsproj, int nService);

--- a/mapwfs11.c
+++ b/mapwfs11.c
@@ -209,11 +209,10 @@ static xmlNodePtr msWFSDumpLayer11(mapObj *map, layerObj *lp, xmlNsPtr psNsOws)
   /*bbox*/
   if (msOWSGetLayerExtent(map, lp, "FO", &ext) == MS_SUCCESS) {
     /*convert to latlong*/
-    if (lp->projection.numargs > 0) {
-      if (!pj_is_latlong(&lp->projection.proj))
-        msProjectRect(&lp->projection, NULL, &ext);
-    } else if (map->projection.numargs > 0 && !pj_is_latlong(&map->projection.proj))
-      msProjectRect(&map->projection, NULL, &ext);
+    if (lp->projection.numargs > 0)
+      msOWSProjectToWGS84(&lp->projection, &ext);
+    else
+      msOWSProjectToWGS84(&map->projection, &ext);
 
     xmlAddChild(psRootNode,
                 msOWSCommonWGS84BoundingBox( psNsOws, 2,


### PR DESCRIPTION
For layers having another source datum than wgs84 the wgs84 bbox is currently wrong in the WFS getcapabilties document. Compared to the WMS server code, the datum wasn't set in msProjectRect(). fixes #4498
