### PR TITLE
CAIRO PDF fails without error when symbol size is 0

### DIFF
--- a/maprendering.c
+++ b/maprendering.c
@@ -833,8 +833,8 @@ int msDrawMarkerSymbol(symbolSetObj *symbolset,imageObj *image, pointObj *p, sty
         break;
       }
 
-      s.style = style;
       computeSymbolStyle(&s,style,symbol,scalefactor,image->resolutionfactor);
+      s.style = style;
       if (!s.color && !s.outlinecolor && symbol->type != MS_SYMBOL_PIXMAP &&
           symbol->type != MS_SYMBOL_SVG) {
         return MS_SUCCESS; // nothing to do if no color, except for pixmap symbols


### PR DESCRIPTION
I have C# MapScript code running under IIS7 64bit which allows users to print a map as a PNG or PDF. My code configures a mapfile based on client permissions and then sets the appropriate OUTPUTFORMAT option.

Below are the resulting PNG and PDF - the only difference in the mapfile is the OUTPUTFORMAT:

![usermapfile_20130514145449_print](https://f.cloud.github.com/assets/4424391/499736/f737bbb8-bc57-11e2-96dc-ae3b06a24611.png)

![capture](https://f.cloud.github.com/assets/4424391/499747/b3000d64-bc58-11e2-9f24-1dd9ca74ff09.png)

One of the layers was incorrectly configured with a symbol size of 0 as seen in this mapfile snippet: 

![capture2](https://f.cloud.github.com/assets/4424391/499805/305a8fde-bc5c-11e2-9465-da814af99231.png)

When the offending style section is removed from the mapfile, the PDF exactly matches the PNG image: 

![capture3](https://f.cloud.github.com/assets/4424391/499813/854fa272-bc5c-11e2-8ee2-1f3746d2bd0e.png)

I am concerned that the CAIRO pdf library simply returns the incomplete PDF image rather than throwing an error. Is it possible for the CAIRO library to throw an error in this instance so that I can catch it from within my C# code?
