### PR TITLE
WMS Server: GetFeatureInfo with many query layers receives SIGABRT with "double free or corruption"

### DIFF
--- a/mapwms.c
+++ b/mapwms.c
@@ -3618,10 +3618,10 @@ int msTranslateWMS2Mapserv(const char **names, const char **values, int numentri
       }
       free(layers);
     } else if (strcasecmp("BBOX", names[i]) == 0) {
+      char *imgext;
       num_allocated++;
       *translated_names = (char**)msSmallRealloc(*translated_names, num_allocated * sizeof(char*));
       *translated_values = (char**)msSmallRealloc(*translated_values, num_allocated * sizeof(char*));
-      char *imgext;
 
       /* Note msReplaceSubstring() works on the string itself, so we need to make a copy */
       imgext = msStrdup(values[i]);


### PR DESCRIPTION
In one of our projects we are using a map containing more than 50 layers (with clustering and Union Layer). Recently we noticed that a GetFeatureInfo for all layers in a single request either is incomplete (output is cut off) or results in an internal server error. GetMap requests run through without any problem.

Clustering and Union Layer don't seem to cause the error. I created a test map with 60 simple equal layers but without clustering and Union Layer and got the same results. I also got this result when switching from GET to POST.

During my tests I always get a complete response (nothing cut off, no internal server error) but the "double free or corruption" error also appears. I think my test layers contain too few information (just 2 columns in output, 4 columns at all) so all data is received before cancelation.

This problem first occurred on SLES 11 using MapServer 6.0.1 compiled on the system. On my Debian testing I could reproduce the error for MapServer 6.0.1 from Debian testing repo and 6.0.1, 6.0.3, 6.2.1 compiled on my system.

Backtrace of MapServer 6.0.3:

```
Program received signal SIGABRT, Aborted.
0xb7fde424 in __kernel_vsyscall ()
(gdb) bt
#0  0xb7fde424 in __kernel_vsyscall ()
#1  0xb6d6780f in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#2  0xb6d6acc3 in __GI_abort () at abort.c:90
#3  0xb6da4265 in __libc_message (do_abort=do_abort@entry=2, fmt=fmt@entry=0xb6ea3c30 "*** Error in `%s': %s: 0x%s ***\n") at ../sysdeps/unix/sysv/linux/libc_fatal.c:199
#4  0xb6daee42 in malloc_printerr (action=<optimized out>, str=<optimized out>, ptr=0x822e888) at malloc.c:4902
#5  0xb6dafb80 in _int_free (av=0xb6ee4440 <main_arena>, p=0x822e880, have_lock=0) at malloc.c:3758
#6  0x08069ef3 in msFreeHashItems (table=0x8236644) at maphash.c:104
#7  0x0807e411 in freeWeb (web=0x82365d8) at mapfile.c:4831
#8  0x080ff17a in msFreeMap (map=0x82346d0) at mapobject.c:105
#9  0x080692c0 in msFreeMapServObj (mapserv=0x822e390) at maptemplate.c:4516
#10 0x08055214 in main (argc=2, argv=0xbfffe6b4) at mapserv.c:1290
```

Backtrace of MapServer 6.2.1:

```
Program received signal SIGABRT, Aborted.
0xb7fde424 in __kernel_vsyscall ()
(gdb) bt
#0  0xb7fde424 in __kernel_vsyscall ()
#1  0xb6d2080f in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
#2  0xb6d23cc3 in __GI_abort () at abort.c:90
#3  0xb6d5d265 in __libc_message (do_abort=do_abort@entry=2, fmt=fmt@entry=0xb6e5cc30 "*** Error in `%s': %s: 0x%s ***\n") at ../sysdeps/unix/sysv/linux/libc_fatal.c:199
#4  0xb6d67e42 in malloc_printerr (action=<optimized out>, str=<optimized out>, ptr=0x80538b8) at malloc.c:4902
#5  0xb6d68b80 in _int_free (av=0xb6e9d440 <main_arena>, p=0x80538b0, have_lock=0) at malloc.c:3758
#6  0xb7e2bb25 in msFreeHashItems (table=0x805b758) at maphash.c:103
#7  0xb7e66fad in freeWeb (web=0x805b6ec) at mapfile.c:5184
#8  0xb7f38b00 in msFreeMap (map=0x8059700) at mapobject.c:107
#9  0xb7e2ac05 in msFreeMapServObj (mapserv=0x8053390) at maptemplate.c:4483
#10 0x08048ea0 in main (argc=2, argv=0xbfffe694) at mapserv.c:274
```

QUERY_STRING used for testing:

```
map=/var/www/wms_gfi_test/mapdata/bigmapfile_gfi_test.map&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetFeatureInfo&LAYERS=bigmapfile_test_001%2Cbigmapfile_test_002%2Cbigmapfile_test_003%2Cbigmapfile_test_004%2Cbigmapfile_test_005%2Cbigmapfile_test_006%2Cbigmapfile_test_007%2Cbigmapfile_test_008%2Cbigmapfile_test_009%2Cbigmapfile_test_010%2Cbigmapfile_test_011%2Cbigmapfile_test_012%2Cbigmapfile_test_013%2Cbigmapfile_test_014%2Cbigmapfile_test_015%2Cbigmapfile_test_016%2Cbigmapfile_test_017%2Cbigmapfile_test_018%2Cbigmapfile_test_019%2Cbigmapfile_test_020%2Cbigmapfile_test_021%2Cbigmapfile_test_022%2Cbigmapfile_test_023%2Cbigmapfile_test_024%2Cbigmapfile_test_025%2Cbigmapfile_test_026%2Cbigmapfile_test_027%2Cbigmapfile_test_028%2Cbigmapfile_test_029%2Cbigmapfile_test_030%2Cbigmapfile_test_031%2Cbigmapfile_test_032%2Cbigmapfile_test_033%2Cbigmapfile_test_034%2Cbigmapfile_test_035%2Cbigmapfile_test_036%2Cbigmapfile_test_037%2Cbigmapfile_test_038%2Cbigmapfile_test_039%2Cbigmapfile_test_040%2Cbigmapfile_test_041%2Cbigmapfile_test_042%2Cbigmapfile_test_043%2Cbigmapfile_test_044%2Cbigmapfile_test_045%2Cbigmapfile_test_046%2Cbigmapfile_test_047%2Cbigmapfile_test_048%2Cbigmapfile_test_049%2Cbigmapfile_test_050%2Cbigmapfile_test_051%2Cbigmapfile_test_052%2Cbigmapfile_test_053%2Cbigmapfile_test_054%2Cbigmapfile_test_055%2Cbigmapfile_test_056%2Cbigmapfile_test_057%2Cbigmapfile_test_058%2Cbigmapfile_test_059%2Cbigmapfile_test_060&QUERY_LAYERS=bigmapfile_test_001%2Cbigmapfile_test_002%2Cbigmapfile_test_003%2Cbigmapfile_test_004%2Cbigmapfile_test_005%2Cbigmapfile_test_006%2Cbigmapfile_test_007%2Cbigmapfile_test_008%2Cbigmapfile_test_009%2Cbigmapfile_test_010%2Cbigmapfile_test_011%2Cbigmapfile_test_012%2Cbigmapfile_test_013%2Cbigmapfile_test_014%2Cbigmapfile_test_015%2Cbigmapfile_test_016%2Cbigmapfile_test_017%2Cbigmapfile_test_018%2Cbigmapfile_test_019%2Cbigmapfile_test_020%2Cbigmapfile_test_021%2Cbigmapfile_test_022%2Cbigmapfile_test_023%2Cbigmapfile_test_024%2Cbigmapfile_test_025%2Cbigmapfile_test_026%2Cbigmapfile_test_027%2Cbigmapfile_test_028%2Cbigmapfile_test_029%2Cbigmapfile_test_030%2Cbigmapfile_test_031%2Cbigmapfile_test_032%2Cbigmapfile_test_033%2Cbigmapfile_test_034%2Cbigmapfile_test_035%2Cbigmapfile_test_036%2Cbigmapfile_test_037%2Cbigmapfile_test_038%2Cbigmapfile_test_039%2Cbigmapfile_test_040%2Cbigmapfile_test_041%2Cbigmapfile_test_042%2Cbigmapfile_test_043%2Cbigmapfile_test_044%2Cbigmapfile_test_045%2Cbigmapfile_test_046%2Cbigmapfile_test_047%2Cbigmapfile_test_048%2Cbigmapfile_test_049%2Cbigmapfile_test_050%2Cbigmapfile_test_051%2Cbigmapfile_test_052%2Cbigmapfile_test_053%2Cbigmapfile_test_054%2Cbigmapfile_test_055%2Cbigmapfile_test_056%2Cbigmapfile_test_057%2Cbigmapfile_test_058%2Cbigmapfile_test_059%2Cbigmapfile_test_060&STYLES=%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C%2C&BBOX=-50809.282257%2C6301337.071405%2C2400067.592338%2C6961752.995697&FEATURE_COUNT=10&HEIGHT=270&WIDTH=1002&FORMAT=image%2Fpng&INFO_FORMAT=text%2Fhtml&SRS=EPSG%3A3857&X=582&Y=77
```

Greetings, Jana.
