### PR TITLE
MaxFeatures (for drawing) support lost at 6.2

### DIFF
--- a/maplayer.c
+++ b/maplayer.c
@@ -979,6 +979,7 @@ int msLayerGetMaxFeaturesToDraw(layerObj *layer, outputFormatObj *format)
   int nMaxFeatures = -1;
   const char *pszTmp = NULL;
   if (layer) {
+    nMaxFeatures = layer->maxfeatures;
     pszTmp = msLookupHashTable(&layer->metadata, "maxfeaturestodraw");
     if (pszTmp)
       nMaxFeatures = atoi(pszTmp);


### PR DESCRIPTION
The layer MAXFEATURES parameter was a means of limiting the number of features drawn. The parameter also was used for limiting query results- kind of a mess. Things were refactored in 6.2 I believe (TODO: find ticket number) and the drawing support seems to be gone...Look specifically at the lakes in the following maps.

Before: ![6.0](http://maps1.dnr.state.mn.us/cgi-bin/mapserv60?map=COMPASS_MAPFILE&mode=map&mapsize=500%20500&mapext=60484.375%204882796.875%20767921.875%205338609.375)

After: ![6.2](http://maps1.dnr.state.mn.us/cgi-bin/mapserv62?map=COMPASS_MAPFILE&mode=map&mapsize=500%20500&mapext=60484.375%204882796.875%20767921.875%205338609.375)
