### PR TITLE
Fix an issue with the complex polygon in oracle

### DIFF
--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -1625,8 +1625,11 @@ static int osGetOrdinates(msOracleSpatialDataHandler *dthand, msOracleSpatialHan
     } /* end of gtype big-if */
   } /* end of not-null-object if */
 
-  if (compound_type)
+  if (compound_type){
+    if(gtype == 2003)
+      shape->type = MS_SHAPE_POLYGON;
     msFreeShape(&newshape);
+  }
 
   return MS_SUCCESS;
 }


### PR DESCRIPTION
The problem was when a polygon is composed from multiple line string and/or an arc polygon, the type of the shape is change for MS_SHAPE_LINE instead to keep the MS_SHAPE_POLYGON flag. So to solve it I validate the type provide by oracle and if it's a complex polygon I force to set the shape type to MS_SHAPE_POLYGON and the shape are now process as a polygon instead of a line string.
