### PR TITLE
`msLoadMap()` fails to close the mapfile file descriptor after a failed mapfile `INCLUDE`

### DIFF
--- a/maplexer.c
+++ b/maplexer.c
@@ -2159,7 +2159,7 @@ int  msyystring_icase = MS_FALSE;
 int  msyystring_return_state;
 int  msyystring_begin_state;
 int  msyystring_size_tmp;
-FILE *msyyin_tmp;
+
 
 int msyyreturncomments = 0;
 
@@ -4332,11 +4332,11 @@ YY_RULE_SETUP
                                                  include_stack[include_stack_ptr] = YY_CURRENT_BUFFER; /* save state */
                                                  include_lineno[include_stack_ptr] = msyylineno;
                                                  include_stack_ptr++;
-                                                 msyyin_tmp = msyyin;
+
                                                  msyyin = fopen(msBuildPath(path, msyybasepath, msyytext), "r");
                                                  if(!msyyin) {
                                                    msSetError(MS_IOERR, "Error opening included file \"%s\".", "msyylex()", msyytext);
-                                                   msyyin = msyyin_tmp;
+                                                   msyyin = YY_CURRENT_BUFFER->yy_input_file;
                                                    return(-1);
                                                  }
 

--- a/maplexer.l
+++ b/maplexer.l
@@ -50,7 +50,7 @@ int  msyystring_icase = MS_FALSE;
 int  msyystring_return_state;
 int  msyystring_begin_state;
 int  msyystring_size_tmp;
-FILE *msyyin_tmp;
+
 
 int msyyreturncomments = 0;
 
@@ -673,11 +673,11 @@ char path[MS_MAXPATHLEN];
                                                  include_stack[include_stack_ptr] = YY_CURRENT_BUFFER; /* save state */
                                                  include_lineno[include_stack_ptr] = msyylineno;
                                                  include_stack_ptr++;
-                                                 msyyin_tmp = msyyin;
+
                                                  msyyin = fopen(msBuildPath(path, msyybasepath, msyytext), "r");
                                                  if(!msyyin) {
                                                    msSetError(MS_IOERR, "Error opening included file \"%s\".", "msyylex()", msyytext);
-                                                   msyyin = msyyin_tmp;
+                                                   msyyin = YY_CURRENT_BUFFER->yy_input_file;
                                                    return(-1);
                                                  }
 


### PR DESCRIPTION
The following program illustrates the problem. The expectation would be that the mapfile file descriptor is closed when there is an error involving a failed `INCLUDE` statement.  Testing using the mapserver master branch, this is not currently the case.

``` c
/**
 * File `test.c`
 *
 * A test program showing that the file descriptor to a mapfile with a non
 * existent INCLUDE value is not closed after `msLoadMap()` returns with an
 * error.  See inline comments for details.
 *
 * Compile along the following lines:
 *
 *    gcc -Wall -I./ -I./build/ -I/usr/include/gdal/ -I/usr/include/libxml2/ ./test.c -o ./test -L/usr/local/lib -lmapserver
 *
 * and run as `./test`.
 */

#include "mapserver.h"

int main(int argc, char *argv[]) {
  /* Open the test mapfile. The following mapfile is a minimal example
   * replicating the test case:

MAP
 NAME "include-mapfile"
 EXTENT 0 0 500 500
 SIZE 250 250

 INCLUDE "non-existent-file.map"
END

  */
  mapObj *map = msLoadMap("./test.map", NULL);

  /* open and close the test mapfile */
  if (!map) {
    msWriteError(stderr);
    msCleanup(0);
  } else {
    msFreeMap(map);             /* shouldn't get here */
    exit(0);
  }

  /* don't exit: we need to be able to look at open file
   * descriptors. e.g. something along the lines of

ls -l /proc/{PID}/fd

   * will show that the mapfile `./test.map` is still open. */
  while (1) {
    sleep(100);
  }

  exit(1); /* shouldn't get here: CTRL-c to exit after looking for the open file. */
}
```

Fixing this enables geo-data/node-mapserv#13 to be closed.
