### PR TITLE
STYLE with GAP fails to draw on tiny line feature

### DIFF
--- a/maprendering.c
+++ b/maprendering.c
@@ -374,7 +374,7 @@ int msImagePolylineMarkers(imageObj *image, shapeObj *p, symbolObj *symbol,
   double symbol_width,symbol_height;
   glyph_element *glyphc = NULL;
   face_element *face;
-  int ret = MS_FAILURE;
+  int ret = MS_SUCCESS;
   if(symbol->type != MS_SYMBOL_TRUETYPE) {
     symbol_width = MS_MAX(1,symbol->sizex*style->scale);
     symbol_height = MS_MAX(1,symbol->sizey*style->scale);


### PR DESCRIPTION
Using master compiled today (Jan. 9, 2014).

Example mapfile: https://www.dropbox.com/s/lfvqvu40wu17h1z/test.map

The mapfile fails to draw (msDrawMap(): Image handling error. Failed to draw layer named 'line'.) when the extents are such that the feature is very tiny (first set of extents in the mapfile), and the GAP parameter is uncommented.  Commenting out the GAP parameter allows the map to draw.  Zooming in on the feature (second set of extents in the mapfile) also allows the map to draw.

The context for this feature is that it was part of a shapefile containg railroad features.
