### PR TITLE
6.4.0 build mapscript module unversionned

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set (MapServer_VERSION_MAJOR 6)
 set (MapServer_VERSION_MINOR 4)
 set (MapServer_VERSION_REVISION 0)
 set (MapServer_VERSION_SUFFIX "")
+set (MapServer_SOVERSION 1)
 
 set(TARGET_VERSION_MAJOR ${MapServer_VERSION_MAJOR})
 set(TARGET_VERSION_MINOR ${MapServer_VERSION_MINOR})
@@ -233,13 +234,13 @@ mapogr.cpp mapcontour.c mapsmoothing.c ${REGEX_SOURCES})
 add_library(mapserver SHARED ${mapserver_SOURCES} ${agg_SOURCES})
 set_target_properties( mapserver  PROPERTIES
   VERSION ${MapServer_VERSION_STRING}
-  SOVERSION 1
+  SOVERSION ${MapServer_SOVERSION}
 ) 
 if(BUILD_STATIC)
   add_library(mapserver_static STATIC ${mapserver_SOURCES} ${agg_SOURCES})
   set_target_properties( mapserver_static PROPERTIES
     VERSION ${MapServer_VERSION_STRING}
-    SOVERSION 1
+    SOVERSION ${MapServer_SOVERSION}
   ) 
 endif(BUILD_STATIC)
 

--- a/mapscript/php/CMakeLists.txt
+++ b/mapscript/php/CMakeLists.txt
@@ -24,6 +24,12 @@ add_library(php_mapscript MODULE
    layer.c map.c php_mapscript_util.c php_mapscript.c mapscript_i.c
 )
 
+if(NOT APPLE)
+set_target_properties( php_mapscript  PROPERTIES
+  VERSION ${MapServer_VERSION_STRING}
+  SOVERSION 1
+) 
+endif(NOT APPLE)
 
 target_link_libraries(php_mapscript ${MAPSERVER_LIBMAPSERVER})
 

--- a/mapscript/php/CMakeLists.txt
+++ b/mapscript/php/CMakeLists.txt
@@ -25,10 +25,10 @@ add_library(php_mapscript MODULE
 )
 
 if(NOT APPLE)
-set_target_properties( php_mapscript  PROPERTIES
-  VERSION ${MapServer_VERSION_STRING}
-  SOVERSION 1
-) 
+   set_target_properties( php_mapscript  PROPERTIES
+      VERSION ${MapServer_VERSION_STRING}
+      SOVERSION ${MapServer_SOVERSION}
+   ) 
 endif(NOT APPLE)
 
 target_link_libraries(php_mapscript ${MAPSERVER_LIBMAPSERVER})

