### PR TITLE
Fix segfault in PHP MapScript implementation of saveQuery

### DIFF
--- a/mapscript/php/map.c
+++ b/mapscript/php/map.c
@@ -1951,7 +1951,7 @@ PHP_METHOD(mapObj, saveQuery)
   zval *zobj = getThis();
   char *filename;
   long filename_len = 0;
-  int results = MS_FALSE;
+  long results = MS_FALSE;
   int status = MS_FAILURE;
   php_map_object *php_map;
 


### PR DESCRIPTION
Calling `saveQuery` from php MapScript with result parameter set to `MS_TRUE` or `MS_FALSE`, php may segfault due to illegal assignmet of a variable parsed as long to an int variable.