### PR TITLE
OGR outputs fail in fastcgi mode when STORAGE is set to stream

### DIFF
--- a/mapio.c
+++ b/mapio.c
@@ -145,6 +145,23 @@ static msIOContextGroup *msIO_GetContextGroup()
   return group;
 }
 
+/* returns MS_TRUE if the msIO standard output hasn't been redirected */
+int msIO_isStdContext() {
+  msIOContextGroup *group = io_context_list;
+  int nThreadId = msGetThreadId();
+  if(!group || group->thread_id != nThreadId) {
+    group = msIO_GetContextGroup();
+    if(!group) {
+      return MS_FALSE; /* probably a bug */
+    }
+  }
+  if(group->stderr_context.cbData == (void*)stderr &&
+      group->stdin_context.cbData == (void*)stdin &&
+      group->stdout_context.cbData == (void*)stdout)
+    return MS_TRUE;
+  return MS_FALSE;
+}
+
 /************************************************************************/
 /*                          msIO_getHandler()                           */
 /************************************************************************/

--- a/mapio.h
+++ b/mapio.h
@@ -108,6 +108,7 @@ extern "C" {
   void MS_DLL_EXPORT msIO_Cleanup(void);
   char MS_DLL_EXPORT *msIO_stripStdoutBufferContentType(void);
   void MS_DLL_EXPORT msIO_stripStdoutBufferContentHeaders(void);
+  int MS_DLL_EXPORT msIO_isStdContext(void);
 
   /* this is just for setting normal stdout's to binary mode on windows */
 

--- a/mapogroutput.c
+++ b/mapogroutput.c
@@ -536,6 +536,12 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
   /*      Determine the output datasource name to use.                    */
   /* ==================================================================== */
   storage = msGetOutputFormatOption( format, "STORAGE", "filesystem" );
+  if( EQUAL(storage,"stream") && !msIO_isStdContext() ) {
+    /* bug #4858, streaming output won't work if standard output has been
+     * redirected, we switch to memory output in this case
+     */
+    storage = "memory";
+  }
 
   /* -------------------------------------------------------------------- */
   /*      Where are we putting stuff?                                     */


### PR DESCRIPTION
When setting FORMATOPTION "STORAGE=stream" in an OGR outputformat, all fastcgi requests for that format will result in a 0 length response. This seems reasonable as the `/vsistdout/` datasource is not connected to the fastcgi msIO.

cc @rouault . is there a workaround to use msIO\* functions in OGR? Would there be any reason to not switch to a memory storage if we can detect we are run in an fcgi container? 
