### PR TITLE
Fix illegal use of stack-allocated objects in maprendering

### DIFF
--- a/maprendering.c
+++ b/maprendering.c
@@ -975,6 +975,7 @@ int msDrawLabelBounds(mapObj *map, imageObj *image, label_bounds *bnds, styleObj
   shape.numlines = 1;
   if(bnds->poly) {
     shape.line = bnds->poly;
+    return msDrawShadeSymbol(map,image,&shape,style,scalefactor);
   } else {
     pointObj pnts1[5];
     lineObj l;
@@ -984,9 +985,9 @@ int msDrawLabelBounds(mapObj *map, imageObj *image, label_bounds *bnds, styleObj
     pnts1[2].x = pnts1[3].x = bnds->bbox.maxx;
     pnts1[0].y = pnts1[3].y = pnts1[4].y = bnds->bbox.miny;
     pnts1[1].y = pnts1[2].y = bnds->bbox.maxy;
-    shape.line = &l;
+    shape.line = &l; // must return from this block
+    return msDrawShadeSymbol(map,image,&shape,style,scalefactor);
   }
-  return msDrawShadeSymbol(map,image,&shape,style,scalefactor);
 }
 
 int msDrawTextSymbol(mapObj *map, imageObj *image, pointObj labelPnt, textSymbolObj *ts)


### PR DESCRIPTION
pointObj and lineObj defined in the else block in msDrawLabelBounds()
are valid only in the "else" block context. Once outside (e.g. in the
"return msDrawShadeSymbol()"), the variables should not be considered
valid anymore ; it led in some cases in underlying calls to
msSmallAlloc() with a negative integer, resulting in a "unable to
allocate memory" error.

First version of this patch extracted the pointObj / lineObj variables
just before the "if" call, the current one was proposed by @gberaudo.
