### PR TITLE
Require Validation of SLD ExternalGraphic OnlineResource

### DIFF
--- a/mapogcsld.c
+++ b/mapogcsld.c
@@ -2073,9 +2073,6 @@ int msSLDParsePointSymbolizer(CPLXMLNode *psRoot, layerObj *psLayer,
 int msSLDParseExternalGraphic(CPLXMLNode *psExternalGraphic,
                               styleObj *psStyle,  mapObj *map)
 {
-  /* needed for libcurl function msHTTPGetFile in maphttp.c */
-#if defined(USE_CURL)
-
   char *pszFormat = NULL;
   CPLXMLNode *psURL=NULL, *psFormat=NULL, *psTmp=NULL;
   char *pszURL=NULL;
@@ -2087,12 +2084,13 @@ int msSLDParseExternalGraphic(CPLXMLNode *psExternalGraphic,
   if (psFormat && psFormat->psChild && psFormat->psChild->pszValue)
     pszFormat = psFormat->psChild->pszValue;
 
-  /* supports GIF and PNG */
+  /* supports GIF and PNG and SVG */
   if (pszFormat &&
       (strcasecmp(pszFormat, "GIF") == 0 ||
        strcasecmp(pszFormat, "image/gif") == 0 ||
        strcasecmp(pszFormat, "PNG") == 0 ||
-       strcasecmp(pszFormat, "image/png") == 0)) {
+       strcasecmp(pszFormat, "image/png") == 0 ||
+       strcasecmp(pszFormat, "image/svg+xml") == 0)) {
 
     /* <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://www.vendor.com/geosym/2267.svg"/> */
     psURL = CPLGetXMLNode(psExternalGraphic, "OnlineResource");
@@ -2105,6 +2103,15 @@ int msSLDParseExternalGraphic(CPLXMLNode *psExternalGraphic,
       }
       if (psTmp && psTmp->psChild) {
         pszURL = (char*)psTmp->psChild->pszValue;
+
+        /* manage ALLOW_REMOTE_ASSETS option to allow loading remote symbols */
+        if ( !msTestConfigOption( map, "ALLOW_REMOTE_ASSETS", MS_FALSE ) )
+        {
+          /* avoid using remote symbol */
+          if (strncasecmp(pszURL, "http", 4) == 0) {
+            return MS_SUCCESS;
+          }
+        }
 
         /*external symbols using http will be automaticallly downloaded. The file should be
           saved in a temporary directory (msAddImageSymbol) #2305*/
@@ -2127,9 +2134,6 @@ int msSLDParseExternalGraphic(CPLXMLNode *psExternalGraphic,
   }
 
   return MS_SUCCESS;
-#else
-  return MS_FAILURE;
-#endif
 }
 
 

--- a/mapsymbol.c
+++ b/mapsymbol.c
@@ -344,6 +344,7 @@ int msAddImageSymbol(symbolSetObj *symbolset, char *filename)
 {
   char szPath[MS_MAXPATHLEN];
   symbolObj *symbol=NULL;
+  char *extension=NULL;
 
   if(!symbolset) {
     msSetError(MS_SYMERR, "Symbol structure unallocated.", "msAddImageSymbol()");
@@ -356,6 +357,16 @@ int msAddImageSymbol(symbolSetObj *symbolset, char *filename)
   if (msGrowSymbolSet(symbolset) == NULL)
     return -1;
   symbol = symbolset->symbol[symbolset->numsymbols];
+
+  /* check if svg checking extension otherwise assume it's a pixmap */
+  extension = strrchr(filename, '.');
+  if (extension == NULL)
+      extension = "";
+  if (strncasecmp(extension, ".svg", 4) == 0) {
+      symbol->type = MS_SYMBOL_SVG;
+  } else {
+      symbol->type = MS_SYMBOL_PIXMAP;
+  }
 
 #ifdef USE_CURL
   if (strncasecmp(filename, "http", 4) == 0) {


### PR DESCRIPTION
Onlineresource must validate against "sld_external_graphic" entry of
map->web->validation in order to be taken into account.

added thanks to Regione Toscana - SITA
