### PR TITLE
A freed geometry should be set to null in msGEOSFreeGeometry()

### DIFF
--- a/mapgeos.c
+++ b/mapgeos.c
@@ -720,6 +720,7 @@ void msGEOSFreeGeometry(shapeObj *shape)
 
   g = (GEOSGeom) shape->geometry;
   GEOSGeom_destroy_r(handle,g);
+  shape->geometry = NULL;
 #else
   msSetError(MS_GEOSERR, "GEOS support is not available.", "msGEOSFreeGEOSGeom()");
   return;


### PR DESCRIPTION
`msGEOSFreeGeometry` checks whether the object to be freed exists, but does not set the freed object to null. If `msGEOSFreeGeometry` is - accidently - called twice on the same object, Mapserver will crash.