### PR TITLE
Failed to build when harfbuzz is not located in default paths

### DIFF
--- a/cmake/FindHarfBuzz.cmake
+++ b/cmake/FindHarfBuzz.cmake
@@ -37,6 +37,7 @@ pkg_check_modules(PC_HARFBUZZ harfbuzz>=0.9.18)
 
 find_path(HARFBUZZ_INCLUDE_DIR NAMES hb.h
     HINTS ${PC_HARFBUZZ_INCLUDE_DIRS} ${PC_HARFBUZZ_INCLUDEDIR}
+    PATH_SUFFIXES harfbuzz
 )
 
 find_library(HARFBUZZ_LIBRARY NAMES harfbuzz

--- a/fontcache.h
+++ b/fontcache.h
@@ -12,7 +12,7 @@
  #else
   #include <fribidi/fribidi.h>
  #endif
- #include <harfbuzz/hb-ft.h>
+ #include <hb-ft.h>
 #endif
 
 


### PR DESCRIPTION
The cmake logic needs tweaking
