### PR TITLE
Fix a segfault when setting a "utfitem" in a layer

### DIFF
--- a/maplayer.c
+++ b/maplayer.c
@@ -740,6 +740,10 @@ int msLayerWhichItems(layerObj *layer, int get_all, const char *metadata)
   }
 
   /* utfgrid count */
+ 	
+  if(layer->utfitem)
+    nt ++;
+
   if(layer->utfdata.type == MS_EXPRESSION || (layer->utfdata.string && strchr(layer->utfdata.string,'[') != NULL && strchr(layer->utfdata.string,']') != NULL))
     nt += msCountChars(layer->utfdata.string, '[');
 


### PR DESCRIPTION
-  Modified the function "msTokenizeExpression" of "maplayer.c" to increase the nt variable, that is used to set the size of the item array, when encountering a "utfitem" in a layer definition.
