### PR TITLE
add JSONP support

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -6856,6 +6856,7 @@ void msApplyDefaultSubstitutions(mapObj *map)
   /* output formats (#3751) */
   for(i=0; i<map->numoutputformats; i++) {
     applyOutputFormatDefaultSubstitutions(map->outputformatlist[i], "filename", &(map->web.validation));
+    applyOutputFormatDefaultSubstitutions(map->outputformatlist[i], "JSONP", &(map->web.validation));
   }
 
   for(i=0; i<map->numlayers; i++) {

--- a/mapogroutput.c
+++ b/mapogroutput.c
@@ -1153,8 +1153,11 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
     char buffer[1024];
     int  bytes_read;
     FILE *fp;
+    const char *jsonp;
 
+    jsonp = msGetOutputFormatOption( format, "JSONP", NULL );
     if( sendheaders ) {
+      if( !jsonp )
       msIO_setHeader("Content-Disposition","attachment; filename=%s",
                      CPLGetFilename( file_list[0] ) );
       if( format->mimetype )
@@ -1173,9 +1176,13 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
       return MS_FAILURE;
     }
 
+    if( jsonp != NULL ) msIO_fprintf( stdout, "%s(", jsonp );
+
     while( (bytes_read = VSIFReadL( buffer, 1, sizeof(buffer), fp )) > 0 )
       msIO_fwrite( buffer, 1, bytes_read, stdout );
     VSIFCloseL( fp );
+
+    if (jsonp != NULL) msIO_fprintf( stdout, ");\n" );
   }
 
   /* -------------------------------------------------------------------- */

--- a/mapogroutput.c
+++ b/mapogroutput.c
@@ -676,6 +676,7 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
   char **layer_options = NULL;
   char **file_list = NULL;
   int iLayer, i;
+  const char *jsonp;
 
   /* -------------------------------------------------------------------- */
   /*      Fetch the output format driver.                                 */
@@ -828,6 +829,8 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
   msFree( request_dir );
   request_dir = NULL;
 
+  jsonp = msGetOutputFormatOption( format, "JSONP", NULL );
+
   /* -------------------------------------------------------------------- */
   /*      Emit content type headers for stream output now.                */
   /* -------------------------------------------------------------------- */
@@ -837,6 +840,7 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
       msIO_sendHeaders();
     } else
       msIO_fprintf( stdout, "%c", 10 );
+    if( jsonp != NULL ) msIO_fprintf( stdout, "%s(", jsonp );
   }
 
   /* ==================================================================== */
@@ -1144,6 +1148,7 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
   /* -------------------------------------------------------------------- */
   if( EQUAL(storage,"stream") ) {
     /* already done */
+    if( jsonp != NULL ) msIO_fprintf( stdout, ");\n" );
   }
 
   /* -------------------------------------------------------------------- */
@@ -1153,9 +1158,7 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
     char buffer[1024];
     int  bytes_read;
     FILE *fp;
-    const char *jsonp;
 
-    jsonp = msGetOutputFormatOption( format, "JSONP", NULL );
     if( sendheaders ) {
       if( !jsonp )
       msIO_setHeader("Content-Disposition","attachment; filename=%s",


### PR DESCRIPTION
This is a small change that creates a JSONP wrapper around OGR output. Uses a format option "JSONP"  that works when "simple" output format is used. Should be considered a workaround until OGR has it's own datasource creation option.