### PR TITLE
Support xs:int for WFS feature properties.

### DIFF
--- a/mapwfs.c
+++ b/mapwfs.c
@@ -990,7 +990,7 @@ static const char* msWFSMapServTypeToXMLType(const char* type)
     if( strcasecmp(type,"Integer") == 0 )
       element_type = "integer";
     /* Note : xs:int and xs:integer differ */
-    else if ( EQUAL(item->type,"int") )
+    else if ( EQUAL(type,"int") )
       element_type = "int";
     else if( EQUAL(type,"Real") ||
              EQUAL(type,"double") /* just in case someone provided the xsd type directly */ )


### PR DESCRIPTION
xs:integer is an unbounded integer whereas xs:int is a signed 32 bits integer.
see : http://stackoverflow.com/questions/15336872/xsd-what-is-the-difference-between-xsinteger-and-xsint
The interpretation of what an xs:integer is can vary depending on the implementation. For example
Microsoft's System.Xml.Schema.XmlSchemaDataType.ValueType maps xs:integer to System.decimal
and xs:int to System.Int32
see : http://bytes.com/topic/net/answers/172493-xmlschemadatatype-xs-integer-system-decimal

This code change will remove any ambiguity when the property is known to be an int32.
