### PR TITLE
Unknown connectiontype GRATICULE

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -4344,7 +4344,7 @@ static void writeLayer(FILE *stream, int indent, layerObj *layer)
   writeString(stream, indent, "CLASSITEM", NULL, layer->classitem);
   writeCluster(stream, indent, &(layer->cluster));
   writeString(stream, indent, "CONNECTION", NULL, layer->connection);
-  writeKeyword(stream, indent, "CONNECTIONTYPE", layer->connectiontype, 10, MS_SDE, "SDE", MS_OGR, "OGR", MS_POSTGIS, "POSTGIS", MS_WMS, "WMS", MS_ORACLESPATIAL, "ORACLESPATIAL", MS_WFS, "WFS", MS_GRATICULE, "GRATICULE", MS_PLUGIN, "PLUGIN", MS_UNION, "UNION", MS_UVRASTER, "UVRASTER");
+  writeKeyword(stream, indent, "CONNECTIONTYPE", layer->connectiontype, 9, MS_SDE, "SDE", MS_OGR, "OGR", MS_POSTGIS, "POSTGIS", MS_WMS, "WMS", MS_ORACLESPATIAL, "ORACLESPATIAL", MS_WFS, "WFS", MS_PLUGIN, "PLUGIN", MS_UNION, "UNION", MS_UVRASTER, "UVRASTER");
   writeString(stream, indent, "DATA", NULL, layer->data);
   writeNumber(stream, indent, "DEBUG", 0, layer->debug); /* is this right? see loadLayer() */
   writeExtent(stream, indent, "EXTENT", layer->extent);


### PR DESCRIPTION
**Reporter: edmarmoretti**
**Date: 2012/01/24 - 22:22**
**Trac URL:** http://trac.osgeo.org/mapserver/ticket/4165
I'm trying to create a coordinate grid using Mapserver 6. My mapfile is:

  LAYER

```
CONNECTIONTYPE GRATICULE

NAME "SAMPLEGRID"

STATUS DEFAULT

TYPE LINE

UNITS DD

CLASS

  LABEL

    SIZE MEDIUM

    COLOR 255 128 89

    OFFSET 0 0

    POSITION CC

    SHADOWSIZE 1 1

    TYPE BITMAP

  END # LABEL

  STYLE

    ANGLE 0

    COLOR 0 255 128

    OFFSET 0 0

  END # STYLE

END # CLASS

GRID

  LABELFORMAT "DDMMSS"

  MAXSUBDIVIDE 5

  MINSUBDIVIDE 5

END # GRID
```

  END # LAYER

But I get the following error messages:

Warning: ms_newMapObj(): [MapServer Error]: msInitializeVirtualTable(): Unknown connectiontype, it was -1

Warning: ms_newMapObj(): [MapServer Error]: getSymbol(): Parsing error near (GRATICULE)

Fatal error: Uncaught exception 'MapScriptException' with message 'Failed to open map file...
