### PR TITLE
Disable use of LAYER.TOLERANCE for WFS GetFeature

### DIFF
--- a/mapwfs.c
+++ b/mapwfs.c
@@ -1953,6 +1953,8 @@ int msWFSGetFeature(mapObj *map, wfsParamsObj *paramsObj, cgiRequestObj *req, ow
     layerObj *lp;
     lp = GET_LAYER(map, j);
     if (lp->status == MS_ON) {
+      /* No reason to handle tolerances for WFS GetFeature */
+      lp->tolerance = 0;
       lpQueried = GET_LAYER(map, j);
       nQueriedLayers++;
     }


### PR DESCRIPTION
Setting tolerance on a layer is intended for raster based point queries. I'm not aware of any use case which could benefit from having tolerance set for WFS queryies, which leads to unexpected modification of the filtering BBOX for WFS. See http://osgeo-org.1560.x6.nabble.com/WFS-GetFeatures-and-BBOX-problem-td5066709.html.

Any objections on silently setting tolerance to 0? (Updated the MapServer doc will follow...)
