### PR TITLE
Build 6.2 against libgif 5.0.3 fail

### DIFF
--- a/mapimageio.c
+++ b/mapimageio.c
@@ -993,12 +993,19 @@ int msSaveRasterBufferToBuffer(rasterBufferObj *data, bufferObj *buffer,
     return MS_FAILURE;
   }
 }
+
 #ifdef USE_GIF
+#if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
+static char const *gif_error_msg(int code)
+#else
 static char const *gif_error_msg()
+#endif
 {
   static char msg[80];
 
+#if (!defined GIFLIB_MAJOR) || (GIFLIB_MAJOR < 5)
   int code = GifLastError();
+#endif
   switch (code) {
     case E_GIF_ERR_OPEN_FAILED: /* should not see this */
       return "Failed to open given file";
@@ -1090,14 +1097,25 @@ int readGIF(char *path, rasterBufferObj *rb)
   ColorMapObject *cmap;
   int interlacedOffsets[] = {0,4,2,1};
   int interlacedJumps[] = {8,8,4,2};
+#if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
+  int errcode;
+#endif
 
 
   rb->type = MS_BUFFER_BYTE_RGBA;
+#if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
+  image =  DGifOpenFileName(path, &errcode);
+  if (image == NULL) {
+    msSetError(MS_MISCERR,"failed to load gif image: %s","readGIF()", gif_error_msg(errcode));
+    return MS_FAILURE;
+  }
+#else
   image =  DGifOpenFileName(path);
   if (image == NULL) {
     msSetError(MS_MISCERR,"failed to load gif image: %s","readGIF()", gif_error_msg());
     return MS_FAILURE;
   }
+#endif
   rb->width = image->SWidth;
   rb->height = image->SHeight;
   rb->data.rgba.row_step = rb->width * 4;
@@ -1122,7 +1140,11 @@ int readGIF(char *path, rasterBufferObj *rb)
 
   do {
     if (DGifGetRecordType(image, &recordType) == GIF_ERROR) {
+#if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
+      msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()", gif_error_msg(image->Error));
+#else
       msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()", gif_error_msg());
+#endif
       return MS_FAILURE;
     }
 
@@ -1132,7 +1154,11 @@ int readGIF(char *path, rasterBufferObj *rb)
         break;
       case IMAGE_DESC_RECORD_TYPE:
         if (DGifGetImageDesc(image) == GIF_ERROR) {
+#if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
+          msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()", gif_error_msg(image->Error));
+#else
           msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()", gif_error_msg());
+#endif
           return MS_FAILURE;
         }
         if (!firstImageRead) {
@@ -1159,7 +1185,11 @@ int readGIF(char *path, rasterBufferObj *rb)
                 g = rb->data.rgba.g + offset;
                 b = rb->data.rgba.b + offset;
                 if (DGifGetLine(image, line, width) == GIF_ERROR) {
+#if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
+                  msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()",gif_error_msg(image->Error));
+#else
                   msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()",gif_error_msg());
+#endif
                   return MS_FAILURE;
                 }
 
@@ -1188,7 +1218,11 @@ int readGIF(char *path, rasterBufferObj *rb)
               g = rb->data.rgba.g + offset;
               b = rb->data.rgba.b + offset;
               if (DGifGetLine(image, line, width) == GIF_ERROR) {
+#if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
+                msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()",gif_error_msg(image->Error));
+#else
                 msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()",gif_error_msg());
+#endif
                 return MS_FAILURE;
               }
               for(j=0; j<width; j++) {
@@ -1213,12 +1247,20 @@ int readGIF(char *path, rasterBufferObj *rb)
         } else {
           /* Skip all next images */
           if (DGifGetCode(image, &codeSize, &codeBlock) == GIF_ERROR) {
+#if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
+            msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()", gif_error_msg(image->Error));
+#else
             msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()", gif_error_msg());
+#endif
             return MS_FAILURE;
           }
           while (codeBlock != NULL) {
             if (DGifGetCodeNext(image, &codeBlock) == GIF_ERROR) {
+#if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
+              msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()", gif_error_msg(image->Error));
+#else
               msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()", gif_error_msg());
+#endif
               return MS_FAILURE;
             }
           }
@@ -1227,14 +1269,22 @@ int readGIF(char *path, rasterBufferObj *rb)
       case EXTENSION_RECORD_TYPE:
         /* skip all extension blocks */
         if (DGifGetExtension(image, &extCode, &extension) == GIF_ERROR) {
+#if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
+          msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()", gif_error_msg(image->Error));
+#else
           msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()", gif_error_msg());
+#endif
           return MS_FAILURE;
         }
         if(extCode == 249 && (extension[1] & 1))
           transIdx = extension[4];
         for (;;) {
           if (DGifGetExtensionNext(image, &extension) == GIF_ERROR) {
+#if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
+            msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()", gif_error_msg(image->Error));
+#else
             msSetError(MS_MISCERR,"corrupted gif image?: %s","readGIF()", gif_error_msg());
+#endif
             return MS_FAILURE;
           }
           if (extension == NULL)
@@ -1254,7 +1304,11 @@ int readGIF(char *path, rasterBufferObj *rb)
   } while (recordType != TERMINATE_RECORD_TYPE);
 
   if (DGifCloseFile(image) == GIF_ERROR) {
+#if defined GIFLIB_MAJOR && GIFLIB_MAJOR >= 5
+    msSetError(MS_MISCERR,"failed to close gif after loading: %s","readGIF()", gif_error_msg(image->Error));
+#else
     msSetError(MS_MISCERR,"failed to close gif after loading: %s","readGIF()", gif_error_msg());
+#endif
     return MS_FAILURE;
   }
 


### PR DESCRIPTION
Trying to build mapserver 6.2.1 (released tarball) on system with giflib 5.0.3 configure is okay, but make fail at 

[   58s] mapimageio.c: In function 'gif_error_msg':
[   58s] mapimageio.c:1001:3: warning: implicit declaration of function 'GifLastError' [-Wimplicit-function-declaration]
[   58s] mapimageio.c: In function 'readGIF':
[   58s] mapimageio.c:1096:3: error: too few arguments to function 'DGifOpenFileName'
[   58s] In file included from mapimageio.c:38:0:
[   58s] /usr/include/gif_lib.h:177:14: note: declared here

Full build log is available here http://goo.gl/UVS0R
