### PR TITLE
No projection when layer ist set to transform false

### DIFF
--- a/mapdraw.c
+++ b/mapdraw.c
@@ -946,18 +946,18 @@ int msDrawVectorLayer(mapObj *map, layerObj *layer, imageObj *image)
   }
 
   /* identify target shapes */
-  if(layer->transform == MS_TRUE)
+  if(layer->transform == MS_TRUE) {
     searchrect = map->extent;
+#ifdef USE_PROJ
+    if((map->projection.numargs > 0) && (layer->projection.numargs > 0))
+      msProjectRect(&map->projection, &layer->projection, &searchrect); /* project the searchrect to source coords */
+#endif
+  }
   else {
     searchrect.minx = searchrect.miny = 0;
     searchrect.maxx = map->width-1;
     searchrect.maxy = map->height-1;
   }
-
-#ifdef USE_PROJ
-  if((map->projection.numargs > 0) && (layer->projection.numargs > 0))
-    msProjectRect(&map->projection, &layer->projection, &searchrect); /* project the searchrect to source coords */
-#endif
 
   status = msLayerWhichShapes(layer, searchrect, MS_FALSE);
   if(status == MS_DONE) { /* no overlap */


### PR DESCRIPTION
In msDrawVectorLayer() MapServer tries to project pixel coordinates in case a layer is set to `TRANFORM FALSE`. This leads to lots of log messages:
`msProjectPoint(): Projection library error. proj says: latitude or longitude exceeded limits`
`msProjectPoint(): Projection library error. proj says: (null)`

I'm uncertain about side effects of this change. Let's see what the autotest says.
