### PR TITLE
Segfault when using ttf symbols with symbolscalednom and minsize=0

### DIFF
--- a/maprendering.c
+++ b/maprendering.c
@@ -247,8 +247,8 @@ imageObj *getTile(imageObj *img, symbolObj *symbol,  symbolStyleObj *s, int widt
           if(UNLIKELY(!face)) { status = MS_FAILURE; break; }
           msUTF8ToUniChar(symbol->character, &unicode);
           unicode = msGetGlyphIndex(face,unicode);
-          glyphc = msGetGlyphByIndex(face, s->scale, unicode);
-          if(UNLIKELY(!face)) { status = MS_FAILURE; break; }
+          glyphc = msGetGlyphByIndex(face, MS_MAX(MS_NINT(s->scale),1), unicode);
+          if(UNLIKELY(!glyphc)) { status = MS_FAILURE; break; }
           status = drawGlyphMarker(tileimg, face, glyphc, p_x, p_y, s->scale, s->rotation,
                 s->color, s->outlinecolor, s->outlinewidth);
         }
@@ -311,7 +311,7 @@ imageObj *getTile(imageObj *img, symbolObj *symbol,  symbolStyleObj *s, int widt
               if(UNLIKELY(!face)) { status = MS_FAILURE; break; }
               msUTF8ToUniChar(symbol->character, &unicode);
               unicode = msGetGlyphIndex(face,unicode);
-              glyphc = msGetGlyphByIndex(face, s->scale, unicode);
+              glyphc = msGetGlyphByIndex(face, MS_MAX(MS_NINT(s->scale),1), unicode);
               if(UNLIKELY(!glyphc)) { status = MS_FAILURE; break; }
               status = drawGlyphMarker(tileimg, face, glyphc, p_x, p_y, s->scale, s->rotation,
                     s->color, s->outlinecolor, s->outlinewidth);
@@ -384,7 +384,7 @@ int msImagePolylineMarkers(imageObj *image, shapeObj *p, symbolObj *symbol,
     face = msGetFontFace(symbol->font, &image->map->fontset);
     if(UNLIKELY(!face)) return MS_FAILURE;
     unicode = msGetGlyphIndex(face,unicode);
-    glyphc = msGetGlyphByIndex(face, style->scale, unicode);
+    glyphc = msGetGlyphByIndex(face, MS_MAX(MS_NINT(style->scale),1), unicode);
     if(UNLIKELY(!glyphc)) return MS_FAILURE;
     symbol_width = glyphc->metrics.maxx - glyphc->metrics.minx;
     symbol_height = glyphc->metrics.maxy - glyphc->metrics.miny;
@@ -922,7 +922,7 @@ int msDrawMarkerSymbol(mapObj *map, imageObj *image, pointObj *p, styleObj *styl
           if(UNLIKELY(!face)) return MS_FAILURE;
           msUTF8ToUniChar(symbol->character,&unicode);
           unicode = msGetGlyphIndex(face,unicode);
-          glyphc = msGetGlyphByIndex(face,s.scale,unicode);
+          glyphc = msGetGlyphByIndex(face, MS_MAX(MS_NINT(s.scale),1), unicode);
           if(UNLIKELY(!glyphc)) return MS_FAILURE;
           ret = drawGlyphMarker(image, face, glyphc, p_x, p_y, s.scale, s.rotation, s.color, s.outlinecolor, s.outlinewidth);
         }


### PR DESCRIPTION
MapServer will crash at very small scales, when a ttf symbol is used together with symbolscalednom, but without minsize, which is default 0.

```
MAP
		SIZE 1000 500
		EXTENT -90 -90 90 90
		PROJECTION
				"init=epsg:4326"
		END

		FONTSET 'glyph.fonts'

		SYMBOL
				NAME "test"
				TYPE TRUETYPE
				FONT "arial"
				CHARACTER '&#97;'
		END

		LAYER
				TYPE LINE
				STATUS DEFAULT

				FEATURE
						POINTS
								0 0
								20 20
						END
				END

				NAME 'ttflayer'
				STATUS DEFAULT
				PROJECTION
						'init=epsg:4326'
				END

				SYMBOLSCALEDENOM 100

				CLASS
						STYLE
								SYMBOL "test"
								WIDTH 2
#								MINSIZE 1
						END
				END
		END
END
```