### PR TITLE
WMS exception may expose PostGIS connection details for users

### DIFF
--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -665,14 +665,13 @@ static msOracleSpatialHandler *msOCISetHandlers( char *username, char *password,
                     OCILogon( hand->envhp, hand->errhp, &hand->svchp, (text *)username, strlen(username), (text *)password, strlen(password), (text *)dblink, strlen(dblink) ) );
 
   if ( !success ) {
-    msDebug( MS_ORACLESPATIALERR,
-                "Cannot create OCI Handlers. "
+    msDebug(   "Cannot create OCI Handlers. "
                 "Connection failure."
                 "Error: %s."
                 "msOracleSpatialLayerOpen()", hand->last_oci_error);
     msSetError( MS_ORACLESPATIALERR,
                 "Cannot create OCI Handlers. "
-                "Connection failure. Check your logs and the connection string. "
+                "Connection failure. Check your logs and the connection string. ",
                 "msOracleSpatialLayerOpen()");
 
     msOCICloseHandlers(hand);
@@ -1721,7 +1720,7 @@ int msOracleSpatialLayerOpen( layerObj *layer )
                 "'geometry_column FROM (SELECT stmt) [USING UNIQUE <column> SRID srid# FUNCTION]'."
                 "If want to set the FUNCTION statement you can use: FILTER, RELATE, GEOMRELATE or NONE.");
     msSetError( MS_ORACLESPATIALERR,
-                "Error parsing OracleSpatial DATA variable. More info in server logs");
+                "Error parsing OracleSpatial DATA variable. More info in server logs", "msOracleSpatialLayerOpen()");
 
     return MS_FAILURE;
   }
@@ -1919,7 +1918,7 @@ int msOracleSpatialLayerWhichShapes( layerObj *layer, rectObj rect, int isQuery)
                 "Your data statement: (%s)"
                 "in msOracleSpatialLayerWhichShapes()", layer->data );
     msSetError( MS_ORACLESPATIALERR,
-                "Error parsing OracleSpatial DATA variable. More info in server logs"
+                "Error parsing OracleSpatial DATA variable. More info in server logs",
                 "msOracleSpatialLayerWhichShapes()" );
 
     if (geom_column_name) free(geom_column_name);
@@ -2563,7 +2562,7 @@ int msOracleSpatialLayerGetShape( layerObj *layer, shapeObj *shape, resultObj *r
                   "Check your data statement."
                   "in msOracleSpatialLayerGetShape()", hand->last_oci_error, query_str );
       msSetError( MS_ORACLESPATIALERR,
-                  "Error in Query statement in msOracleSpatialLayerGetShape(). Check your server logs");
+                  "Error in Query statement. Check your server logs","msOracleSpatialLayerGetShape()");
 
       /* clean nullind  */
       free(nullind);
@@ -2764,7 +2763,7 @@ int msOracleSpatialLayerGetAutoProjection( layerObj *layer, projectionObj *proje
                 "'geometry_column FROM table_name [USING UNIQUE <column> SRID srid# FUNCTION]' or "
                 "'geometry_column FROM (SELECT stmt) [USING UNIQUE <column> SRID srid# FUNCTION]'. "
                 "If want to set the FUNCTION statement you can use: FILTER, RELATE, GEOMRELATE or NONE. "
-                "Your data statement: (%s)",
+                "Your data statement: (%s) "
                 "in msOracleSpatialLayerGetAutoProjection()", layer->data );
 
     msSetError( MS_ORACLESPATIALERR,
@@ -3485,7 +3484,7 @@ int msOracleSpatialLayerTranslateFilter(layerObj *layer, expressionObj *filter, 
                 "in msOracleSpatialLayerGetExtent()", layer->data );
     msSetError( MS_ORACLESPATIALERR,
                 "Error parsing OracleSpatial DATA variable. Check server logs. ",
-                "msOracleSpatialLayerGetExtent()", layer->data );
+                "msOracleSpatialLayerGetExtent()");
     /* clean items */
     
     if (geom_column_name) free(geom_column_name);

