### PR TITLE
MAXSCALEDENOM & MAXSCALEDENOM throw an error if in LABEL

### DIFF
--- a/mapdraw.c
+++ b/mapdraw.c
@@ -1593,16 +1593,15 @@ int lineLayerDrawShape(mapObj *map, imageObj *image, layerObj *layer, shapeObj *
       labelObj *label = layer->class[c]->labels[l];
       textSymbolObj ts;
       char *annotext;
+      if(!msGetLabelStatus(map,layer,shape,label)) {
+        continue;
+      }
+
       annotext = msShapeGetLabelAnnotation(layer,anno_shape,label);
       if(!annotext) continue;
       initTextSymbol(&ts);
       msPopulateTextSymbolForLabelAndString(&ts,label,annotext,layer->scalefactor,image->resolutionfactor, layer->labelcache);
       
-      if(!msGetLabelStatus(map,layer,shape,label)) {
-        freeTextSymbol(&ts);
-        free(annotext);
-        continue;
-      }
       
       if (label->anglemode == MS_ANGLEMODE_FOLLOW) { /* bug #1620 implementation */
         struct label_follow_result lfr;


### PR DESCRIPTION
In the last trunk.
If add a MINSCALEDENOM and MAXSCALEDENOM inside a LABEL . Mapserver crash but without give any message log.

I tested it with this:

<pre>
LAYER
    NAME "test1"
    TYPE LINE
    STATUS OFF
    EXTENT  1660351.00 4458445.22 1866743.13 4960849.91
    FEATURE
    WKT "LINESTRING(1662120.546188 4858603.677291, 1662738.746295 4858875.082216, 1663854.522097 4858618.755342, 1664779.309249 4858638.85941)"
    END #FEATURE
    METADATA
      "wms_title" "Test"
      "ows_enable_request" "*"
    END
    LABELCACHE on
    MINSCALEDENOM 1
    MAXSCALEDENOM 4000000
    CLASS
      STYLE
        COLOR 200 0 0
        OUTLINECOLOR 0 255 0
      END
    LABEL
     TEXT 'BLAH BLAH'
        COLOR 0 85 255
        OUTLINECOLOR 212 0 0
        OUTLINEWIDTH 2
        MINSCALEDENOM 1
        MAXSCALEDENOM 40000
        FONT "LiberationSans-Regular"
        TYPE truetype
        SIZE 9
        ANGLE FOLLOW
        OFFSET 15 99
        POSITION auto
        PRIORITY 10
        MAXOVERLAPANGLE 180.0
        BUFFER 1
        FORCE OFF
        PARTIALS FALSE
        MINDISTANCE 200
    END
    END #CLASS
  END 

</pre>
