### PR TITLE
Parse key value pairs sent in POST body

### DIFF
--- a/mapows.c
+++ b/mapows.c
@@ -95,7 +95,7 @@ static int msOWSPreParseRequest(cgiRequestObj *request,
                                 owsRequestObj *ows_request)
 {
   /* decide if KVP or XML */
-  if (request->type == MS_GET_REQUEST || (request->type == MS_POST_REQUEST && strcmp(request->contenttype, "application/x-www-form-urlencoded"))) {
+  if (request->type == MS_GET_REQUEST || (request->type == MS_POST_REQUEST && strcmp(request->contenttype, "application/x-www-form-urlencoded")==0)) {
     int i;
     /* parse KVP parameters service, version and request */
     for (i = 0; i < request->NumParams; ++i) {


### PR DESCRIPTION
MapServer lacks support of reading KVP from a POST body. This got lost somewhere between 5.4 and 6.2.
I would prefer adding a new request method, e.g. MS_POSTKVP_REQUEST in order to avoid string comparison. Any opinions?
