### PR TITLE
Wrong se:Size rounding when applying SLD

### DIFF
--- a/mapogcsld.c
+++ b/mapogcsld.c
@@ -613,20 +613,20 @@ layerObj  *msSLDParseSLD(mapObj *map, char *psSLDXML, int *pnLayers)
 }
 
 
-int _msSLDParseSizeParameter(CPLXMLNode *psSize)
+double _msSLDParseSizeParameter(CPLXMLNode *psSize)
 {
-  int nSize = 0;
+  double dSize = 0;
   CPLXMLNode *psLiteral = NULL;
 
   if (psSize) {
     psLiteral = CPLGetXMLNode(psSize, "Literal");
     if (psLiteral && psLiteral->psChild && psLiteral->psChild->pszValue)
-      nSize = atof(psLiteral->psChild->pszValue);
+      dSize = atof(psLiteral->psChild->pszValue);
     else if (psSize->psChild && psSize->psChild->pszValue)
-      nSize = atof(psSize->psChild->pszValue);
+      dSize = atof(psSize->psChild->pszValue);
   }
 
-  return nSize;
+  return dSize;
 }
 
 /************************************************************************/


### PR DESCRIPTION
symbol values with fractional size were truncated

here a test sld: https://gist.github.com/luipir/5964556
where `<se:Size>0.7</se:Size>` were truncated in: SIZE 0

as suggested by: EvenR changed `nSize` in `dSize` "to indicate the change of type"

solution has been found in #mapserver chat

bugfix founded by Regione Toscana-SITA
