### PR TITLE
Update cmake modules for Mac

### DIFF
--- a/cmake/FindFreetype.cmake
+++ b/cmake/FindFreetype.cmake
@@ -44,7 +44,7 @@
 FIND_PATH(FREETYPE_INCLUDE_DIR_ft2build ft2build.h 
   HINTS
   $ENV{FREETYPE_DIR}
-  PATH_SUFFIXES include
+  PATH_SUFFIXES include include/freetype2
   PATHS
   /usr/local/X11R6/include
   /usr/local/X11/include
@@ -54,7 +54,7 @@ FIND_PATH(FREETYPE_INCLUDE_DIR_ft2build ft2build.h
   /usr/freeware/include
 )
 
-FIND_PATH(FREETYPE_INCLUDE_DIR_freetype2 freetype/config/ftheader.h 
+FIND_PATH(FREETYPE_INCLUDE_DIR_freetype2 config/ftheader.h
   HINTS
   $ENV{FREETYPE_DIR}/include/freetype2
   PATHS
@@ -64,7 +64,7 @@ FIND_PATH(FREETYPE_INCLUDE_DIR_freetype2 freetype/config/ftheader.h
   /sw/include
   /opt/local/include
   /usr/freeware/include
-  PATH_SUFFIXES freetype2
+  PATH_SUFFIXES freetype freetype2
 )
 
 set(FREETYPE_NAMES ${FREETYPE_NAMES} freetype libfreetype freetype219 freetype239 freetype241MT_D freetype2411)

--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -13,9 +13,10 @@ ENDIF (MYSQL_INCLUDE_DIR)
 FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
   /usr/local/include/mysql
   /usr/include/mysql
+  PATH_SUFFIXES mysql
 )
 
-SET(MYSQL_NAMES mysqlclient mysqlclient_r)
+SET(MYSQL_NAMES mysqlclient mysqlclient_r libmysqlclient)
 FIND_LIBRARY(MYSQL_LIBRARY
   NAMES ${MYSQL_NAMES}
   PATHS /usr/lib /usr/local/lib


### PR DESCRIPTION
- FindFreetype.cmake: update to work with Freetype 2.5.2’s new header file layout
- FindMySQL.cmake: add suffix and name to find components on Mac
