### PR TITLE
WMS clients with EXTENT cut BBOX

### DIFF
--- a/mapwmslayer.c
+++ b/mapwmslayer.c
@@ -703,6 +703,11 @@ msBuildWMSLayerURL(mapObj *map, layerObj *lp, int nRequestType,
 
         bbox_width = ceil((bbox.maxx - bbox.minx) / cellsize);
         bbox_height = ceil((bbox.maxy - bbox.miny) / cellsize);
+
+        /* Force going through the resampler if we're going to receive a clipped BBOX (#4931) */
+        if(msLayerGetProcessingKey(lp, "RESAMPLE") == NULL) {
+          msLayerSetProcessingKey(lp, "RESAMPLE", "nearest");
+        }
       }
     }
   }


### PR DESCRIPTION
The following mapfile with data shows an issue when using a LAYER with CONNECTIONTYPE WMS and EXTENT or METADATA "ows_extent" parameters.

This wms layer call another layer inside the same mapfile (but this could be in another webservice). An EXTENT parameter is set up with the correct extent of the data (ogrinfo -so has been used for this).

The Extent parameter seems force MapServer to cut the bbox asked by the initial resquest:

I asked for 
- LAYERS=test
- BBOX=591029.94832393,7034780.744266,601196.09341815,7044946.8893603
- WIDTH=532&HEIGHT=532

full parameter for testing:

```
LAYERS=test&TRANSPARENT=true&VERSION=1.3&FORMAT=image%2Fpng&SERVICE=WMS&REQUEST=GetMap&STYLES=&CRS=EPSG%3A2154&BBOX=591029.94832393,7034780.744266,601196.09341815,7044946.8893603&WIDTH=532&HEIGHT=532&LAYERS=SXT_PHOTOANCIENNE_PICARDIE_BAIE_AUTHIE&TRANSPARENT=true&VERSION=1.3&FORMAT=image%2Fpng&SERVICE=WMS&REQUEST=GetMap&STYLES=&CRS=EPSG%3A2154&BBOX=591029.94832393,7034780.744266,601196.09341815,7044946.8893603&WIDTH=532&HEIGHT=532
```

MapServer WMS Client layer request:
- LAYERS=emprise
- BBOX=595000,7034780.744266,601196.09341819,7043000
- HEIGHT=431&WIDTH=325

full parameter for testing:

```
LAYERS=emprise&REQUEST=GetMap&SERVICE=WMS&FORMAT=image/png&STYLES=&HEIGHT=431&VERSION=1.1.1&SRS=EPSG:2154&WIDTH=325&BBOX=595000,7034780.744266,601196.09341819,7043000&TRANSPARENT=TRUE&EXCEPTIONS=application/vnd.ogc.se_inimage
```

As you can see the size of the picture has been changed to HEIGHT=431&WIDTH=325

This change imply a shift in the final image sent to the final WMS client (see mapserv_notcorrect).
- picture correct : 
  ![mapserv_correct](https://cloud.githubusercontent.com/assets/660191/3068517/5fbb9638-e28f-11e3-824f-8e1c4fc34a09.png)
- picture not correct : 
  ![mapserv_notcorrect](https://cloud.githubusercontent.com/assets/660191/3068518/5fe8ad6c-e28f-11e3-9874-096c7de97815.png)

Shapefile + picture + mapfile = http://dl.free.fr/fANDyiIPP
