### PR TITLE
Add <ogc:PropertyName></ogc:PropertyName> tags in <label></label>

### DIFF
--- a/mapogcsld.c
+++ b/mapogcsld.c
@@ -3839,7 +3839,7 @@ char *msSLDGenerateTextSLD(classObj *psClass, layerObj *psLayer, int nVersion)
     snprintf(szTmp, sizeof(szTmp), "<%sTextSymbolizer>\n",  sNameSpace);
     pszSLD = msStringConcatenate(pszSLD, szTmp);
 
-    snprintf(szTmp, sizeof(szTmp), "<%sLabel>%s</%sLabel>\n",  sNameSpace,
+    snprintf(szTmp, sizeof(szTmp), "<%sLabel><ogc:PropertyName>%s</ogc:PropertyName></%sLabel>\n",  sNameSpace,
              psLayer->labelitem, sNameSpace);
     pszSLD = msStringConcatenate(pszSLD, szTmp);
 


### PR DESCRIPTION
Add ogc:PropertyName/ogc:PropertyName tags in <label></label> when we are using values from column (ie property in OGC terms). In MapServer this is the only way to get value for label via labelitem parameter.
