### PR TITLE
A big offset on polygon can show weird results

### DIFF
--- a/mapdraw.c
+++ b/mapdraw.c
@@ -2076,6 +2076,9 @@ int msDrawShape(mapObj *map, layerObj *layer, shapeObj *shape, imageObj *image, 
       }
       maxsize = MS_MAX(msSymbolGetDefaultSize(symbol), MS_MAX(style->size, style->width));
       maxunscaledsize = MS_MAX(style->minsize*image->resolutionfactor, style->minwidth*image->resolutionfactor);
+      if(shape->type == MS_SHAPE_POLYGON && !IS_PARALLEL_OFFSET(style->offsety)) {
+         maxsize += MS_MAX(fabs(style->offsety),fabs(style->offsetx));
+      }
       clip_buf = MS_MAX(clip_buf,MS_NINT(MS_MAX(maxsize * layer->scalefactor, maxunscaledsize) + 1));
     }
 

--- a/mapprimitive.c
+++ b/mapprimitive.c
@@ -1772,7 +1772,7 @@ labelPathObj** msPolylineLabelPath(mapObj *map, imageObj *img,shapeObj *p, int m
           offset = -offset;
       }
     }
-    p = msOffsetPolyline(p,offset, -99);
+    p = msOffsetPolyline(p,offset, MS_STYLE_SINGLE_SIDED_OFFSET);
     if(!p) return NULL;
   }
 

--- a/maprendering.c
+++ b/maprendering.c
@@ -520,10 +520,10 @@ int msDrawLineSymbol(symbolSetObj *symbolset, imageObj *image, shapeObj *p,
         finalscalefactor = 1.0;
       }
 
-      if(style->offsety==-99) {
-        offsetLine = msOffsetPolyline(p,style->offsetx * finalscalefactor ,-99);
-      } else if(style->offsety==-999) {
-        offsetLine = msOffsetPolyline(p,style->offsetx * finalscalefactor ,-999);
+      if(style->offsety==MS_STYLE_SINGLE_SIDED_OFFSET) {
+        offsetLine = msOffsetPolyline(p,style->offsetx * finalscalefactor ,MS_STYLE_SINGLE_SIDED_OFFSET);
+      } else if(style->offsety==MS_STYLE_DOUBLE_SIDED_OFFSET) {
+        offsetLine = msOffsetPolyline(p,style->offsetx * finalscalefactor ,MS_STYLE_DOUBLE_SIDED_OFFSET);
       } else if(style->offsetx!=0 || style->offsety!=0) {
         offsetLine = msOffsetPolyline(p, style->offsetx * finalscalefactor,
                                       style->offsety * finalscalefactor);
@@ -643,10 +643,10 @@ int msDrawShadeSymbol(symbolSetObj *symbolset, imageObj *image, shapeObj *p, sty
         symbol->renderer = renderer;
 
       if (style->offsetx != 0 || style->offsety != 0) {
-        if(style->offsety==-99) {
-          offsetPolygon = msOffsetPolyline(p, style->offsetx*scalefactor, -99);
-        } else if(style->offsety==-999) {
-          offsetPolygon = msOffsetPolyline(p,style->offsetx * scalefactor ,-999);
+        if(style->offsety==MS_STYLE_SINGLE_SIDED_OFFSET) {
+          offsetPolygon = msOffsetPolyline(p, style->offsetx*scalefactor, MS_STYLE_SINGLE_SIDED_OFFSET);
+        } else if(style->offsety==MS_STYLE_DOUBLE_SIDED_OFFSET) {
+          offsetPolygon = msOffsetPolyline(p,style->offsetx * scalefactor ,MS_STYLE_DOUBLE_SIDED_OFFSET);
         } else {
           offsetPolygon = msOffsetPolyline(p, style->offsetx*scalefactor,style->offsety*scalefactor);
         }

--- a/mapserver.h
+++ b/mapserver.h
@@ -944,6 +944,10 @@ extern "C" {
 #endif
   };
 
+#define MS_STYLE_SINGLE_SIDED_OFFSET -99
+#define MS_STYLE_DOUBLE_SIDED_OFFSET -999
+#define IS_PARALLEL_OFFSET(offsety) (offsety == MS_STYLE_SINGLE_SIDED_OFFSET || offsety == MS_STYLE_DOUBLE_SIDED_OFFSET)
+
 
 
   /********************************************************************/

--- a/maputil.c
+++ b/maputil.c
@@ -1845,9 +1845,9 @@ shapeObj *msOffsetPolyline(shapeObj *p, double offsetx, double offsety)
 {
   int i, j;
   shapeObj *ret;
-  if(offsety == -99) { /* complex calculations */
+  if(offsety == MS_STYLE_SINGLE_SIDED_OFFSET) { /* complex calculations */
     return msOffsetCurve(p,offsetx);
-  } else if(offsety == -999) {
+  } else if(offsety == MS_STYLE_DOUBLE_SIDED_OFFSET) {
     shapeObj *tmp1;
     ret = msOffsetCurve(p,offsetx/2.0);
     tmp1 = msOffsetCurve(p, -offsetx/2.0);


### PR DESCRIPTION
See screenshot (top and left border) using this STYLE:

```
    STYLE
        COLOR 100 0 0
        OUTLINECOLOR 0 0 80
            WIDTH 5
    END
      STYLE
         SYMBOL 'point_bleu'
         COLOR 200 10 10
         OUTLINECOLOR 10 10 200
         OFFSET 15 15
         SIZE 5.0
      END
```

![but_polygone_en_ligne_with_offset](https://f.cloud.github.com/assets/660191/33911/0337949c-50dd-11e2-833a-d32b400e777a.png)
