### PR TITLE
Enable runtime substitutions using `class` level `validation` blocks

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -6653,16 +6653,11 @@ void msApplySubstitutions(mapObj *map, char **names, char **values, int npairs)
             /* skip as the name exists in the layer validation but does not validate */
             continue;
           }
-        } else if (msLookupHashTable(&(map->web.validation), names[i])) {
-          if (msValidateParameter(values[i],
-                                  msLookupHashTable(&(map->web.validation), names[i]),
-                                  msLookupHashTable(&(map->web.metadata), validation_pattern_key),
-                                  NULL, NULL) != MS_SUCCESS) {
-            /* skip as the name exists in the web validation but does not validate */
-            continue;
-          }
-        } else {
-          /* skip as there are no validations */
+        } else if (msValidateParameter(values[i],
+                                       msLookupHashTable(&(map->web.validation), names[i]),
+                                       msLookupHashTable(&(map->web.metadata), validation_pattern_key),
+                                       NULL, NULL) != MS_SUCCESS) {
+          /* skip as the web validation fails */
           continue;
         }
 
@@ -6684,16 +6679,11 @@ void msApplySubstitutions(mapObj *map, char **names, char **values, int npairs)
           /* skip as the name exists in the layer validation but does not validate */
           continue;
         }
-      } else if (msLookupHashTable(&(map->web.validation), names[i])) {
-        if (msValidateParameter(values[i],
-                                msLookupHashTable(&(map->web.validation), names[i]),
-                                msLookupHashTable(&(map->web.metadata), validation_pattern_key),
-                                NULL, NULL) != MS_SUCCESS) {
-          /* skip as the name exists in the web validation but does not validate */
-          continue;
-        }
-      } else {
-        /* skip as there are no validations */
+      } else if (msValidateParameter(values[i],
+                                     msLookupHashTable(&(map->web.validation), names[i]),
+                                     msLookupHashTable(&(map->web.metadata), validation_pattern_key),
+                                     NULL, NULL) != MS_SUCCESS) {
+        /* skip as the web validation fails */
         continue;
       }
 


### PR DESCRIPTION
This fixes mapserver/mapserver/issues/4596.  As well as now honouring
class level validation blocks a validation hierarchy is implemented
across `web`, `layer` and `class` level validation blocks.  This
hierarchy _only_ takes effect when identical validation keys appear in
`web`, `layer` or `class` such that keys in more specialised blocks
override those in more generalised blocks. i.e. `class` overrides
`layer` which overrides `web`.

In conjunction with the above, default class level substitutions are
also enabled and also implement the precedence rules above. i.e. a
default substitution in `class` overrides `layer` which overrides
`web`.
