### PR TITLE
Fix NULL pointer dereference

### DIFF
--- a/mapdraw.c
+++ b/mapdraw.c
@@ -103,12 +103,13 @@ imageObj *msPrepareImage(mapObj *map, int allow_nonsquare)
   } else {
     image = NULL;
   }
-  image->map = map;
-
+  
   if(!image) {
     msSetError(MS_IMGERR, "Unable to initialize image.", "msPrepareImage()");
     return(NULL);
   }
+  
+  image->map = map;
 
   /*
    * If we want to support nonsquare pixels, note that now, otherwise


### PR DESCRIPTION
Fix NULL pointer dereference in mapdraw.c:msPrepareImage() in case an image could not be initialized.