### PR TITLE
LINE layer does not draw or gives small malloc error

### DIFF
--- a/mapprimitive.c
+++ b/mapprimitive.c
@@ -1547,7 +1547,11 @@ void msPolylineComputeLineSegments(shapeObj *shape, struct polyline_lengths *pll
     struct line_lengths *ll = &pll->ll[i];
     double max_subline_segment_length = 0;
     
-    ll->segment_lengths = (double*) msSmallMalloc(sizeof(double) * (shape->line[i].numpoints - 1));
+    if(shape->line[i].numpoints > 1) {
+      ll->segment_lengths = (double*) msSmallMalloc(sizeof(double) * (shape->line[i].numpoints - 1));
+    } else {
+      ll->segment_lengths = NULL;
+    }
     ll->total_length = 0;
     
     for(j=1; j<shape->line[i].numpoints; j++) {


### PR DESCRIPTION
Map file below with good and bad line feature, in this case the line does not get drawn. 

Using OGR connection to sqlite db gives error msSmallMalloc(): Out of memory allocating -8 bytes.

```
MAP
  CONFIG "PROJ_LIB" "/tmp/navhome/lib/share/proj"
  CONFIG "PROJ_DEBUG" "OFF"
  CONFIG "CPL_DEBUG" "ON"
  #CONFIG "MS_ERRORFILE" "mapserver.log"
  CONFIG "ON_MISSING_DATA" "LOG"
  DEBUG 5

  EXTENT -110.5 38.5 -110 39.5 # fails

  FONTSET "fontset.txt"
  IMAGECOLOR 0 0 0
  IMAGETYPE "png"
  NAME "global_map"
  SIZE 1280 768
  STATUS ON
  UNITS DD

  OUTPUTFORMAT
    NAME "AGG_PNG"
    MIMETYPE "image/png"
    DRIVER "AGG/PNG"
    EXTENSION "png"
    IMAGEMODE RGBA
    TRANSPARENT TRUE
    FORMATOPTION "COMPRESSION=0"
  END # OUTPUTFORMAT

  PROJECTION
    "proj=latlong"
    "ellps=WGS84"
  END # PROJECTION

  SYMBOL
    NAME 'City'
    TYPE ELLIPSE
    POINTS 1 1 END
    FILLED FALSE
  END

LAYER
  NAME 'badwkt'
  TYPE LINE
  STATUS DEFAULT
  FEATURE
    POINTS
#      -110.220982 38.982832  #works
       -110.220980 38.982832  #fails
      -110.220887 38.982863
      -110.221614 38.982708
      -110.220980 38.982832
    END
    TEXT "Testing"
  END

  CLASS

    LABEL
      FONT "Uni"
        SIZE 10
        COLOR 255 255 255
        ENCODING "UTF-8"
        PARTIALS FALSE
        POSITION LC
      END # LABEL

    STYLE
      COLOR 255 255 255
      WIDTH 4
    END
  END
END
END # MAP
```
