### PR TITLE
Fix SLD PerpendicularOffset for lines and labels

### DIFF
--- a/mapogcsld.c
+++ b/mapogcsld.c
@@ -3030,7 +3030,7 @@ int ParseTextLinePlacement(CPLXMLNode *psRoot, classObj *psClass)
   psOffset = CPLGetXMLNode(psRoot, "PerpendicularOffset");
   if (psOffset && psOffset->psChild && psOffset->psChild->pszValue) {
     psLabelObj->offsetx = atoi(psOffset->psChild->pszValue);
-    psLabelObj->offsety = -99;
+    psLabelObj->offsety = MS_LABEL_PERPENDICULAR_OFFSET;
 
     /*if there is a PerpendicularOffset, we will assume that the
       best setting for mapserver would be to use angle=0 and the

--- a/mapprimitive.c
+++ b/mapprimitive.c
@@ -1754,14 +1754,14 @@ labelPathObj** msPolylineLabelPath(mapObj *map, imageObj *img,shapeObj *p, int m
   labelpaths = (labelPathObj **) msSmallMalloc(sizeof(labelPathObj *) * labelpaths_size);
   (*regular_lines) = (int *) msSmallMalloc(sizeof(int) * regular_lines_size);
 
-  if(label->offsetx != 0 && (label->offsety == -99 || label->offsety == 99)) {
+  if(label->offsetx != 0 && IS_PERPENDICULAR_OFFSET(label->offsety)) {
     double offset;
     if(label->offsetx > 0) {
       offset = label->offsetx + label->size/2;
     } else {
       offset = label->offsetx - label->size/2;
     }
-    if(label->offsety == 99 && p->numlines>0 && p->line[0].numpoints > 0) {
+    if(label->offsety == MS_LABEL_PERPENDICULAR_TOP_OFFSET && p->numlines>0 && p->line[0].numpoints > 0) {
       /* is the line mostly left-to-right or right-to-left ?
        * FIXME this should be done line by line, by stepping through shape->lines, however
        * the OffsetPolyline function works on shapeObjs, not lineObjs
@@ -1799,7 +1799,7 @@ labelPathObj** msPolylineLabelPath(mapObj *map, imageObj *img,shapeObj *p, int m
   /* set the number of paths in the array */
   *numpaths = labelpaths_index;
   *num_regular_lines = regular_lines_index;
-  if(label->offsety == -99 && label->offsetx != 0) {
+  if(IS_PERPENDICULAR_OFFSET(label->offsety) && label->offsetx != 0) {
      msFreeShape(p);
      msFree(p);
   }

--- a/mapserver.h
+++ b/mapserver.h
@@ -946,7 +946,7 @@ extern "C" {
 
 #define MS_STYLE_SINGLE_SIDED_OFFSET -99
 #define MS_STYLE_DOUBLE_SIDED_OFFSET -999
-#define IS_PARALLEL_OFFSET(offsety) (offsety == MS_STYLE_SINGLE_SIDED_OFFSET || offsety == MS_STYLE_DOUBLE_SIDED_OFFSET)
+#define IS_PARALLEL_OFFSET(offsety) ((offsety) == MS_STYLE_SINGLE_SIDED_OFFSET || (offsety) == MS_STYLE_DOUBLE_SIDED_OFFSET)
 
 
 
@@ -1060,6 +1060,11 @@ extern "C" {
 
     labelLeaderObj leader;
   };
+
+#define MS_LABEL_PERPENDICULAR_OFFSET -99
+#define MS_LABEL_PERPENDICULAR_TOP_OFFSET 99
+#define IS_PERPENDICULAR_OFFSET(offsety) ((offsety) == MS_LABEL_PERPENDICULAR_OFFSET || (offsety) == MS_LABEL_PERPENDICULAR_TOP_OFFSET)
+
 
   /************************************************************************/
   /*                               classObj                               */


### PR DESCRIPTION
From the mapserver-users mailing list:

```
Hi all,

I've noticed that there's an implementation difference between
specifying a perpendicular offset in the STYLE section of the Mapfile:

  STYLE
    ...
    OFFSET 3 -99
    ...
  END

and specifying it via an SLD:

  <sld:LineSymbolizer>
    ...
    <sld:PerpendicularOffset>3</sld:PerpendicularOffset>
    ...
  <sld:LineSymbolizer>


The first one, via the Mapfile, does a complex offset calculation
(function msOffsetPolyline() in maputil.c; calls msOffsetCurve() for
perpendicular offset).
The second one, via the SLD, simply does a displacement by the given
value in both the X and Y directions (function msSLDParseLineSymbolizer()
in mapogcsld.c).
These two produce quite different results.
[Note that the SLD one would be the same as specifying "OFFSET 3 3" in
the Mapfile.]

My questions:
Is there a reason the two methods are different?
If not, would it be possible to change the SLD one to use the same
calculations as done for the Mapfile?
```
