### PR TITLE
WFS needs to project Map Extent when setting the WFS/OWS SRS

### DIFF
--- a/mapwfs.c
+++ b/mapwfs.c
@@ -362,15 +362,23 @@ static int msWFSGetFeatureApplySRS(mapObj *map, const char *srs, int nWFSVersion
   char *pszOutputSRS=NULL;
   layerObj *lp;
   int i;
+  projectionObj proj;
 
   /*validation of SRS
     - wfs 1.0 does not have an srsname parameter so all queried layers should be advertized using the
       same srs. For wfs 1.1.0 an srsName can be passed, we should validate that It is valid for all
       queries layers
   */
+
   pszMapSRS = msOWSGetEPSGProj(&(map->projection), &(map->web.metadata), "FO", MS_TRUE);
-  if(pszMapSRS && nWFSVersion >  OWS_1_0_0)
+  if(pszMapSRS && nWFSVersion >  OWS_1_0_0){
+    msInitProjection(&proj);
+    if (msLoadProjectionStringEPSG(&proj, pszMapSRS) == 0) {
+      msProjectRect(&(map->projection), &proj, &map->extent);
+    }
     msLoadProjectionStringEPSG(&(map->projection), pszMapSRS);
+    msFreeProjection(&proj);
+  }
 
   if (srs == NULL || nWFSVersion == OWS_1_0_0) {
     for (i=0; i<map->numlayers; i++) {


### PR DESCRIPTION
WFS Sets the default SRS to the first OWS SRS, however, it doesn't project the default MapExt when it does so.