### PR TITLE
GetLegendGraphic with Y OFFSET -99 crash mapserver

### DIFF
--- a/maplegend.c
+++ b/maplegend.c
@@ -119,6 +119,7 @@ int msDrawLegendIcon(mapObj *map, layerObj *lp, classObj *theclass,
   }
 
   /* initialize the box used for polygons and for outlines */
+  msInitShape(&box);
   box.line = (lineObj *)msSmallMalloc(sizeof(lineObj));
   box.numlines = 1;
   box.line[0].point = (pointObj *)msSmallMalloc(sizeof(pointObj)*5);
@@ -244,6 +245,7 @@ int msDrawLegendIcon(mapObj *map, layerObj *lp, classObj *theclass,
         else
             offset = theclass->styles[0]->width/2;
       }
+      msInitShape(&zigzag);
       zigzag.line = (lineObj *)msSmallMalloc(sizeof(lineObj));
       zigzag.numlines = 1;
       zigzag.line[0].point = (pointObj *)msSmallMalloc(sizeof(pointObj)*4);


### PR DESCRIPTION
Mapserver 6.4.0 compiled under Debian 7.

If you request a legend with a WMS GetLegendGraphic request for a layer with OFFSET 1 -99 in its STYLE section, mapserv will crash with this error in the kern.log:

mapserv[3440]: segfault at 40 ip 00007feb2f0f33db sp 00007fffa294cf00 error 4 in libstdc++.so.6.0.17[7feb2f091000+e8000]

Mapserv will not crash for a normal WMS GetMap request and it renders fine.

The x offset value can be anything positive.
A positive y offset value does not crash mapserv.

I can provide a sample mapfile under request.
