### PR TITLE
Handle PROJ_LIB environment variable.

### DIFF
--- a/mapproject.c
+++ b/mapproject.c
@@ -1246,6 +1246,18 @@ static const char *msProjFinder( const char *filename)
 #endif /* def USE_PROJ */
 
 /************************************************************************/
+/*                       msProjLibInitFromEnv()                         */
+/************************************************************************/
+void msProjLibInitFromEnv()
+{
+  const char *val;
+
+  if( (val=getenv( "PROJ_LIB" )) != NULL ) {
+    msSetPROJ_LIB(val, NULL);
+  }
+}
+
+/************************************************************************/
 /*                           msSetPROJ_LIB()                            */
 /************************************************************************/
 void msSetPROJ_LIB( const char *proj_lib, const char *pszRelToPath )

--- a/mapproject.h
+++ b/mapproject.h
@@ -99,6 +99,7 @@ extern "C" {
       double *x, double *y );
 
   MS_DLL_EXPORT void msSetPROJ_LIB( const char *, const char * );
+  MS_DLL_EXPORT void msProjLibInitFromEnv();
 
   /* Provides compatiblity with PROJ.4 4.4.2 */
 #ifndef PJ_VERSION

--- a/mapservutil.c
+++ b/mapservutil.c
@@ -1817,6 +1817,10 @@ int msCGIHandler(const char *query_string, void **out_buffer, size_t *buffer_len
   msIOBuffer  *buf;
 
   msIO_installStdoutToBuffer();
+
+  /* Use PROJ_LIB env vars if set */
+  msProjLibInitFromEnv();
+
   /* Use MS_ERRORFILE and MS_DEBUGLEVEL env vars if set */
   if( msDebugInitFromEnv() != MS_SUCCESS ) {
     msCGIWriteError(mapserv);

--- a/maputil.c
+++ b/maputil.c
@@ -1893,6 +1893,9 @@ int msSetup()
   msThreadInit();
 #endif
 
+  /* Use PROJ_LIB env vars if set */
+  msProjLibInitFromEnv();
+
   /* Use MS_ERRORFILE and MS_DEBUGLEVEL env vars if set */
   if (msDebugInitFromEnv() != MS_SUCCESS)
     return MS_FAILURE;

--- a/shp2img.c
+++ b/shp2img.c
@@ -113,6 +113,9 @@ int main(int argc, char *argv[])
       exit(1);
     }
 
+    /* Use PROJ_LIB env vars if set */
+    msProjLibInitFromEnv();
+
     /* Use MS_ERRORFILE and MS_DEBUGLEVEL env vars if set */
     if ( msDebugInitFromEnv() != MS_SUCCESS ) {
       msWriteError(stderr);


### PR DESCRIPTION
According to the docs (http://mapserver.org/errors.html), PROJ_LIB may be set as environment variable, too. This pull request makes it working and fixes #4930.