### PR TITLE
Fixup axis order and srs in wfs client mode.

### DIFF
--- a/mapwfslayer.c
+++ b/mapwfslayer.c
@@ -455,9 +455,6 @@ static char *msBuildWFSLayerGetURL(mapObj *map, layerObj *lp, rectObj *bbox,
 
 	  msFree(projUrn);
   }
-    snprintf(pszURL + strlen(pszURL), bufferSize-strlen(pszURL),
-             "&BBOX=%.15g,%.15g,%.15g,%.15g",
-             bbox->minx, bbox->miny, bbox->maxx, bbox->maxy);
 
   if (psParams->nMaxFeatures > 0)
     snprintf(pszURL + strlen(pszURL), bufferSize-strlen(pszURL),


### PR DESCRIPTION
For WFS client: fixup axis order, always include SRSNAME and, in case of WFS 1.1, add SRS in BBOX parameter. Based on patch http://trac.osgeo.org/mapserver/attachment/ticket/4228/ms_wfs-1.1.0-v02.patch from mapserver/mapserver#4228
