### PR TITLE
implement offseted line outlines

### DIFF
--- a/maprendering.c
+++ b/maprendering.c
@@ -522,6 +522,8 @@ int msDrawLineSymbol(symbolSetObj *symbolset, imageObj *image, shapeObj *p,
 
       if(style->offsety==-99) {
         offsetLine = msOffsetPolyline(p,style->offsetx * finalscalefactor ,-99);
+      } else if(style->offsety==-999) {
+        offsetLine = msOffsetPolyline(p,style->offsetx * finalscalefactor ,-999);
       } else if(style->offsetx!=0 || style->offsety!=0) {
         offsetLine = msOffsetPolyline(p, style->offsetx * finalscalefactor,
                                       style->offsety * finalscalefactor);
@@ -641,10 +643,13 @@ int msDrawShadeSymbol(symbolSetObj *symbolset, imageObj *image, shapeObj *p, sty
         symbol->renderer = renderer;
 
       if (style->offsetx != 0 || style->offsety != 0) {
-        if(style->offsety==-99)
+        if(style->offsety==-99) {
           offsetPolygon = msOffsetPolyline(p, style->offsetx*scalefactor, -99);
-        else
+        } else if(style->offsety==-999) {
+          offsetPolygon = msOffsetPolyline(p,style->offsetx * scalefactor ,-999);
+        } else {
           offsetPolygon = msOffsetPolyline(p, style->offsetx*scalefactor,style->offsety*scalefactor);
+        }
       } else {
         offsetPolygon=p;
       }

--- a/mapserver.h
+++ b/mapserver.h
@@ -2628,6 +2628,7 @@ extern "C" {
   MS_DLL_EXPORT shapeObj *msGEOSIntersection(shapeObj *shape1, shapeObj *shape2);
   MS_DLL_EXPORT shapeObj *msGEOSDifference(shapeObj *shape1, shapeObj *shape2);
   MS_DLL_EXPORT shapeObj *msGEOSSymDifference(shapeObj *shape1, shapeObj *shape2);
+  MS_DLL_EXPORT shapeObj *msGEOSOffsetCurve(shapeObj *p, double offset);
 
   MS_DLL_EXPORT int msGEOSContains(shapeObj *shape1, shapeObj *shape2);
   MS_DLL_EXPORT int msGEOSOverlaps(shapeObj *shape1, shapeObj *shape2);

--- a/maputil.c
+++ b/maputil.c
@@ -49,7 +49,9 @@
 #ifdef USE_RSVG
 #include <glib-object.h>
 #endif
-
+#ifdef USE_GEOS
+#include <geos_c.h>
+#endif
 
 
 extern char *msyystring_buffer;
@@ -1845,6 +1847,16 @@ shapeObj *msOffsetPolyline(shapeObj *p, double offsetx, double offsety)
   shapeObj *ret;
   if(offsety == -99) { /* complex calculations */
     return msOffsetCurve(p,offsetx);
+  } else if(offsety == -999) {
+    shapeObj *tmp1;
+    ret = msOffsetCurve(p,offsetx/2.0);
+    tmp1 = msOffsetCurve(p, -offsetx/2.0);
+    for(i=0;i<tmp1->numlines; i++) {
+      msAddLineDirectly(ret,tmp1->line + i);
+    }
+    msFreeShape(tmp1);
+    free(tmp1);
+    return ret;
   }
 
   ret = (shapeObj*)msSmallMalloc(sizeof(shapeObj));


### PR DESCRIPTION
We currently have no way of easily rendering line outlines _only_, i.e. without an accompanying "fill", given that currently outlines are generated by stacking solidly stroked lines. Thus these kinds of renderings are difficultly/not supported for tunnels (note that the the "fill" is semi transparent, it could also have been completely left out):

![line-outlines](https://f.cloud.github.com/assets/358469/870936/7f67ecec-f83a-11e2-845e-ce1cb193bd72.png)

Obtaining such a rendering with the current version requires a bit of mapfile hacking, using

```
style #right outline
  color 0 0 0
  offset 5 -99 #offseted to the right by half the road width
  width 1
  pattern 4 4 end
end
style #left outline
  color 0 0 0
  offset -5 -99 #offseted to the left by half the road width
  width 1
  pattern 4 4 end
end
style #fill (optional)
  color 255 0 0
  width 10
  opacity 50
end
```

This solution has two major drawbacks:
- the value of the offset has to be explicitely set to half the value of the road width
- we need two STYLE objects, which plays rather badly with the stacking of cached styles (i.e. other road classes will need a fake empty STYLE..END block to push them up one level in the style caching process)

Current patch extends the OFFSET keyword

```
style #outlines
  color 0 0 0
  offset 10 -999 #offseted to the right and left, 10 pixels apart
  width 1
  pattern 4 4 end
end
style #fill (optional)
  color 255 0 0
  width 10
  opacity 50
end
```

The special -999 offset Y value, similarly to -99, offsets the input line in both directions by half the value of the specified offset X value. The resulting shape becomes a multiline object.
