### PR TITLE
Mapserver 6.5-dev (or 6.4) getlegendgraphic segfault

### DIFF
--- a/maplegend.c
+++ b/maplegend.c
@@ -201,7 +201,6 @@ int msDrawLegendIcon(mapObj *map, layerObj *lp, classObj *theclass,
         int symbolNum;
         styleObj imgStyle;
         symbolObj *symbol=NULL;
-        for(symbolNum=0; symbolNum<theclass->numstyles; symbolNum++)
         symbolNum = msAddImageSymbol(&(map->symbolset), msBuildPath(szPath, map->mappath, theclass->keyimage));
         if(symbolNum == -1) {
           msSetError(MS_GDERR, "Failed to open legend key image", "msCreateLegendIcon()");


### PR DESCRIPTION
Hi, I'm getting segfault when I'm trying to render getlegendgraphic

GDB output: http://pastebin.com/23Y78FHY

LAYER definition: http://pastebin.com/wj6E2YMq

Legend image: http://gis.lesprojekt.cz/legenda.png

Linux distribution is debian wheezy.
