### PR TITLE
Update mapfile.c

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -665,9 +665,9 @@ static void writeColor(FILE *stream, int indent, const char *name, colorObj *def
     sprintf(buffer+4, "%02x", color->blue);
     sprintf(buffer+6, "%02x", color->alpha);
     *(buffer+8) = 0;
-    fprintf(stream, "%s \"#%s\"\n", name, buffer);
+    msIO_fprintf(stream, "%s \"#%s\"\n", name, buffer);
   } else {
-    fprintf(stream, "%s %d %d %d\n", name, color->red, color->green, color->blue);
+    msIO_fprintf(stream, "%s %d %d %d\n", name, color->red, color->green, color->blue);
   }
 #endif
 }


### PR DESCRIPTION
There has a bug in line 668 and 670. we should replace fprintf with msIO_fprintf. if not, the result will print to stdout in python mapscript.
