### PR TITLE
Fix a memory leak in `freeClass()` exposed by valgrind's memcheck

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -1867,6 +1867,7 @@ static int loadLabel(labelObj *label)
         break;
       case(EOF):
         msSetError(MS_EOFERR, NULL, "loadLabel()");
+        freeLabel(label);       /* free any structures allocated before EOF */
         return(-1);
       case(EXPRESSION):
         if(loadExpression(&(label->expression)) == -1) return(-1); /* loadExpression() cleans up previously allocated expression */
@@ -3482,7 +3483,10 @@ int loadClass(classObj *class, layerObj *layer)
         if(msGrowClassLabels(class) == NULL) return(-1);
         initLabel(class->labels[class->numlabels]);
         class->labels[class->numlabels]->size = MS_MEDIUM; /* only set a default if the LABEL section is present */
-        if(loadLabel(class->labels[class->numlabels]) == -1) return(-1);
+        if(loadLabel(class->labels[class->numlabels]) == -1) {
+          msFree(class->labels[class->numlabels]);
+          return(-1);
+        }
         class->numlabels++;
         break;
       case(LEADER):


### PR DESCRIPTION
In `msGrowClassLabels()` memory is assigned to
`class->labels[class->numlabels]` but was only freed to
`class->numstyles-1` in `freeClass()`.  This fix ensures the last
label is freed.

The valgrind error was in the form:

```
406 (400 direct, 6 indirect) bytes in 1 blocks are definitely lost in loss record 233 of 321
   at 0x402A629: calloc (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
   by 0x54E20D9: msGrowClassLabels (mapfile.c:3420)
   by 0x54E274A: loadClass (mapfile.c:3482)
   by 0x54E4F43: loadLayer (mapfile.c:4149)
   by 0x54ED8F9: loadMapInternal (mapfile.c:6225)
   by 0x54EDFF0: msLoadMapFromString (mapfile.c:6362)
   ...
```
