### PR TITLE
mapows.c: Handle Content-Type HTTP headers with a charset appended.

### DIFF
--- a/mapows.c
+++ b/mapows.c
@@ -95,7 +95,7 @@ static int msOWSPreParseRequest(cgiRequestObj *request,
                                 owsRequestObj *ows_request)
 {
   /* decide if KVP or XML */
-  if (request->type == MS_GET_REQUEST || (request->type == MS_POST_REQUEST && strcmp(request->contenttype, "application/x-www-form-urlencoded")==0)) {
+  if (request->type == MS_GET_REQUEST || (request->type == MS_POST_REQUEST && strncmp(request->contenttype, "application/x-www-form-urlencoded", strlen("application/x-www-form-urlencoded")) == 0)) {
     int i;
     /* parse KVP parameters service, version and request */
     for (i = 0; i < request->NumParams; ++i) {


### PR DESCRIPTION
The fix for #4585 in cgiutil.c is also needed in mapows.c to handle Content-Type HTTP headers with a charset appended. This change complements #4651.
