### PR TITLE
Wrong resolution factor during LegendIcon creation with KEYIMAGE

### DIFF
--- a/maplegend.c
+++ b/maplegend.c
@@ -220,7 +220,7 @@ int msDrawLegendIcon(mapObj *map, layerObj *lp, classObj *theclass,
           imgStyle.maxsize = imgStyle.size;
 
         imgStyle.symbol = symbolNum;
-        msDrawMarkerSymbol(&map->symbolset,image_draw,&marker,&imgStyle,lp->scalefactor * image_draw->resolutionfactor);
+        msDrawMarkerSymbol(&map->symbolset,image_draw,&marker,&imgStyle,1.0);
         /* TO DO: we may want to handle this differently depending on the relative size of the keyimage */
       } else {
         for(i=0; i<theclass->numstyles; i++) {


### PR DESCRIPTION
MapServer 6.4.1.
I'm using the createLegendIcon class method with PHP Mapscript to generate a high resolution legend.
The RESOLUTION value in the mapfile is modified with php the script to obtain a 300 DPI legend icon.
Problem is, if the class has a KEYIMAGE defined, the symbol is scaled wrongly and zoomed way too much.
My solution is to modify maplegend.c at line 223, in function msDrawLegendIcon, and remove image_draw->resolutionfactor when theclass->keyimage != NULL:
msDrawMarkerSymbol(&map->symbolset,image_draw,&marker,&imgStyle,lp->scalefactor);