--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -288,7 +288,8 @@ static int ERROR( char *routine, msOracleSpatialHandler *hand, msOracleSpatialDa
 {
   if (hand->last_oci_status == MS_FAILURE) {
     /* there was an error */
-    msSetError( MS_ORACLESPATIALERR, (char *)hand->last_oci_error, routine );
+    msSetError( MS_ORACLESPATIALERR, "OracleSpatial server returned an error, check logs for more details", routine );
+    msDebug("OracleSpatial server returned an error in funtion (%s): %s.\n", routine, (char*)hand->last_oci_error );
 
     /* reset error flag */
     hand->last_oci_status = MS_SUCCESS;
@@ -664,11 +665,15 @@ static msOracleSpatialHandler *msOCISetHandlers( char *username, char *password,
                     OCILogon( hand->envhp, hand->errhp, &hand->svchp, (text *)username, strlen(username), (text *)password, strlen(password), (text *)dblink, strlen(dblink) ) );
 
   if ( !success ) {
+    msDebug( MS_ORACLESPATIALERR,
+                "Cannot create OCI Handlers. "
+                "Connection failure."
+                "Error: %s."
+                "msOracleSpatialLayerOpen()", hand->last_oci_error);
     msSetError( MS_ORACLESPATIALERR,
                 "Cannot create OCI Handlers. "
-                "Connection failure. Check the connection string. "
-                "Error: %s.",
-                "msOracleSpatialLayerOpen()", hand->last_oci_error);
+                "Connection failure. Check your logs and the connection string. "
+                "msOracleSpatialLayerOpen()");
 
     msOCICloseHandlers(hand);
     return NULL;
@@ -1711,12 +1716,12 @@ int msOracleSpatialLayerOpen( layerObj *layer )
     return MS_SUCCESS;
 
   if (layer->data == NULL) {
-    msSetError( MS_ORACLESPATIALERR,
-                "Error parsing OracleSpatial DATA variable. Must be:"
+    msDebug(    "Error parsing OracleSpatial DATA variable. Must be:"
                 "'geometry_column FROM table_name [USING UNIQUE <column> SRID srid# FUNCTION]' or "
                 "'geometry_column FROM (SELECT stmt) [USING UNIQUE <column> SRID srid# FUNCTION]'."
-                "If want to set the FUNCTION statement you can use: FILTER, RELATE, GEOMRELATE or NONE.",
-                "msOracleSpatialLayerOpen()");
+                "If want to set the FUNCTION statement you can use: FILTER, RELATE, GEOMRELATE or NONE.");
+    msSetError( MS_ORACLESPATIALERR,
+                "Error parsing OracleSpatial DATA variable. More info in server logs");
 
     return MS_FAILURE;
   }
@@ -1907,13 +1912,15 @@ int msOracleSpatialLayerWhichShapes( layerObj *layer, rectObj rect, int isQuery)
   table_name = (char *) malloc(sizeof(char) * TABLE_NAME_SIZE);
   /* parse geom_column_name and table_name */
   if (!msSplitData( layer->data, &geom_column_name, &table_name, &unique, &srid, &indexfield, &function, &version)) {
-    msSetError( MS_ORACLESPATIALERR,
-                "Error parsing OracleSpatial DATA variable. Must be:"
+    msDebug( "Error parsing OracleSpatial DATA variable. Must be:"
                 "'geometry_column FROM table_name [USING UNIQUE <column> SRID srid# FUNCTION]' or "
                 "'geometry_column FROM (SELECT stmt) [USING UNIQUE <column> SRID srid# FUNCTION]'."
                 "If want to set the FUNCTION statement you can use: FILTER, RELATE, GEOMRELATE or NONE."
-                "Your data statement: %s",
-                "msOracleSpatialLayerWhichShapes()", layer->data );
+                "Your data statement: (%s)"
+                "in msOracleSpatialLayerWhichShapes()", layer->data );
+    msSetError( MS_ORACLESPATIALERR,
+                "Error parsing OracleSpatial DATA variable. More info in server logs"
+                "msOracleSpatialLayerWhichShapes()" );
 
     if (geom_column_name) free(geom_column_name);
     if (srid) free(srid);
@@ -2158,11 +2165,13 @@ int msOracleSpatialLayerWhichShapes( layerObj *layer, rectObj rect, int isQuery)
   }
 
   if (!success) {
-    msSetError( MS_ORACLESPATIALERR,
-                "Error: %s . "
+    msDebug( "Error: %s . "
                 "Query statement: %s . "
-                "Check your data statement.",
+                "Check your data statement."
                 "msOracleSpatialLayerWhichShapes()", hand->last_oci_error, query_str );
+    msSetError( MS_ORACLESPATIALERR,
+                "Check your data statement and server logs",
+                "msOracleSpatialLayerWhichShapes()");
 
     /* clean items */
     free(items);
@@ -2448,13 +2457,14 @@ int msOracleSpatialLayerGetShape( layerObj *layer, shapeObj *shape, resultObj *r
 
     table_name = (char *) malloc(sizeof(char) * TABLE_NAME_SIZE);
     if (!msSplitData( layer->data, &geom_column_name, &table_name, &unique, &srid, &indexfield, &function, &version )) {
-      msSetError( MS_ORACLESPATIALERR,
-                  "Error parsing OracleSpatial DATA variable. Must be: "
+      msDebug( "Error parsing OracleSpatial DATA variable. Must be: "
                   "'geometry_column FROM table_name [USING UNIQUE <column> SRID srid# FUNCTION]' or "
                   "'geometry_column FROM (SELECT stmt) [USING UNIQUE <column> SRID srid# FUNCTION]'. "
                   "If want to set the FUNCTION statement you can use: FILTER, RELATE, GEOMRELATE or NONE. "
-                  "Your data statement: %s",
-                  "msOracleSpatialLayerGetShape()", layer->data );
+                  "Your data statement: (%s) msOracleSpatialLayerGetShape()", layer->data );
+      msSetError( MS_ORACLESPATIALERR,
+                  "Error parsing OracleSpatial DATA variable. Check server logs. ",
+                  "msOracleSpatialLayerGetShape()");
 
       /* clean nullind  */
       free(nullind);
@@ -2548,11 +2558,12 @@ int msOracleSpatialLayerGetShape( layerObj *layer, shapeObj *shape, resultObj *r
     }
 
     if(!success) {
-      msSetError( MS_ORACLESPATIALERR,
-                  "Error: %s . "
+      msDebug( "Error: %s . "
                   "Query statement: %s ."
-                  "Check your data statement.",
-                  "msOracleSpatialLayerGetShape()", hand->last_oci_error, query_str );
+                  "Check your data statement."
+                  "in msOracleSpatialLayerGetShape()", hand->last_oci_error, query_str );
+      msSetError( MS_ORACLESPATIALERR,
+                  "Error in Query statement in msOracleSpatialLayerGetShape(). Check your server logs");
 
       /* clean nullind  */
       free(nullind);
@@ -2749,13 +2760,16 @@ int msOracleSpatialLayerGetAutoProjection( layerObj *layer, projectionObj *proje
 
   table_name = (char *) malloc(sizeof(char) * TABLE_NAME_SIZE);
   if (!msSplitData( layer->data, &geom_column_name, &table_name, &unique, &srid, &indexfield, &function, &version )) {
-    msSetError( MS_ORACLESPATIALERR,
-                "Error parsing OracleSpatial DATA variable. Must be: "
+    msDebug(  "Error parsing OracleSpatial DATA variable. Must be: "
                 "'geometry_column FROM table_name [USING UNIQUE <column> SRID srid# FUNCTION]' or "
                 "'geometry_column FROM (SELECT stmt) [USING UNIQUE <column> SRID srid# FUNCTION]'. "
                 "If want to set the FUNCTION statement you can use: FILTER, RELATE, GEOMRELATE or NONE. "
-                "Your data statement: %s",
-                "msOracleSpatialLayerGetAutoProjection()", layer->data );
+                "Your data statement: (%s)",
+                "in msOracleSpatialLayerGetAutoProjection()", layer->data );
+
+    msSetError( MS_ORACLESPATIALERR,
+                "Error parsing OracleSpatial DATA variable",
+                "msOracleSpatialLayerGetAutoProjection()");
 
     if (geom_column_name) free(geom_column_name);
     if (srid) free(srid);
@@ -2781,11 +2795,14 @@ int msOracleSpatialLayerGetAutoProjection( layerObj *layer, projectionObj *proje
             && TRY( hand, OCIAttrGet( (dvoid *)sthand->stmthp, (ub4)OCI_HTYPE_STMT, (dvoid *)&sthand->rows_fetched, (ub4 *)0, (ub4)OCI_ATTR_ROWS_FETCHED, hand->errhp ) );
 
   if(!success) {
-    msSetError( MS_ORACLESPATIALERR,
-                "Error: %s . "
+    msDebug( "Error: %s . "
                 "Query statement: %s . "
-                "Check your data statement.",
-                "msOracleSpatialLayerGetAutoProjection()", hand->last_oci_error, query_str );
+                "Check your data statement."
+                "in msOracleSpatialLayerGetAutoProjection()", hand->last_oci_error, query_str );
+    msSetError( MS_ORACLESPATIALERR,
+                "Error "
+                "Check your data statement and server logs",
+                "msOracleSpatialLayerGetAutoProjection()" );
 
     if (geom_column_name) free(geom_column_name);
     if (srid) free(srid);
@@ -2963,13 +2980,15 @@ int msOracleSpatialLayerGetItems( layerObj *layer )
 
   table_name = (char *) malloc(sizeof(char) * TABLE_NAME_SIZE);
   if (!msSplitData(layer->data, &geom_column_name, &table_name, &unique, &srid, &indexfield, &function, &version)) {
-    msSetError( MS_ORACLESPATIALERR,
-                "Error parsing OracleSpatial DATA variable. Must be: "
+    msDebug(   "Error parsing OracleSpatial DATA variable. Must be: "
                 "'geometry_column FROM table_name [USING UNIQUE <column> SRID srid# FUNCTION]' or "
                 "'geometry_column FROM (SELECT stmt) [USING UNIQUE <column> SRID srid# FUNCTION]'. "
                 "If want to set the FUNCTION statement you can use: FILTER, RELATE, GEOMRELATE or NONE. "
-                "Your data statement: %s",
-                "msOracleSpatialLayerGetItems()", layer->data );
+                "Your data statement: (%s)"
+                "in msOracleSpatialLayerGetItems()", layer->data );
+    msSetError( MS_ORACLESPATIALERR,
+                "Error parsing OracleSpatial DATA variable. Check server logs. ",
+                "msOracleSpatialLayerGetItems()");
 
     if (geom_column_name) free(geom_column_name);
     if (srid) free(srid);
@@ -3153,13 +3172,15 @@ int msOracleSpatialLayerGetExtent(layerObj *layer, rectObj *extent)
 
   table_name = (char *) malloc(sizeof(char) * TABLE_NAME_SIZE);
   if (!msSplitData( layer->data, &geom_column_name, &table_name, &unique, &srid, &indexfield, &function, &version )) {
-    msSetError( MS_ORACLESPATIALERR,
-                "Error parsing OracleSpatial DATA variable. Must be: "
+    msDebug(   "Error parsing OracleSpatial DATA variable. Must be: "
                 "'geometry_column FROM table_name [USING UNIQUE <column> SRID srid# FUNCTION]' or "
                 "'geometry_column FROM (SELECT stmt) [USING UNIQUE <column> SRID srid# FUNCTION]'. "
                 "If want to set the FUNCTION statement you can use: FILTER, RELATE, GEOMRELATE or NONE. "
-                "Your data statement: %s",
-                "msOracleSpatialLayerGetExtent()", layer->data );
+                "Your data statement: (%s) "
+                "in msOracleSpatialLayerGetExtent()", layer->data );
+    msSetError( MS_ORACLESPATIALERR,
+                "Error parsing OracleSpatial DATA variable. Check server logs. ",
+                "msOracleSpatialLayerGetExtent()");
     /* clean items */
     free(items);
 
@@ -3196,11 +3217,14 @@ int msOracleSpatialLayerGetExtent(layerObj *layer, rectObj *extent)
   }
 
   if(!success) {
-    msSetError( MS_ORACLESPATIALERR,
-                "Error: %s . "
+    msDebug(   "Error: %s . "
                 "Query statement: %s . "
-                "Check your data statement.",
-                "msOracleSpatialLayerGetExtent()", hand->last_oci_error, query_str );
+                "Check your data statement."
+                "in msOracleSpatialLayerGetExtent()", hand->last_oci_error, query_str );
+
+    msSetError( MS_ORACLESPATIALERR,
+                "Check your data statement and server logs",
+                "msOracleSpatialLayerGetExtent()" );
 
     /* clean items */
     free(items);
@@ -3223,11 +3247,13 @@ int msOracleSpatialLayerGetExtent(layerObj *layer, rectObj *extent)
   }
 
   if(!success) {
-    msSetError( MS_ORACLESPATIALERR,
-                "Error: %s . "
+    msDebug(    "Error: %s . "
                 "Query statement: %s ."
-                "Check your data statement.",
-                "msOracleSpatialLayerGetExtent()", hand->last_oci_error, query_str );
+                "Check your data statement."
+                "in msOracleSpatialLayerGetExtent()", hand->last_oci_error, query_str );
+    msSetError( MS_ORACLESPATIALERR,
+                "Check your data statement and server logs",
+                "msOracleSpatialLayerGetExtent()" );
 
     /* clean items */
     free(items);
@@ -3451,12 +3477,14 @@ int msOracleSpatialLayerTranslateFilter(layerObj *layer, expressionObj *filter, 
 
   table_name = (char *) malloc(sizeof(char) * TABLE_NAME_SIZE);
   if (!msSplitData( layer->data, &geom_column_name, &table_name, &unique, &srid, &indexfield, &function, &version )) {
-    msSetError( MS_ORACLESPATIALERR,
-                "Error parsing OracleSpatial DATA variable. Must be: "
+    msDebug(   "Error parsing OracleSpatial DATA variable. Must be: "
                 "'geometry_column FROM table_name [USING UNIQUE <column> SRID srid# FUNCTION]' or "
                 "'geometry_column FROM (SELECT stmt) [USING UNIQUE <column> SRID srid# FUNCTION]'. "
                 "If want to set the FUNCTION statement you can use: FILTER, RELATE, GEOMRELATE or NONE. "
-                "Your data statement: %s",
+                "Your data statement: (%s)"
+                "in msOracleSpatialLayerGetExtent()", layer->data );
+    msSetError( MS_ORACLESPATIALERR,
+                "Error parsing OracleSpatial DATA variable. Check server logs. ",
                 "msOracleSpatialLayerGetExtent()", layer->data );
     /* clean items */
     

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1129,7 +1129,8 @@ msPostGISRetrieveVersion(PGconn *pgconn)
   pgresult = PQexecParams(pgconn, sql,0, NULL, NULL, NULL, NULL, 0);
 
   if ( !pgresult || PQresultStatus(pgresult) != PGRES_TUPLES_OK) {
-    msSetError(MS_QUERYERR, "Error executing SQL: %s", "msPostGISRetrieveVersion()", sql);
+    msDebug("Error executing SQL: (%s) in msPostGISRetrieveVersion()", sql);
+    msSetError(MS_QUERYERR, "Error executing SQL. check server logs.", "msPostGISRetrieveVersion()");
     return MS_FAILURE;
   }
 
@@ -2439,7 +2440,8 @@ int msPostGISLayerOpen(layerObj *layer)
         }
       }
 
-      msSetError(MS_QUERYERR, "Database connection failed (%s) with connect string '%s'\nIs the database running? Is it allowing connections? Does the specified user exist? Is the password valid? Is the database on the standard port?", "msPostGISLayerOpen()", PQerrorMessage(layerinfo->pgconn), maskeddata);
+      msDebug( "Database connection failed (%s) with connect string '%s'\nIs the database running? Is it allowing connections? Does the specified user exist? Is the password valid? Is the database on the standard port? in msPostGISLayerOpen()", PQerrorMessage(layerinfo->pgconn), maskeddata);
+      msSetError(MS_QUERYERR, "Database connection failed. Check server logs for more details.Is the database running? Is it allowing connections? Does the specified user exist? Is the password valid? Is the database on the standard port?", "msPostGISLayerOpen()");
 
       if(layerinfo->pgconn) PQfinish(layerinfo->pgconn);
       free(maskeddata);
@@ -2459,7 +2461,8 @@ int msPostGISLayerOpen(layerObj *layer)
       PQreset(layerinfo->pgconn);
       if( PQstatus(layerinfo->pgconn) != CONNECTION_OK ) {
         /* Nope, time to bail out. */
-        msSetError(MS_QUERYERR, "PostgreSQL database connection gone bad (%s)", "msPostGISLayerOpen()", PQerrorMessage(layerinfo->pgconn));
+        msSetError(MS_QUERYERR, "PostgreSQL database connection. Check server logs for more details", "msPostGISLayerOpen()");
+        msDebug( "PostgreSQL database connection gone bad (%s) in msPostGISLayerOpen()", PQerrorMessage(layerinfo->pgconn));
         free(layerinfo);
         /* FIXME: we should also release the connection from the pool in this case, but it is stale...
          * for the time being we do not release it so it can never be used again. If this happens multiple
@@ -2695,10 +2698,8 @@ int msPostGISLayerWhichShapes(layerObj *layer, rectObj rect, int isQuery)
 
   /* Something went wrong. */
   if (!pgresult || PQresultStatus(pgresult) != PGRES_TUPLES_OK) {
-    if ( layer->debug ) {
-      msDebug("msPostGISLayerWhichShapes(): Error (%s) executing query: %s\n", PQerrorMessage(layerinfo->pgconn), strSQL);
-    }
-    msSetError(MS_QUERYERR, "Error executing query: %s ", "msPostGISLayerWhichShapes()", PQerrorMessage(layerinfo->pgconn));
+    msDebug("msPostGISLayerWhichShapes(): Error (%s) executing query: %s\n", PQerrorMessage(layerinfo->pgconn), strSQL);
+    msSetError(MS_QUERYERR, "Error executing query. Check server logs","msPostGISLayerWhichShapes()");
     free(strSQL);
     if (pgresult) {
       PQclear(pgresult);
@@ -2876,10 +2877,8 @@ int msPostGISLayerGetShape(layerObj *layer, shapeObj *shape, resultObj *record)
 
     /* Something went wrong. */
     if ( (!pgresult) || (PQresultStatus(pgresult) != PGRES_TUPLES_OK) ) {
-      if ( layer->debug ) {
-        msDebug("msPostGISLayerGetShape(): Error (%s) executing SQL: %s\n", PQerrorMessage(layerinfo->pgconn), strSQL );
-      }
-      msSetError(MS_QUERYERR, "Error executing SQL: %s", "msPostGISLayerGetShape()", PQerrorMessage(layerinfo->pgconn));
+      msDebug("msPostGISLayerGetShape(): Error (%s) executing SQL: %s\n", PQerrorMessage(layerinfo->pgconn), strSQL );
+      msSetError(MS_QUERYERR, "Error executing SQL. Check server logs.","msPostGISLayerGetShape()");
 
       if (pgresult) {
         PQclear(pgresult);
@@ -3102,10 +3101,8 @@ int msPostGISLayerGetItems(layerObj *layer)
   pgresult = PQexecParams(layerinfo->pgconn, sql,0, NULL, NULL, NULL, NULL, 0);
 
   if ( (!pgresult) || (PQresultStatus(pgresult) != PGRES_TUPLES_OK) ) {
-    if ( layer->debug ) {
-      msDebug("msPostGISLayerGetItems(): Error (%s) executing SQL: %s\n", PQerrorMessage(layerinfo->pgconn), sql);
-    }
-    msSetError(MS_QUERYERR, "Error executing SQL: %s", "msPostGISLayerGetItems()", PQerrorMessage(layerinfo->pgconn));
+    msDebug("msPostGISLayerGetItems(): Error (%s) executing SQL: %s\n", PQerrorMessage(layerinfo->pgconn), sql);
+    msSetError(MS_QUERYERR, "Error executing SQL. Check server logs","msPostGISLayerGetItems()");
     if (pgresult) {
       PQclear(pgresult);
     }
@@ -3212,7 +3209,8 @@ int msPostGISLayerGetExtent(layerObj *layer, rectObj *extent)
   msFree(strSQL);
 
   if ( (!pgresult) || (PQresultStatus(pgresult) != PGRES_TUPLES_OK) ) {
-    msSetError(MS_MISCERR, "Error executing SQL: %s", "msPostGISLayerGetExtent()", PQerrorMessage(layerinfo->pgconn));
+    msDebug("Error executing SQL: (%s) in msPostGISLayerGetExtent()", PQerrorMessage(layerinfo->pgconn));
+    msSetError(MS_MISCERR, "Error executing SQL. Check server logs.","msPostGISLayerGetExtent()");
     if (pgresult)
       PQclear(pgresult);
 


### PR DESCRIPTION
As an example an exception that I could read with my WMS client from demo.mapserver.org when PostgreSQL server was down:

<?xml version='1.0' encoding="ISO-8859-1" standalone="no" ?> <!DOCTYPE ServiceExceptionReport SYSTEM "http://schemas.opengis.net/wms/1.1.1/exception_1_1_1.dtd">
<ServiceExceptionReport version="1.1.1"> <ServiceException>
msDrawMap(): Image handling error. Failed to draw layer named &#39;landuse_layer4&#39;.
msPostGISLayerOpen(): Query error. Database connection failed (FATAL:  database &quot;osm&quot; does not exist
) with connect string &#39;host=localhost dbname=osm user=www-data password=*******\* port=5432&#39; Is the database running? Is it allowing connections? Does the specified user exist? Is the password valid? Is the database on the standard port?
</ServiceException>
</ServiceExceptionReport>

Everything else than password gets exposed to all WMS users. For me connection details belong only to MS_ERRORFILE.
