### PR TITLE
Fixed element ordering to be alphabetical.

### DIFF
--- a/xmlmapfile/mapfile.xsd
+++ b/xmlmapfile/mapfile.xsd
@@ -755,12 +755,12 @@
 				<xs:element name="QueryMap" type="ms:QueryMap" minOccurs="0"/>
 				<xs:element name="Reference" type="ms:Reference" minOccurs="0"/>
 				<xs:element name="resolution" type="xs:positiveInteger" default="72" minOccurs="0"/>
-				<xs:element name="scaleDenom" type="xs:double" minOccurs="0"/>
 				<xs:element name="ScaleBar" type="ms:ScaleBar"/>
+				<xs:element name="scaleDenom" type="xs:double" minOccurs="0"/>
 				<xs:element name="shapePath" type="xs:string" minOccurs="0"/>
 				<xs:element name="size" type="ms:sizeType" minOccurs="0"/>
-				<xs:element name="symbolSet" type="xs:string" minOccurs="0"/>
 				<xs:element name="Symbol" type="ms:Symbol" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="symbolSet" type="xs:string" minOccurs="0"/>
 				<xs:element name="templatePattern" type="xs:string" minOccurs="0"/>
 				<xs:element name="units" default="METERS" minOccurs="0">
 					<xs:simpleType>


### PR DESCRIPTION
According to [this](http://trac.osgeo.org/mapserver/wiki/XMLMapfiles) the xml elements were intended to be in alphabetical order, but two of them were misplaced. This puts them in the correct order. 

This also makes it easier for programs to output xml mapfiles that will validate because they don't have to write exceptions in the sorting method, because it now truly is alphabetical. 

Note: this is my first time contributing. If I should have done this a different way (like open an issue first) please let me know.
