### PR TITLE
Double backslashes in Windows UNC pathnames should be escaped by the mapfile writer

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -554,23 +554,30 @@ static void writeCharacter(FILE *stream, int indent, const char *name, const cha
 
 static void writeString(FILE *stream, int indent, const char *name, const char *defaultString, char *string)
 {
-  char *string_tmp;
+  char *string_escaped;
 
   if(!string) return;
   if(defaultString && strcmp(string, defaultString) == 0) return;
   writeIndent(stream, ++indent);
   if(name) msIO_fprintf(stream, "%s ", name);
-  if ( (strchr(string, '\'') == NULL) && (strchr(string, '\"') == NULL))
-    msIO_fprintf(stream, "\"%s\"\n", string);
-  else if ( (strchr(string, '\"') != NULL) && (strchr(string, '\'') == NULL))
-    msIO_fprintf(stream, "'%s'\n", string);
-  else if ( (strchr(string, '\'') != NULL) && (strchr(string, '\"') == NULL))
-    msIO_fprintf(stream, "\"%s\"\n", string);
-  else {
-    string_tmp = msStringEscape(string);
-    msIO_fprintf(stream, "\"%s\"\n", string_tmp);
-    if(string!=string_tmp) free(string_tmp);
+  if(strchr(string,'\\')) {
+    string_escaped = msStrdup(string);
+    string_escaped = msReplaceSubstring(string_escaped,"\\","\\\\");
+  } else {
+    string_escaped = string;
   }
+  if ( (strchr(string_escaped, '\'') == NULL) && (strchr(string_escaped, '\"') == NULL))
+    msIO_fprintf(stream, "\"%s\"\n", string_escaped);
+  else if ( (strchr(string_escaped, '\"') != NULL) && (strchr(string_escaped, '\'') == NULL))
+    msIO_fprintf(stream, "'%s'\n", string_escaped);
+  else if ( (strchr(string_escaped, '\'') != NULL) && (strchr(string_escaped, '\"') == NULL))
+    msIO_fprintf(stream, "\"%s\"\n", string_escaped);
+  else {
+    char *string_tmp = msStringEscape(string_escaped);
+    msIO_fprintf(stream, "\"%s\"\n", string_tmp);
+    if(string_escaped!=string_tmp) free(string_tmp);
+  }
+  if(string_escaped!=string) free(string_escaped);
 }
 
 static void writeNumberOrString(FILE *stream, int indent, const char *name, double defaultNumber, double number, char *string)


### PR DESCRIPTION
Since the mapserver parser changes the double backslashes to a single slash the reverse operation should take place when writing the mapfile. Currently if we do subsequent load and write operations on the same mapfile we may get invalid file locatons in the mapfiles.

For exampe if we have "\\myserver\myshare\Maps\myfile.shp" in the DATA section loading and then saving the file will results: "\myserver\myshare\Maps\myfile.shp". When loading the map back again we will get "\myserver\myshare\Maps\myfile.shp" which is an invalid file location causing run time issues.

I think backslashes should be replaced with double backslashes every time when saving the file at least in the CONNECTION, DATA, SHAPEPATH, FONTSET, SYMBOLSET sections.
