### PR TITLE
Few labels placed with ANGLE FOLLOW, and REPEATDISTANCE set

### DIFF
--- a/mapprimitive.c
+++ b/mapprimitive.c
@@ -2045,7 +2045,6 @@ int msLineLabelPath(mapObj *map, imageObj *img, lineObj *p, textSymbolObj *ts, s
             anglediff = fabs(theta - tp->glyphs[k-2].rot);
             anglediff = MS_MIN(anglediff, MS_2PI - anglediff);
             if(anglediff > maxoverlapangle ) {
-              printf("failed between %c and %c: angle: %f\n",ts->annotext[k-2],ts->annotext[k-1],anglediff);
               goto LABEL_FAILURE;
             }
           }


### PR DESCRIPTION
I'm using MapServer build from Master that was build today.

I want to have repeating labels placed around a linear feature.  For some reason, I need to have a very high MAXOVERLAPANGLE to get something close to what I'm expecting:  See here: https://dl.dropboxusercontent.com/u/3219487/label_test.png

The green feature on the left is using the default MAXOVERLAPANGLE value (i.e. it is not set in the label block).  For some reason only two labels get placed.

The red feature on the right has MAXOVERLAPANGLE 90, and other than the cramped up labels in the corners, this is more like what I expected for the green feature. 

My mapfile for mapserver-6.5 is here: https://dl.dropboxusercontent.com/u/3219487/label_issues.map

With MapServer 6.4 (after adding a fontset and font to the label blocks), I got a better result for the green feature: https://dl.dropboxusercontent.com/u/3219487/test64.png
