### PR TITLE
Allows floating point NoData/NULLVALUEs for floating point images.

### DIFF
--- a/maputil.c
+++ b/maputil.c
@@ -1581,7 +1581,7 @@ imageObj *msImageCreate(int width, int height, outputFormatObj *format,
         for( ; i > 0; )
           image->img.raw_16bit[--i] = nv;
       } else if( format->imagemode == MS_IMAGEMODE_FLOAT32 ) {
-        float nv = atoi(nullvalue);
+        float nv = atof(nullvalue);
         for( ; i > 0; )
           image->img.raw_float[--i] = nv;
       } else if( format->imagemode == MS_IMAGEMODE_BYTE ) {


### PR DESCRIPTION
For floating point DEM inputs, I needed specify a floating point NoData value so that it would be included in the output. It was being truncated as an integer, when it should have parsed it as a float.
