### PR TITLE
Support GDAL 2.0 64bit integer fields

### DIFF
--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -1809,6 +1809,14 @@ msOGRPassThroughFieldDefinitions( layerObj *layer, msOGRFileInfo *psInfo )
           sprintf( gml_width, "%d", OGR_Fld_GetWidth( hField) );
         break;
 
+#if GDAL_VERSION_MAJOR >= 2
+      case OFTInteger64:
+        gml_type = "Long";
+        if( OGR_Fld_GetWidth( hField) > 0 )
+          sprintf( gml_width, "%d", OGR_Fld_GetWidth( hField) );
+        break;
+#endif
+
       case OFTReal:
         gml_type = "Real";
         if( OGR_Fld_GetWidth( hField) > 0 )
@@ -1992,8 +2000,8 @@ msOGRFileNextShape(layerObj *layer, shapeObj *shape,
         break; // Shape is ready to be returned!
 
       if (layer->debug >= MS_DEBUGLEVEL_VVV)
-        msDebug("msOGRFileNextShape: Rejecting feature (shapeid = %ld, tileid=%d) of incompatible type for this layer (feature wkbType %d, layer type %d)\n",
-                OGR_F_GetFID( hFeature ), psInfo->nTileId,
+        msDebug("msOGRFileNextShape: Rejecting feature (shapeid = " CPL_FRMT_GIB ", tileid=%d) of incompatible type for this layer (feature wkbType %d, layer type %d)\n",
+                (GIntBig)OGR_F_GetFID( hFeature ), psInfo->nTileId,
                 OGR_F_GetGeometryRef( hFeature )==NULL ? wkbFlatten(wkbUnknown):wkbFlatten( OGR_G_GetGeometryType( OGR_F_GetGeometryRef( hFeature ) ) ),
                 layer->type);
 
@@ -2009,7 +2017,7 @@ msOGRFileNextShape(layerObj *layer, shapeObj *shape,
     shape->type = MS_SHAPE_NULL;
   }
 
-  shape->index =  OGR_F_GetFID( hFeature );;
+  shape->index =  (int)OGR_F_GetFID( hFeature ); // FIXME? GetFID() is a 64bit integer in GDAL 2.0
   shape->resultindex = psInfo->last_record_index_read;
   shape->tileindex = psInfo->nTileId;
 
@@ -2124,7 +2132,7 @@ msOGRFileGetShape(layerObj *layer, shapeObj *shape, long record,
     shape->index = record;
     shape->resultindex = -1;
   } else {
-    shape->index = OGR_F_GetFID( hFeature );
+    shape->index = (int)OGR_F_GetFID( hFeature ); // FIXME? GetFID() is a 64bit integer in GDAL 2.0
     shape->resultindex = record;
   }
 
@@ -2206,7 +2214,7 @@ NextFile:
   connection = msStrdup( OGR_F_GetFieldAsString( hFeature,
                          layer->tileitemindex ));
 
-  nFeatureId = OGR_F_GetFID( hFeature );
+  nFeatureId = (int)OGR_F_GetFID( hFeature ); // FIXME? GetFID() is a 64bit integer in GDAL 2.0
 
   OGR_F_Destroy( hFeature );
 

--- a/mapogroutput.c
+++ b/mapogroutput.c
@@ -493,7 +493,11 @@ static int msOGRWriteShape( layerObj *map_layer, OGRLayerH hOGRLayer,
     if( shape->values[i][0] == '\0' ) {
       OGRFieldDefnH hFieldDefn = OGR_FD_GetFieldDefn(hLayerDefn, out_field);
       OGRFieldType eFieldType = OGR_Fld_GetType(hFieldDefn);
-      if( eFieldType == OFTInteger || eFieldType == OFTReal )
+      if( eFieldType == OFTInteger || eFieldType == OFTReal
+#if GDAL_VERSION_MAJOR >= 2
+          || eFieldType == OFTInteger64
+#endif
+          )
       {
         out_field++;
         continue;
@@ -989,6 +993,12 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
         eType = OFTString;
       else if( EQUAL(item->type,"Integer") )
         eType = OFTInteger;
+      else if( EQUAL(item->type,"Long") )
+#if GDAL_VERSION_MAJOR >= 2
+        eType = OFTInteger64;
+#else
+        eType = OFTReal;
+#endif
       else if( EQUAL(item->type,"Real") )
         eType = OFTReal;
       else if( EQUAL(item->type,"Character") )

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -3003,8 +3003,11 @@ msPostGISPassThroughFieldDefinitions( layerObj *layer,
       gml_type = "Integer";
       sprintf( gml_width, "%d", 5 );
 
-    } else if( oid == INT4OID || oid == INT8OID ) {
+    } else if( oid == INT4OID ) {
       gml_type = "Integer";
+
+    } else if( oid == INT8OID ) {
+      gml_type = "Long";
 
     } else if( oid == FLOAT4OID || oid == FLOAT8OID ) {
       gml_type = "Real";

--- a/mapwfs.c
+++ b/mapwfs.c
@@ -992,6 +992,8 @@ static const char* msWFSMapServTypeToXMLType(const char* type)
     /* Note : xs:int and xs:integer differ */
     else if ( EQUAL(type,"int") )
       element_type = "int";
+    if( strcasecmp(type,"Long") == 0 ) /* 64bit integer */
+      element_type = "long";
     else if( EQUAL(type,"Real") ||
              EQUAL(type,"double") /* just in case someone provided the xsd type directly */ )
       element_type = "double";


### PR DESCRIPTION
Now that http://trac.osgeo.org/gdal/wiki/rfc31_ogr_64 has been
committed in GDAL trunk 2.0dev, OFTInteger64 can be return as a
field type.
So :
- when reading OGR layer, support mapping OFTInteger64 to a new "Long" datatype
- when reading PostGIS layer, map INT8 columns to "Long" datatype
- in mapwfs, map "Long" to xs:long
- in OGR output code, map "Long" to OFTInteger64, if GDAL 2.0, or
  OFTReal otherwise

OGR_F_GetFID() in GDAL 2.0 returns a 64 bit integer. We just fix
warnings by casting to int, but if a 64bit FID was really returned,
we might have issues.