### PR TITLE
The GetLegendGraphics don't follow the Style MinScaleDenominator / MaxScaleDenominator values

### DIFF
--- a/mapscript/php/mapscript_i.c
+++ b/mapscript/php/mapscript_i.c
@@ -1081,12 +1081,12 @@ int classObj_drawLegendIcon(classObj *self, mapObj *map, layerObj *layer, int wi
 #ifdef USE_GD
   msClearLayerPenValues(layer); // just in case the mapfile has already been processed
 #endif
-  return msDrawLegendIcon(map, layer, self, width, height, dstImg, dstX, dstY);
+  return msDrawLegendIcon(map, layer, self, width, height, dstImg, dstX, dstY, MS_TRUE);
 }
 
 imageObj *classObj_createLegendIcon(classObj *self, mapObj *map, layerObj *layer, int width, int height)
 {
-  return msCreateLegendIcon(map, layer, self, width, height);
+  return msCreateLegendIcon(map, layer, self, width, height, MS_TRUE);
 }
 
 

--- a/mapscript/swiginc/class.i
+++ b/mapscript/swiginc/class.i
@@ -178,12 +178,12 @@
   }
   
   int drawLegendIcon(mapObj *map, layerObj *layer, int width, int height, imageObj *dstImage, int dstX, int dstY) {
-    return msDrawLegendIcon(map, layer, self, width, height, dstImage, dstX, dstY);
+    return msDrawLegendIcon(map, layer, self, width, height, dstImage, dstX, dstY, MS_TRUE);
   }
  
   %newobject createLegendIcon;
   imageObj *createLegendIcon(mapObj *map, layerObj *layer, int width, int height) {
-    return msCreateLegendIcon(map, layer, self, width, height);
+    return msCreateLegendIcon(map, layer, self, width, height, MS_TRUE);
   } 
 
   %newobject getLabel;

--- a/mapserver.h
+++ b/mapserver.h
@@ -2109,8 +2109,8 @@ extern "C" {
   MS_DLL_EXPORT int msLegendCalcSize(mapObj *map, int scale_independent, int *size_x, int *size_y,
                                      int *alayers, int numl_ayer);
   MS_DLL_EXPORT int msEmbedLegend(mapObj *map, imageObj *img);
-  MS_DLL_EXPORT int msDrawLegendIcon(mapObj* map, layerObj* lp, classObj* myClass, int width, int height, imageObj *img, int dstX, int dstY);
-  MS_DLL_EXPORT imageObj *msCreateLegendIcon(mapObj* map, layerObj* lp, classObj* myClass, int width, int height);
+  MS_DLL_EXPORT int msDrawLegendIcon(mapObj* map, layerObj* lp, classObj* myClass, int width, int height, imageObj *img, int dstX, int dstY, int scale_independant);
+  MS_DLL_EXPORT imageObj *msCreateLegendIcon(mapObj* map, layerObj* lp, classObj* myClass, int width, int height, int scale_independant);
 
   MS_DLL_EXPORT int msLoadFontSet(fontSetObj *fontSet, mapObj *map); /* in maplabel.c */
   MS_DLL_EXPORT int msInitFontSet(fontSetObj *fontset);

--- a/mapservutil.c
+++ b/mapservutil.c
@@ -1578,7 +1578,7 @@ int msCGIDispatchLegendIconRequest(mapservObj *mapserv)
   /* drop this reference to output format */
   msApplyOutputFormat(&format, NULL, MS_NOOVERRIDE, MS_NOOVERRIDE, MS_NOOVERRIDE);
 
-  if(msDrawLegendIcon(mapserv->map, GET_LAYER(mapserv->map, layerindex), GET_LAYER(mapserv->map, layerindex)->class[classindex], mapserv->map->legend.keysizex,  mapserv->map->legend.keysizey, img, 0, 0) != MS_SUCCESS)
+  if(msDrawLegendIcon(mapserv->map, GET_LAYER(mapserv->map, layerindex), GET_LAYER(mapserv->map, layerindex)->class[classindex], mapserv->map->legend.keysizex,  mapserv->map->legend.keysizey, img, 0, 0, MS_TRUE) != MS_SUCCESS)
     return MS_FAILURE;
 
   if(mapserv->sendheaders) {

--- a/maptemplate.c
+++ b/maptemplate.c
@@ -2407,10 +2407,10 @@ int processIcon(mapObj *map, int nIdxLayer, int nIdxClass, char** pszInstr, char
 
       if(thisClass == NULL) {
         /* Nonexistent class.  Create an empty image */
-        img = msCreateLegendIcon(map, NULL, NULL, nWidth, nHeight);
+        img = msCreateLegendIcon(map, NULL, NULL, nWidth, nHeight, MS_TRUE);
       } else {
         img = msCreateLegendIcon(map, GET_LAYER(map, nIdxLayer),
-                                 thisClass, nWidth, nHeight);
+                                 thisClass, nWidth, nHeight, MS_TRUE);
       }
 
       if(!img) {

--- a/mapwms.c
+++ b/mapwms.c
@@ -4611,9 +4611,19 @@ this request. Check wms/ows_enable_request settings.",
           nHeight = 20;
       }
 
-      img = msCreateLegendIcon(map, GET_LAYER(map, iLayerIndex),
-                               GET_LAYER(map, iLayerIndex)->class[i],
-                               nWidth, nHeight);
+      if ( psScale != NULL ) {
+        /* Scale-dependent legend. calculate map->scaledenom */
+        map->cellsize = msAdjustExtent(&(map->extent), map->width, map->height);
+        msCalculateScale(map->extent, map->units, map->width, map->height, map->resolution, &map->scaledenom);
+        img = msCreateLegendIcon(map, GET_LAYER(map, iLayerIndex),
+                                 GET_LAYER(map, iLayerIndex)->class[i],
+                                 nWidth, nHeight, MS_FALSE);
+      } else {
+        /* Scale-independent legend */
+        img = msCreateLegendIcon(map, GET_LAYER(map, iLayerIndex),
+                                 GET_LAYER(map, iLayerIndex)->class[i],
+                                 nWidth, nHeight, MS_TRUE);
+      }
     }
     if (img == NULL) {
       msSetError(MS_IMGERR,


### PR DESCRIPTION
In the mapserver 6.3-dev:

the Legend from a GetLegendGraphics call don't follow the setting minScaleDenominator / maxScaleDenominator when they are put on the style level.

It will merge all the styles indipendently from the minScaleDenominator and maxScaleDenominator.
