### PR TITLE
printed color alpha value in map file

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -650,7 +650,17 @@ static void writeColor(FILE *stream, int indent, const char *name, colorObj *def
 #if ALPHACOLOR_ENABLED
   fprintf(stream, "%s %d %d %d\n", name, color->red, color->green, color->blue, color->alpha);
 #else
-  fprintf(stream, "%s %d %d %d\n", name, color->red, color->green, color->blue);
+  if(color->alpha != 255) {
+    char buffer[9];
+    sprintf(buffer, "%02x", color->red);
+    sprintf(buffer+2, "%02x", color->green);
+    sprintf(buffer+4, "%02x", color->blue);
+    sprintf(buffer+6, "%02x", color->alpha);
+    *(buffer+8) = 0;
+    fprintf(stream, "%s \"#%s\"\n", name, buffer);
+  } else {
+    fprintf(stream, "%s %d %d %d\n", name, color->red, color->green, color->blue);
+  }
 #endif
 }
 


### PR DESCRIPTION
solved  bug related to the printing of color alpha value.

bug found applying SLD style to generate .MAP. Fill and Stroke opacity values of the SLD file weren't represented in .MAP as last hexadecimal value of the COLOR string.

test file used to find the bug: https://gist.github.com/luipir/6001021

bug slution found thanks to the help of tbonfort and founding by Regione Toscana-SITA
