### PR TITLE
Expression segmentation fault

### DIFF
--- a/mappostgis.c
+++ b/mappostgis.c
@@ -587,7 +587,7 @@ wkbConvCollectionToShape(wkbObj *w, shapeObj *shape)
       failures++;
     }
   }
-  if ( failures == ncomponents )
+  if ( failures == ncomponents || ncomponents == 0)
     return MS_FAILURE;
   else
     return MS_SUCCESS;
@@ -2195,6 +2195,8 @@ int msPostGISReadShape(layerObj *layer, shapeObj *shape)
     shape->numvalues = layer->numitems;
 
     msComputeBounds(shape);
+  } else {
+     shape->type = MS_SHAPE_NULL;
   }
 
   if( layer->debug > 2 ) {


### PR DESCRIPTION
Mapserver crashes with empty geometrycollections from PostGIS when using expressions in Class

As already discussed on the list with Thomas, here's the issue ...

Please see http://osgeo-org.1560.x6.nabble.com/Expression-segmentation-fault-td5076003.html for the discussion and patch
