### PR TITLE
Fix postgis installation on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,10 @@ compiler:
 before_install:
   - git submodule update --init --recursive
   - sudo mv /etc/apt/sources.list.d/pgdg-source.list* /tmp
-  - sudo apt-get -qq remove postgis
+  - sudo apt-get  remove postgis libpq5 libpq-dev postgresql-9.1-postgis postgresql-9.2-postgis postgresql-9.3-postgis postgresql-9.1 postgresql-9.2 postgresql-9.3 libgdal1
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq bison flex swig cmake librsvg2-dev colordiff postgis postgresql-9.1-postgis-2.0-scripts libpq-dev libpng12-dev libjpeg-dev libgif-dev libgeos-dev libgd2-xpm-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal1-dev libproj-dev libxml2-dev python-dev php5-dev libexempi-dev lcov lftp
+  - sudo apt-get update 
+  - sudo apt-get install  bison flex swig cmake librsvg2-dev colordiff postgis postgresql-9.1 postgresql-9.1-postgis-2.1 postgresql-9.1-postgis-2.1-scripts libpq-dev libpng12-dev libjpeg-dev libgif-dev libgeos-dev libgd2-xpm-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal1-dev libproj-dev libxml2-dev python-dev php5-dev libexempi-dev lcov lftp
   - sudo pip install git+git://github.com/tbonfort/cpp-coveralls.git@extensions
   - cd msautotest
   - ./create_postgis_test_data.sh


### PR DESCRIPTION
There where some incompatibilities between the gdal/postgis versions installed by default on the travisCI VMs and the ones provided by the ubuntugis ppa. This pull-request uninstalls all prior postgres/postgis instances and starts fresh with ubuntugis packages.
