### PR TITLE
Remove atexit() call on Win32 code path that cause crashes on mapserv

### DIFF
--- a/mapserv.c
+++ b/mapserv.c
@@ -234,10 +234,6 @@ int main(int argc, char *argv[])
 #ifdef USE_FASTCGI
   msIO_installFastCGIRedirect();
 
-#ifdef WIN32
-  atexit( msCleanupOnExit );
-#endif
-
   /* In FastCGI case we loop accepting multiple requests.  In normal CGI */
   /* use we only accept and process one request.  */
   while( FCGI_Accept() >= 0 ) {


### PR DESCRIPTION
Reported on http://lists.osgeo.org/pipermail/mapserver-dev/2014-October/014269.html
The cleanup done by the atexit() callback is redundant with the one done
by msCleanup(0) at the end of the main().
