### PR TITLE
Fix 'separated' spelling

### DIFF
--- a/mapowscommon.c
+++ b/mapowscommon.c
@@ -394,7 +394,7 @@ xmlNodePtr msOWSCommonOperationsMetadataOperation(xmlNsPtr psNsOws, xmlNsPtr psX
  * @param version the integerized x.y.z version of OWS Common to use
  * @param elname name of the element (Parameter | Constraint)
  * @param name name of the Parameter
- * @param values list of values (comma seperated list) or NULL if none
+ * @param values list of values (comma separated list) or NULL if none
  *
  * @return psRootNode xmlNodePtr pointer of XML construct
  *

--- a/shp2img.c
+++ b/shp2img.c
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
       fprintf(stdout,"  -o image: output filename (stdout if not provided)\n");
       fprintf(stdout,"  -e minx miny maxx maxy: extents to render\n");
       fprintf(stdout,"  -s sizex sizey: output image size\n");
-      fprintf(stdout,"  -l layers: layers / groups to enable - make sure they are quoted and space seperated if more than one listed\n" );
+      fprintf(stdout,"  -l layers: layers / groups to enable - make sure they are quoted and space separated if more than one listed\n" );
       fprintf(stdout,"  -all_debug n: Set debug level for map and all layers\n" );
       fprintf(stdout,"  -map_debug n: Set map debug level\n" );
       fprintf(stdout,"  -layer_debug layer_name n: Set layer debug level\n" );


### PR DESCRIPTION
source: http://anonscm.debian.org/gitweb/?p=pkg-grass/mapserver.git;a=blob;f=debian/patches/shp2img-typo.patch

(found by @sebastic)
