### PR TITLE
Fix crash when copying a map with label leaders

### DIFF
--- a/mapcopy.c
+++ b/mapcopy.c
@@ -396,6 +396,7 @@ int msCopyLabel(labelObj *dst, labelObj *src)
 
   if(src->leader) {
     dst->leader = msSmallMalloc(sizeof(labelLeaderObj));
+    initLeader(dst->leader);
     msCopyLabelLeader(dst->leader,src->leader);
   } else {
     if(dst->leader) {
@@ -573,6 +574,7 @@ int msCopyClass(classObj *dst, classObj *src, layerObj *layer)
     }
     if(!dst->leader) {
       dst->leader = msSmallMalloc(sizeof(labelLeaderObj));
+      initLeader(dst->leader);
     }
     msCopyLabelLeader(dst->leader,src->leader);
   }


### PR DESCRIPTION
When copying a map (using `msCopyMap`) that contains leaders, new leaders are initialized using `msSmallAlloc` but the memory is left uninitialized.  This results in `numstyles` not being set to 0, and `msCopyLabelLeader` uses `numstyles` to free existing styles before copying styles from `src` to `dst`.  This causes a segfault.
