### PR TITLE
writeMap(): Adding ANGLE to saved directives

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -6002,6 +6002,7 @@ static void writeMap(FILE *stream, int indent, mapObj *map)
   colorObj c;
 
   writeBlockBegin(stream, indent, "MAP");
+  writeNumber(stream, indent, "ANGLE", 0, map->gt.rotation_angle);
   writeHashTableInline(stream, indent, "CONFIG", &(map->configoptions));
   writeString(stream, indent, "DATAPATTERN", NULL, map->datapattern); /* depricated */
   writeNumber(stream, indent, "DEBUG", 0, map->debug);


### PR DESCRIPTION
ANGLE is missing in the directives for the generated mapfile when calling mapfile.c:writeMap() ; this commit aims to force saving the custom angle.

Note: I could not manage to test it at runtime (compilation succeeded though), but due to the triviality of the PR, I thought it was ok to propose it in the current state. I checked that the map->gt object was created even with a blank mapfile.
