### PR TITLE
correctly detect presence of __sync_fetch_and_add

### DIFF
--- a/configure
+++ b/configure
@@ -17836,7 +17836,7 @@ else
 int
 main ()
 {
-int x;__sync_fetch_and_add(&x,1);
+long x;long y=__sync_fetch_and_add(&x,1);
   ;
   return 0;
 }

--- a/configure.in
+++ b/configure.in
@@ -851,7 +851,7 @@ dnl ---------------------------------------------------------------------
 dnl Check for the __sync_fetch_and_add builtin
 dnl ---------------------------------------------------------------------
 AC_CACHE_CHECK([for __sync_fetch_and_add], ac_cv_func_sync_fetch_and_add,
-[AC_TRY_LINK([],[int x;__sync_fetch_and_add(&x,1);],ac_cv_func_sync_fetch_and_add=yes,ac_cv_func_sync_fetch_and_add=no)])
+[AC_TRY_LINK([],[long x;long y=__sync_fetch_and_add(&x,1);],ac_cv_func_sync_fetch_and_add=yes,ac_cv_func_sync_fetch_and_add=no)])
 if test "$ac_cv_func_sync_fetch_and_add" = yes; then
   ALL_ENABLED="-DHAVE_SYNC_FETCH_AND_ADD $ALL_ENABLED"
   AC_DEFINE(HAVE_SYNC_FETCH_AND_ADD,1,[Define if you have the __sync_fetch_and_add function])


### PR DESCRIPTION
It seems that gcc will provide a stub function on architectures that don't support atomic operations like __sync_fetch_and_add _unless_ the argument is not an int32 and its return value is not used. This breaks mapserver compilation because prior to this pr the detection code did not check for the same exact conditions under which __sync_fetch_and_add is used in mapserver internals.

This pr improves the detection code so that situations like those described above can be handled correctly.
