### PR TITLE
Fix getCapabilities on maps with no layers

### DIFF
--- a/mapows.c
+++ b/mapows.c
@@ -326,7 +326,7 @@ int msOWSRequestIsEnabled(mapObj *map, layerObj *layer,
     if (disabled) return MS_FALSE;
   }
 
-  if (map && (map->numlayers > 0) && check_all_layers == MS_TRUE) {
+  if (map && check_all_layers == MS_TRUE) {
     int i, globally_enabled = MS_FALSE;
     enable_request = msOWSLookupMetadata(&map->web.metadata, namespaces, "enable_request");
     globally_enabled = msOWSParseRequestMetadata(enable_request, request, &disabled);
@@ -357,6 +357,9 @@ int msOWSRequestIsEnabled(mapObj *map, layerObj *layer,
       if (result || (!disabled && globally_enabled))
         return MS_TRUE;
     }
+
+    if (!disabled && globally_enabled)
+        return MS_TRUE;
   }
 
   return MS_FALSE;


### PR DESCRIPTION
Fix to print GetCapabilities xml element in a map with no layers. 

Now if you set check_all_layers to MS_TRUE it'll still look into the map for the enabled request even if there is no layer.
