### PR TITLE
Update mapfile.c

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -1275,6 +1275,11 @@ int msProcessProjection(projectionObj *p)
     /*WMS 1.3.0: AUTO2:auto_crs_id,factor,lon0,lat0*/
     return _msProcessAutoProjection(p);
   }
+  
+  if(strlen(p->args[0]) == 0){
+    return -1;  
+  }
+  
   msAcquireLock( TLOCK_PROJ );
 #if PJ_VERSION < 480
   if( !(p->proj = pj_init(p->numargs, p->args)) ) {


### PR DESCRIPTION
for unknown reason, p->args[0] may be empty in function msProcessProjection, when we use proj4 string for projection section in mapfile, which will result in a error in proj4 library: msProcessProjection(): Projection library error. projection not named