### PR TITLE
added format "image/svg+xml" to msSLDParseExternalGraphic - added thanks to Faunalia and Regione Toscana - SITA

### DIFF
--- a/mapogcsld.c
+++ b/mapogcsld.c
@@ -2094,7 +2094,8 @@ int msSLDParseExternalGraphic(CPLXMLNode *psExternalGraphic,
       (strcasecmp(pszFormat, "GIF") == 0 ||
        strcasecmp(pszFormat, "image/gif") == 0 ||
        strcasecmp(pszFormat, "PNG") == 0 ||
-       strcasecmp(pszFormat, "image/png") == 0)) {
+       strcasecmp(pszFormat, "image/png") == 0 ||
+       strcasecmp(pszFormat, "image/svg+xml") == 0)) {
 
     /* <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.vendor.com/geosym/2267.svg"/> */
     psURL = CPLGetXMLNode(psExternalGraphic, "OnlineResource");

--- a/mapsymbol.c
+++ b/mapsymbol.c
@@ -347,6 +347,7 @@ int msAddImageSymbol(symbolSetObj *symbolset, char *filename)
 {
   char szPath[MS_MAXPATHLEN];
   symbolObj *symbol=NULL;
+  char *extension=NULL;
 
   if(!symbolset) {
     msSetError(MS_SYMERR, "Symbol structure unallocated.", "msAddImageSymbol()");
@@ -398,9 +399,18 @@ int msAddImageSymbol(symbolSetObj *symbolset, char *filename)
       symbol->full_pixmap_path = msStrdup(msBuildPath(szPath, NULL, filename));
     }
     symbol->imagepath = msStrdup(filename);
+    symbol->inmapfile = MS_TRUE;
   }
   symbol->name = msStrdup(filename);
-  symbol->type = MS_SYMBOL_PIXMAP;
+  /* check if svg checking extension otherwise assume it's a pixmap */
+  extension = strrchr(filename, '.');
+  if (extension == NULL)
+	  extension = "";
+  if (strncasecmp(extension, ".svg", 4) == 0) {
+	  symbol->type = MS_SYMBOL_SVG;
+  } else {
+	  symbol->type = MS_SYMBOL_PIXMAP;
+  }
   return(symbolset->numsymbols++);
 }
 


### PR DESCRIPTION
added format "image/svg+xml" to msSLDParseExternalGraphic - added thanks to Faunalia and Regione Toscana - SITA

in this way it's possibile to add external svg URL in a SLD.

patch is useful only if mapserver is compiled with CURL
