### PR TITLE
Mapserver crash when the text label from styleitem has some bracket in it

### DIFF
--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -2737,6 +2737,7 @@ static int msOGRUpdateStyle(OGRStyleMgrH hStyleMgr, mapObj *map, layerObj *layer
         c->numlabels++;
         initLabel(c->labels[0]);
       }
+      freeExpression(&c->labels[0]->text);
       c->labels[0]->text.type = MS_STRING;
       c->labels[0]->text.string = msStrdup(labelTextString);
 


### PR DESCRIPTION
Hi,

using the STYLEITEM to have label and in the field there is this value:

LABEL(f:"Arial",t:"(N.3)",a:0,s:9g,c:#FF00FF)
I do some test and see that the point "." is not a problem .
Instead the problem seem to be the brackets.

I try to escape them using this sintax

<pre>
LABEL(f:"Arial",t:"\(N.3\)",a:0,s:9g,c:#FF00FF)
</pre>


but , if it has succes to avoi the crash of mapserver , unfortunatley in the text rendered
appear the "\" char.
:(

So I guess this is an issue.
