### PR TITLE
RFC91: fix expressions/filters set from SLD (#4974)

### DIFF
--- a/mapogcfiltercommon.c
+++ b/mapogcfiltercommon.c
@@ -439,6 +439,7 @@ char *FLTGetSpatialComparisonCommonExpression(FilterEncodingNode *psNode, layerO
 
   if (psNode->eType != FILTER_NODE_TYPE_SPATIAL)
     return NULL;
+    
 
   /* get the shape */
   /* BBOX case: replace it with NOT DISJOINT. */
@@ -485,6 +486,7 @@ char *FLTGetSpatialComparisonCommonExpression(FilterEncodingNode *psNode, layerO
 
   if (psTmpShape) {
 
+    pszExpression = msStringConcatenate(pszExpression, "(");
     /*
     ** target is layer projection
     */
@@ -543,7 +545,7 @@ char *FLTGetSpatialComparisonCommonExpression(FilterEncodingNode *psNode, layerO
     }
 
     /* terminate the function */
-    pszExpression = msStringConcatenate(pszExpression, ") = TRUE");
+    pszExpression = msStringConcatenate(pszExpression, ") = TRUE )");
   }
 
   /*

--- a/mapogcsld.c
+++ b/mapogcsld.c
@@ -415,28 +415,14 @@ int msSLDApplySLD(mapObj *map, char *psSLDXML, int iLayer, char *pszStyleLayerNa
                       else
                         snprintf(szTmp, sizeof(szTmp), "%s", " OR ");
 
-                      pszBuffer =msStringConcatenate(pszBuffer, szTmp);
-                      psExpressionNode = BuildExpressionTree(lp->class[k]->expression.string,NULL);
-                      if (psExpressionNode) {
-                        pszSqlExpression = FLTGetSQLExpression(psExpressionNode,lp);
-                        if (pszSqlExpression) {
-                          pszBuffer = msStringConcatenate(pszBuffer, pszSqlExpression);
-                          msFree(pszSqlExpression);
-                        } else {
-                          bFailedExpression =1;
-                          break;
-                        }
-                        FLTFreeFilterEncodingNode(psExpressionNode);
-                      } else {
-                        bFailedExpression =1;
-                        break;
-                      }
+                      pszBuffer = msStringConcatenate(pszBuffer, szTmp);
+                      pszBuffer = msStringConcatenate(pszBuffer, lp->class[k]->expression.string);
                     }
                     if (!bFailedExpression) {
                       snprintf(szTmp, sizeof(szTmp), "%s", "))");
                       pszBuffer =msStringConcatenate(pszBuffer, szTmp);
                       msLoadExpressionString(&lp->filter, pszBuffer);
-                      lp->filter.type = MS_STRING;
+                      lp->filter.type = MS_EXPRESSION;
                     }
                     msFree(pszBuffer);
                     pszBuffer = NULL;

--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -1769,29 +1769,24 @@ msOGRFileNextShape(layerObj *layer, shapeObj *shape,
       }
     }
 
-    // Check the expression unless it is a WHERE clause already
-    // handled by OGR.
-    if( (layer->filter.string && EQUALN(layer->filter.string,"WHERE ",6))
-        || msEvalExpression(layer, shape, &(layer->filter), layer->filteritemindex) == MS_TRUE ) {
-      // Feature matched filter expression... process geometry
-      // shape->type will be set if geom is compatible with layer type
-      if (ogrConvertGeometry(OGR_F_GetGeometryRef( hFeature ), shape,
-                             layer->type) == MS_SUCCESS) {
-        if (shape->type != MS_SHAPE_NULL)
-          break; // Shape is ready to be returned!
+    // Feature matched filter expression... process geometry
+    // shape->type will be set if geom is compatible with layer type
+    if (ogrConvertGeometry(OGR_F_GetGeometryRef( hFeature ), shape,
+                           layer->type) == MS_SUCCESS) {
+      if (shape->type != MS_SHAPE_NULL)
+        break; // Shape is ready to be returned!
 
-        if (layer->debug >= MS_DEBUGLEVEL_VVV)
-          msDebug("msOGRFileNextShape: Rejecting feature (shapeid = %ld, tileid=%d) of incompatible type for this layer (feature wkbType %d, layer type %d)\n",
-                  OGR_F_GetFID( hFeature ), psInfo->nTileId,
-                  OGR_F_GetGeometryRef( hFeature )==NULL ? wkbFlatten(wkbUnknown):wkbFlatten( OGR_G_GetGeometryType( OGR_F_GetGeometryRef( hFeature ) ) ),
-                  layer->type);
+      if (layer->debug >= MS_DEBUGLEVEL_VVV)
+        msDebug("msOGRFileNextShape: Rejecting feature (shapeid = %ld, tileid=%d) of incompatible type for this layer (feature wkbType %d, layer type %d)\n",
+                OGR_F_GetFID( hFeature ), psInfo->nTileId,
+                OGR_F_GetGeometryRef( hFeature )==NULL ? wkbFlatten(wkbUnknown):wkbFlatten( OGR_G_GetGeometryType( OGR_F_GetGeometryRef( hFeature ) ) ),
+                layer->type);
 
-      } else {
-        msFreeShape(shape);
-        OGR_F_Destroy( hFeature );
-        RELEASE_OGR_LOCK;
-        return MS_FAILURE; // Error message already produced.
-      }
+    } else {
+      msFreeShape(shape);
+      OGR_F_Destroy( hFeature );
+      RELEASE_OGR_LOCK;
+      return MS_FAILURE; // Error message already produced.
     }
 
     // Feature rejected... free shape to clear attributes values.


### PR DESCRIPTION
- surround spatial expressions with () so they are treated as expressions
- no need to translate expressions for DB backends, RFC91 takes care of that for us