--- a/mapscript/python/CMakeLists.txt
+++ b/mapscript/python/CMakeLists.txt
@@ -35,6 +35,12 @@ SWIG_LINK_LIBRARIES(pythonmapscript ${PYTHON_LIBRARIES} ${MAPSERVER_LIBMAPSERVER
 
 set_target_properties(${SWIG_MODULE_pythonmapscript_REAL_NAME} PROPERTIES PREFIX "")
 set_target_properties(${SWIG_MODULE_pythonmapscript_REAL_NAME} PROPERTIES OUTPUT_NAME _mapscript)
+if(NOT APPLE)
+   set_target_properties(${SWIG_MODULE_pythonmapscript_REAL_NAME} PROPERTIES
+      VERSION ${MapServer_VERSION_STRING}
+      SOVERSION ${MapServer_SOVERSION}
+   ) 
+endif(NOT APPLE)
 
 
 execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(True)" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
With previous mapserver 6.2.1 for example php_mapscript-6.2.1.so was created.

Now with the new cmake 6.4.0 only php_mapscript.so is produced
It seems the same apply for all mapscript modules

[   14s] + cd build
[   14s] + export CMAKE_PREFIX_PATH=/usr/include:/usr/include/fastcgi:/usr/include/pgsql:/usr/include/pgsql/server:/usr/lib/postgresql92/lib64
[   14s] + CMAKE_PREFIX_PATH=/usr/include:/usr/include/fastcgi:/usr/include/pgsql:/usr/include/pgsql/server:/usr/lib/postgresql92/lib64
[   14s] + cmake -D CMAKE_INSTALL_PREFIX=/usr -D CMAKE_BUILD_TYPE=Release -D WITH_CAIRO=TRUE -D WITH_CLIENT_WFS=TRUE -D WITH_CLIENT_WMS=TRUE -D WITH_CURL=TRUE -D WITH_FCGI=TRUE -D WITH_FRIBIDI=TRUE -D WITH_GD=TRUE -D WITH_GDAL=TRUE -D WITH_GEOS=TRUE -D WITH_GIF=TRUE -D WITH_ICONV=TRUE -D WITH_JAVA=TRUE -D WITH_KML=TRUE -D WITH_LIBXML2=TRUE -D WITH_OGR=TRUE -D WITH_MYSQL=TRUE -D WITH_PERL=TRUE -D CUSTOM_PERL_SITE_ARCH_DIR=/usr/lib/perl5/vendor_perl/5.16.2/x86_64-linux-thread-multi -D WITH_PHP=TRUE -D WITH_POSTGIS=TRUE -D WITH_PROJ=TRUE -D WITH_PYTHON=TRUE -D WITH_RUBY=TRUE -D WITH_SOS=TRUE -D WITH_THREAD_SAFETY=TRUE -D WITH_WCS=TRUE -D WITH_WMS=TRUE -D WITH_WFS=TRUE -D WITH_XMLMAPFILE=TRUE -DWITH_POINT_Z_M=TRUE -DWITH_APACHE_MODULE=FALSE -D WITH_SVGCAIRO=FALSE -D WITH_MYSQL=FALSE -D WITH_CSHARP=FALSE -D WITH_ORACLESPATIAL=FALSE -D WITH_ORACLE_PLUGIN=FALSE -D WITH_MSSQL2008=FALSE -D WITH_SDE=FALSE -D WITH_SDE_PLUGIN=FALSE -D WITH_EXEMPI=FALSE ../mapserver-6.4.0/
[   15s] -- The C compiler identification is GNU 4.7.2
[   15s] -- The CXX compiler identification is GNU 4.7.2
[   15s] -- Check for working C compiler: /usr/bin/cc
[   15s] -- Check for working C compiler: /usr/bin/cc -- works
[   15s] -- Detecting C compiler ABI info
[   15s] -- Detecting C compiler ABI info - done
[   15s] -- Check for working CXX compiler: /usr/bin/c++
[   15s] -- Check for working CXX compiler: /usr/bin/c++ -- works
[   15s] -- Detecting CXX compiler ABI info
[   15s] -- Detecting CXX compiler ABI info - done
[   15s] -- Looking for strrstr
[   15s] -- Looking for strrstr - not found
[   15s] -- Looking for strcasecmp
[   15s] -- Looking for strcasecmp - found
[   15s] -- Looking for strcasestr
[   15s] -- Looking for strcasestr - found
[   15s] -- Looking for strdup
[   15s] -- Looking for strdup - found
[   15s] -- Looking for strlcat
[   15s] -- Looking for strlcat - not found
[   15s] -- Looking for strlcpy
[   15s] -- Looking for strlcpy - not found
[   15s] -- Looking for strlen
[   16s] -- Looking for strlen - found
[   16s] -- Looking for strncasecmp
[   16s] -- Looking for strncasecmp - found
[   16s] -- Looking for vsnprintf
[   16s] -- Looking for vsnprintf - found
[   16s] -- Looking for lrintf
[   16s] -- Looking for lrintf - found
[   16s] -- Looking for lrint
[   16s] -- Looking for lrint - found
[   16s] -- Looking for dlfcn.h
[   16s] -- Looking for dlfcn.h - found
[   16s] -- Performing Test HAVE_SYNC_FETCH_AND_ADD
[   16s] -- Performing Test HAVE_SYNC_FETCH_AND_ADD - Success
[   16s] -- Found ZLIB: /usr/lib64/libz.so (found version "1.2.7") 
[   16s] -- Found PNG: /usr/lib64/libpng.so (found version "1.5.13") 
[   16s] -- Found JPEG: /usr/lib64/libjpeg.so  
[   16s] -- Found Freetype: /usr/lib64/libfreetype.so  
[   16s] -- Found PROJ: /usr/lib64/libproj.so  
[   16s] -- Looking for gdImagePng in /usr/lib64/libgd.so
[   16s] -- Looking for gdImagePng in /usr/lib64/libgd.so - found
[   16s] -- Looking for gdImageJpeg in /usr/lib64/libgd.so
[   16s] -- Looking for gdImageJpeg in /usr/lib64/libgd.so - found
[   16s] -- Looking for gdImageGif in /usr/lib64/libgd.so
[   16s] -- Looking for gdImageGif in /usr/lib64/libgd.so - found
[   16s] -- Looking for gdFontCacheSetup in /usr/lib64/libgd.so
[   16s] -- Looking for gdFontCacheSetup in /usr/lib64/libgd.so - found
[   16s] -- Found PkgConfig: /usr/bin/pkg-config (found version "0.27.1") 
[   16s] -- Found FRIBIDI: /usr/lib64/libfribidi.so  
[   16s] -- Looking for iconv
[   16s] -- Looking for iconv - found
[   16s] -- Found iconv library: 
[   16s] -- checking for module 'cairo'
[   16s] --   found cairo, version 1.12.8
[   16s] -- Found CAIRO: /usr/lib64/libcairo.so  
[   16s] -- Found FCGI: /usr/lib64/libfcgi.so  
[   16s] -- Found GEOS: /usr/lib64/libgeos_c.so  
[   16s] -- Found POSTGRESQL: /usr/lib64/libpq.so  
[   16s] -- Looking for PQserverVersion in pq
[   16s] -- Looking for PQserverVersion in pq - found
[   16s] -- Found GDAL: /usr/lib64/libgdal.so  
[   16s] -- Found CURL: /usr/lib64/libcurl.so (found version "7.28.1") 
[   17s] -- Found LibXml2: /usr/lib64/libxml2.so (found version "2.9.0") 
[   17s] -- Looking for include file pthread.h
[   17s] -- Looking for include file pthread.h - found
[   17s] -- Looking for pthread_create
[   17s] -- Looking for pthread_create - not found
[   17s] -- Looking for pthread_create in pthreads
[   17s] -- Looking for pthread_create in pthreads - not found
[   17s] -- Looking for pthread_create in pthread
[   17s] -- Looking for pthread_create in pthread - found
[   17s] -- Found Threads: TRUE  
[   17s] -- Found LibXslt: /usr/lib64/libxslt.so (found version "1.1.28") 
[   17s] -- Performing Test GIF_GifFileType_UserData
[   17s] -- Performing Test GIF_GifFileType_UserData - Success
[   17s] -- Found GIF: /usr/lib64/libgif.so (found version "4") 
[   17s] -- Found SWIG: /usr/bin/swig (found version "2.0.9") 
[   17s] -- Found PythonInterp: /usr/bin/python (found version "2.7.3") 
[   17s] -- /usr/include/php5/main
[   17s] -- Found PHP5-Version 5.3.17 (using /usr/bin/php-config)
[   17s] -- Found Perl: /usr/bin/perl (found version "5.16.2") 
[   17s] -- Found PerlLibs: /usr/lib/perl5/5.16.2/x86_64-linux-thread-multi/CORE/libperl.so  
[   17s] -- Found Ruby: /usr/bin/ruby (found version "1.9.1") 
[   17s] -- Found JNI: /usr/lib64/jvm/java/jre/lib/amd64/libjawt.so  
[   18s] -- Found Java: /usr/lib64/jvm/java/bin/java (found version "1.7.0.15") 
[   18s] -- * Summary of configured options for this build
[   18s] --  * Mandatory components
[   18s] --   * png: /usr/lib64/libpng.so
[   18s] --   * jpeg: /usr/lib64/libjpeg.so
[   18s] --   * freetype: /usr/lib64/libfreetype.so
[   18s] --  * Optional components
[   18s] --   * GDAL: /usr/lib64/libgdal.so
[   18s] --   * OGR: /usr/lib64/libgdal.so
[   18s] --   * GD: /usr/lib64/libgd.so
[   18s] --   * GIF: /usr/lib64/libgif.so
[   18s] --   * MYSQL: disabled
[   18s] --   * FRIBIDI: /usr/lib64/libfribidi.so
[   18s] --   * GIF: /usr/lib64/libgif.so
[   18s] --   * CAIRO: /usr/lib64/libcairo.so
[   18s] --   * SVGCAIRO: disabled
[   18s] --   * RSVG: disabled
[   18s] --   * CURL: /usr/lib64/libcurl.so
[   18s] --   * PROJ: /usr/lib64/libproj.so
[   18s] --   * LIBXML2: /usr/lib64/libxml2.so
[   18s] --   * POSTGIS: /usr/lib64/libpq.so
[   18s] --   * GEOS: /usr/lib64/libgeos_c.so
[   18s] --   * FastCGI: /usr/lib64/libfcgi.so
[   18s] --   * Oracle Spatial: disabled
[   18s] --   * SDE: disabled
[   18s] --   * Exempi XMP: disabled
[   18s] --  * Optional features
[   18s] --   * WMS SERVER: ENABLED
[   18s] --   * WFS SERVER: ENABLED
[   18s] --   * WCS SERVER: ENABLED
[   18s] --   * SOS SERVER: ENABLED
[   18s] --   * WMS CLIENT: ENABLED
[   18s] --   * WFS CLIENT: ENABLED
[   18s] --   * ICONV: ENABLED
[   18s] --   * Thread-safety support: ENABLED
[   18s] --   * KML output: ENABLED
[   18s] --   * Z+M point coordinate support: ENABLED
[   18s] --   * XML Mapfile support: ENABLED
[   18s] --  * Mapscripts
[   18s] --   * Python: ENABLED
[   18s] --   * PHP: ENABLED
[   18s] --   * PERL: ENABLED
[   18s] --   * RUBY: ENABLED
[   18s] --   * JAVA: ENABLED
[   18s] --   * C#: disabled
[   18s] --   * Apache Module (Experimental): disabled
[   18s] -- 
[   18s] -- Will install files to /usr
[   18s] -- Configuring done

resulting buildroot

[   65s] + ls -R /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64:
[   65s] etc
[   65s] srv
[   65s] usr
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/etc:
[   65s] php.d
[   65s] php5
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/etc/php.d:
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/etc/php5:
[   65s] conf.d
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/etc/php5/conf.d:
[   65s] mapscript.ini
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/srv:
[   65s] www
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/srv/www:
[   65s] cgi-bin
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/srv/www/cgi-bin:
[   65s] legend
[   65s] mapserv
[   65s] scalebar
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr:
[   65s] bin
[   65s] include
[   65s] lib
[   65s] lib64
[   65s] sbin
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/bin:
[   65s] legend
[   65s] mapserv
[   65s] msencrypt
[   65s] scalebar
[   65s] shp2img
[   65s] shptree
[   65s] shptreetst
[   65s] shptreevis
[   65s] sortshp
[   65s] tile4ms
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/include:
[   65s] mapserver
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/include/mapserver:
[   65s] cgiutil.h
[   65s] dxfcolor.h
[   65s] hittest.h
[   65s] mapaxisorder.h
[   65s] mapcopy.h
[   65s] mapentities.h
[   65s] maperror.h
[   65s] mapfile.h
[   65s] mapgml.h
[   65s] maphash.h
[   65s] maphttp.h
[   65s] mapio.h
[   65s] mapkmlrenderer.h
[   65s] maplibxml2.h
[   65s] mapogcfilter.h
[   65s] mapogcsld.h
[   65s] mapoglcontext.h
[   65s] mapoglrenderer.h
[   65s] mapows.h
[   65s] mapowscommon.h
[   65s] mapparser.h
[   65s] mappostgis.h
[   65s] mapprimitive.h
[   65s] mapproject.h
[   65s] mapraster.h
[   65s] mapregex.h
[   65s] mapresample.h
[   65s] mapserv.h
[   65s] mapserver-api.h
[   65s] mapserver.h
[   65s] mapshape.h
[   65s] mapsymbol.h
[   65s] maptemplate.h
[   65s] mapthread.h
[   65s] maptile.h
[   65s] maptime.h
[   65s] maptree.h
[   65s] mapwcs.h
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib:
[   65s] perl5
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib/perl5:
[   65s] vendor_perl
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib/perl5/vendor_perl:
[   65s] 5.16.2
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib/perl5/vendor_perl/5.16.2:
[   65s] x86_64-linux-thread-multi
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib/perl5/vendor_perl/5.16.2/x86_64-linux-thread-multi:
[   65s] auto
[   65s] mapscript.pm
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib/perl5/vendor_perl/5.16.2/x86_64-linux-thread-multi/auto:
[   65s] mapscript
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib/perl5/vendor_perl/5.16.2/x86_64-linux-thread-multi/auto/mapscript:
[   65s] mapscript.so
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib64:
[   65s] libjavamapscript.so
[   65s] libmapserver.so
[   65s] libmapserver.so.1
[   65s] libmapserver.so.6.4.0
[   65s] php5
[   65s] python2.7
[   65s] ruby
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib64/php5:
[   65s] extensions
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib64/php5/extensions:
[   65s] php_mapscript.so
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib64/python2.7:
[   65s] site-packages
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib64/python2.7/site-packages:
[   65s] _mapscript.so
[   65s] mapscript.py
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib64/ruby:
[   65s] 1.9.1
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib64/ruby/1.9.1:
[   65s] x86_64-linux
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/lib64/ruby/1.9.1/x86_64-linux:
[   65s] mapscript.so
[   65s] 
[   65s] /home/abuild/rpmbuild/BUILDROOT/mapserver-6.4.0-1.x86_64/usr/sbin:
