### PR TITLE
MapServer 6.2.1 crashes on WCS request

### DIFF
--- a/mapwcs20.c
+++ b/mapwcs20.c
@@ -1855,6 +1855,7 @@ static int msWCSGetCoverageMetadata20(layerObj *layer, wcs20coverageMetadataObj 
 {
   char  *srs_uri = NULL;
   int i = 0;
+  memset(cm,0,sizeof(wcs20coverageMetadataObj));
   if ( msCheckParentPointer(layer->map,"map") == MS_FAILURE )
     return MS_FAILURE;
 


### PR DESCRIPTION
MapServer crashes on simple WCS requests. 
Valgrind dump attanched here : https://gist.github.com/gsueur/6069674
