### PR TITLE
Don't entity-encode URLs used on attributes: libxml2 does this for us.

### DIFF
--- a/mapwfs11.c
+++ b/mapwfs11.c
@@ -266,7 +266,7 @@ int msWFSGetCapabilities11(mapObj *map, wfsParamsObj *params,
   const char *user_namespace_uri = NULL;
   gmlNamespaceListObj *namespaceList=NULL; /* for external application schema support */
 
-  char *script_url=NULL, *script_url_encoded=NULL, *formats_list;
+  char *script_url=NULL, *formats_list;
   const char *value = NULL;
   const char *encoding;
 
@@ -366,8 +366,7 @@ int msWFSGetCapabilities11(mapObj *map, wfsParamsObj *params,
                             psNsOws, psNsXLink, map, "FO"));
 
   /*operation metadata */
-  if ((script_url=msOWSGetOnlineResource(map, "FO", "onlineresource", req)) == NULL
-      || (script_url_encoded = msEncodeHTMLEntities(script_url)) == NULL) {
+  if ((script_url=msOWSGetOnlineResource(map, "FO", "onlineresource", req)) == NULL) {
     msSetError(MS_WFSERR, "Server URL not found", "msWFSGetCapabilities11()");
     return msWFSException11(map, "mapserv", "NoApplicableCode", params->pszVersion);
   }
@@ -382,7 +381,7 @@ int msWFSGetCapabilities11(mapObj *map, wfsParamsObj *params,
   /* -------------------------------------------------------------------- */
   psNode = xmlAddChild(psMainNode,
                        msOWSCommonOperationsMetadataOperation(psNsOws,psNsXLink,"GetCapabilities",
-                           OWS_METHOD_GETPOST, script_url_encoded));
+                           OWS_METHOD_GETPOST, script_url));
 
   xmlAddChild(psMainNode, psNode);
   xmlAddChild(psNode, msOWSCommonOperationsMetadataDomainType(
@@ -403,7 +402,7 @@ int msWFSGetCapabilities11(mapObj *map, wfsParamsObj *params,
   if (msOWSRequestIsEnabled(map, NULL, "F", "DescribeFeatureType", MS_TRUE)) {
     psNode = xmlAddChild(psMainNode,
                          msOWSCommonOperationsMetadataOperation(psNsOws,psNsXLink,"DescribeFeatureType",
-                             OWS_METHOD_GETPOST, script_url_encoded));
+                             OWS_METHOD_GETPOST, script_url));
     xmlAddChild(psMainNode, psNode);
 
     /*output format*/
@@ -419,7 +418,7 @@ int msWFSGetCapabilities11(mapObj *map, wfsParamsObj *params,
 
     psNode = xmlAddChild(psMainNode,
                          msOWSCommonOperationsMetadataOperation(psNsOws,psNsXLink,"GetFeature",
-                             OWS_METHOD_GETPOST, script_url_encoded));
+                             OWS_METHOD_GETPOST, script_url));
     xmlAddChild(psMainNode, psNode);
 
     xmlAddChild(psNode, msOWSCommonOperationsMetadataDomainType(ows_version, psNsOws,
@@ -497,7 +496,6 @@ int msWFSGetCapabilities11(mapObj *map, wfsParamsObj *params,
   xmlFreeNs(psNsOgc);
 
   free(script_url);
-  free(script_url_encoded);
   free(xsi_schemaLocation);
   free(schemalocation);
 


### PR DESCRIPTION
Refs #4622

I'll try and put something in msautotest for this too.
