### PR TITLE
Replace `strlcpy` with `strncpy` in `msIO_stripStdoutBufferContentType()...

### DIFF
--- a/mapio.c
+++ b/mapio.c
@@ -809,7 +809,10 @@ char *msIO_stripStdoutBufferContentType()
   }
 
   /* -------------------------------------------------------------------- */
-  /*      Copy out content type.                                          */
+  /*      Copy out content type. Note we go against the coding guidelines */
+  /*      here and use strncpy() instead of strlcpy() as the source       */
+  /*      buffer may not be NULL terminated - strlcpy() requires NULL     */
+  /*      terminated sources (see issue #4672).                           */
   /* -------------------------------------------------------------------- */
   content_type = (char *) malloc(end_of_ct-14+2);
   strncpy( content_type, (const char *) buf->data + 14, end_of_ct - 14 + 2);


### PR DESCRIPTION
The use of `strlcpy` was producing _uninitialised value_ errors in
valgrind.  It appears this was due to the fact that `strlcpy` expects
the source string to be null terminated which is not always the case
in this context.

The valgrind error was in the form:

```
Conditional jump or move depends on uninitialised value(s)
   at 0x5428601: strlcpy (in /usr/local/lib/libmapserver.so.6.3-dev)
   by 0x543EDED: msIO_stripStdoutBufferContentType (in /usr/local/lib/libmapserver.so.6.3-dev)
   ...
 Uninitialised value was created by a heap allocation
   at 0x402BB7A: malloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
   by 0x543F0AF: msIO_bufferWrite (in /usr/local/lib/libmapserver.so.6.3-dev)
   by 0x543E4C3: msIO_contextWrite (in /usr/local/lib/libmapserver.so.6.3-dev)
   by 0x543E7A7: msIO_vfprintf (in /usr/local/lib/libmapserver.so.6.3-dev)
   by 0x543E634: msIO_fprintf (in /usr/local/lib/libmapserver.so.6.3-dev)
   by 0x543E2B6: msIO_setHeader (in /usr/local/lib/libmapserver.so.6.3-dev)
   by 0x53E9BAE: loadParams (in /usr/local/lib/libmapserver.so.6.3-dev)
   ...
```
