### PR TITLE
Fix undeclared symbols in maputil.c

### DIFF
--- a/maputil.c
+++ b/maputil.c
@@ -682,12 +682,12 @@ char *msEvalTextExpressionInternal(expressionObj *expr, shapeObj *shape, int bJS
 
 char *msEvalTextExpressionJSonEscape(expressionObj *expr, shapeObj *shape)
 {
-    return msEvalTextExpressionInternal(expr, shape, TRUE);
+    return msEvalTextExpressionInternal(expr, shape, MS_TRUE);
 }
 
 char *msEvalTextExpression(expressionObj *expr, shapeObj *shape)
 {
-    return msEvalTextExpressionInternal(expr, shape, FALSE);
+    return msEvalTextExpressionInternal(expr, shape, MS_FALSE);
 }
 
 char* msShapeGetLabelAnnotation(layerObj *layer, shapeObj *shape, labelObj *lbl) {


### PR DESCRIPTION
Getting the following build error, I think the fix is to use MS_TRUE and MS_FALSE.

```
/tmp/mapserver/maputil.c: In function ‘msEvalTextExpressionJSonEscape’:
/tmp/mapserver/maputil.c:685:54: error: ‘TRUE’ undeclared (first use in this function)
...
/tmp/mapserver/maputil.c: In function ‘msEvalTextExpression’:
/tmp/mapserver/maputil.c:690:54: error: ‘FALSE’ undeclared (first use in this function)
...
```
