### PR TITLE
Fixes N-1 problem in clustering BUT needs to be checked by original developer if possible

### DIFF
--- a/mapcluster.c
+++ b/mapcluster.c
@@ -541,12 +541,20 @@ static void UpdateShapeAttributes(layerObj* layer, clusterInfo* base, clusterInf
         int count = atoi(base->shape.values[i]) + 1;
         msFree(base->shape.values[i]);
         base->shape.values[i] = msIntToString(count);
-      } else if (!EQUAL(base->shape.values[i], current->shape.values[i])
-                 && !EQUAL(base->shape.values[i], "")) {
-        /* clear the value if that doesn't match */
+      }
+      /* clear the value if that doesn't match */
+			/*   NOTE:
+			 * !EQUAL(base->shape.values[i], "")
+			 *   should change to
+			 * EQUAL(base->shape.values[i], "")
+			 *   but becomes a noop!
+			else if (!EQUAL(base->shape.values[i], current->shape.values[i])
+                && !EQUAL(base->shape.values[i], "")) {
+fprintf(stderr, "delete UpdateShapeAttributes: '%s'|'%s'\n", base->shape.values[i], current->shape.values[i]);
         msFree(base->shape.values[i]);
         base->shape.values[i] = msStrdup("");
       }
+			*/
     }
   }
 }


### PR DESCRIPTION
Please check reasoning behind this code to ensure we're not
introducing another bug.

  NOTE:
!EQUAL(base->shape.values[i], "")
  should change to
EQUAL(base->shape.values[i], "")
  but becomes a noop!
