### PR TITLE
Install Ruby mapscript with CMake

### DIFF
--- a/mapscript/ruby/CMakeLists.txt
+++ b/mapscript/ruby/CMakeLists.txt
@@ -12,9 +12,6 @@ SWIG_LINK_LIBRARIES(rubymapscript ${RUBY_LIBRARY} ${MAPSERVER_LIBMAPSERVER})
 set_target_properties(${SWIG_MODULE_rubymapscript_REAL_NAME} PROPERTIES PREFIX "")
 set_target_properties(${SWIG_MODULE_rubymapscript_REAL_NAME} PROPERTIES OUTPUT_NAME mapscript)
 
-#get_target_property(LOC_MAPSCRIPT_LIB ${SWIG_MODULE_mapscript_REAL_NAME} LOCATION)
-#set(mapscript_files ${LOC_MAPSCRIPT_LIB} ${CMAKE_CURRENT_BINARY_DIR}/mapscript.py)
-#install(FILES ${mapscript_files} DESTINATION ${PYTHON_SITE_PACKAGES})
-
-#install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mapscript.py DESTINATION ${PYTHON_SITE_PACKAGES})
-#install(TARGETS mapscript DESTINATION ${PYTHON_SITE_PACKAGES})
+get_target_property(LOC_MAPSCRIPT_LIB ${SWIG_MODULE_rubymapscript_REAL_NAME} LOCATION)
+execute_process(COMMAND ${RUBY_EXECUTABLE} -r rbconfig -e "puts RbConfig::CONFIG['archdir']" OUTPUT_VARIABLE RUBY_ARCHDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+install(FILES ${LOC_MAPSCRIPT_LIB} DESTINATION ${RUBY_ARCHDIR})


### PR DESCRIPTION
The CMakeLists.txt for the Ruby mapscript extension doesn't include installation instructions.

The mapscript.so library is installed in the directory specified by the 'archdir' configuration option of the default ruby executable.
