### PR TITLE
restore php testcases for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: c
+language: php
+php:
+  - 5.5
 
 compiler:
   - gcc
@@ -19,7 +21,6 @@ notifications:
   email:
     recipients:
       - thomas.bonfort@gmail.com
-
   irc:
     channels:
       - "irc.freenode.org#mapserver"

--- a/Makefile.autotest
+++ b/Makefile.autotest
@@ -36,5 +36,5 @@ php-testcase:
 test: autotest-install
 	@$(MAKE) -f $(MAKEFILE) $(MFLAGS)	wxs-testcase renderers-testcase misc-testcase gdal-testcase query-testcase mspython-testcase
 	@./print-test-results.sh
-	#@$(MAKE) -f $(MAKEFILE) $(MFLAGS)	php-testcase
+	@$(MAKE) -f $(MAKEFILE) $(MFLAGS)	php-testcase
 


### PR DESCRIPTION
the "php" travis machines have a working phpunit, this PR restores testing php mapscript. cc @aboudreault
