### PR TITLE
POST request Content-type headers don't accept extra args

### DIFF
--- a/cgiutil.c
+++ b/cgiutil.c
@@ -159,7 +159,7 @@ int loadParams(cgiRequestObj *request,
 
     /* if the content_type is application/x-www-form-urlencoded,
        we have to parse it like the QUERY_STRING variable */
-    if(strcmp(request->contenttype, "application/x-www-form-urlencoded") == 0) {
+    if(strncmp(request->contenttype, "application/x-www-form-urlencoded", strlen("application/x-www-form-urlencoded")) == 0) {
       while( data_len > 0 && isspace(post_data[data_len-1]) )
         post_data[--data_len] = '\0';
 


### PR DESCRIPTION
When building an XHR request to MapServer with a POST method some browser will add the charet to the Content-type header parameters. This make MapServer unable to read the map parameter from the post data. 

Example:

```
Ext.Ajax.request({
      url: mapserver,
      method: 'POST',
      params: {
        savequery: 'true',
        map: mapfile,
        mapext: extent.left +" "+ extent.bottom +" "+ extent.right +" "+ extent.top,
        mode: 'nquery',
        ....
      },
      success: function(response) {
        console.log(response)
      }
    });
```

This will make Firefox to send the following content-type:

```
Content-Type: application/x-www-form-urlencoded; charset=UTF-8
```

https://github.com/mapserver/mapserver/blob/master/cgiutil.c#L162
MapServer requires the Content-Type of any POST request to be exactly 
application/x-www-form-urlencoded
Using a strncmp would solve the issue.

In the mean time, the POST request will work if you pass the mapfile in the QUERY_STRING (?map=...mapfile.map).
