### PR TITLE
Fix scaletoken substitutions on capabilities and raster featureinfo

### DIFF
--- a/maplayer.c
+++ b/maplayer.c
@@ -109,14 +109,19 @@ int msLayerApplyScaletokens(layerObj *layer, double scale)
   }
   msLayerRestoreFromScaletokens(layer);
   for(i=0;i<layer->numscaletokens;i++) {
-    int tokenindex=0;
     scaleTokenObj *st = &layer->scaletokens[i];
     scaleTokenEntryObj *ste = NULL;
-    while(tokenindex<st->n_entries) {
-      ste = &(st->tokens[tokenindex]);
-      if(scale < ste->maxscale && scale >= ste->minscale) break; /* current token is the correct one */
-      tokenindex++;
-      ste = NULL;
+    if(scale<=0) {
+       ste = &(st->tokens[0]);
+      /* no scale defined, use first entry */
+    } else {
+      int tokenindex=0;
+      while(tokenindex<st->n_entries) {
+        ste = &(st->tokens[tokenindex]);
+        if(scale < ste->maxscale && scale >= ste->minscale) break; /* current token is the correct one */
+        tokenindex++;
+        ste = NULL;
+      }
     }
     assert(ste);
     if(layer->data && strstr(layer->data,st->name)) {


### PR DESCRIPTION
apply scaletoken substitutions in a few corner cases:
- for getcapabilities requests (or when no scale is defined), we use the first
  configured scaletoken
- for getfeatureinfo requests on raster layers, added token replacements in
  msRasterQueryByRect() (which is in-turn called by the other raster query
  functions.
