### PR TITLE
Add PROCESSING FORCE_DRAW_LABEL_CACHE layer-level directive

### DIFF
--- a/mapdraw.c
+++ b/mapdraw.c
@@ -328,6 +328,8 @@ imageObj *msDrawMap(mapObj *map, int querymap)
   for(i=0; i<map->numlayers; i++) {
 
     if(map->layerorder[i] != -1) {
+      char *force_draw_label_cache = NULL;
+
       lp = (GET_LAYER(map,  map->layerorder[i]));
 
       if(lp->postlabelcache) /* wait to draw */
@@ -391,9 +393,11 @@ imageObj *msDrawMap(mapObj *map, int querymap)
       }
 
       /* Flush layer cache in-between layers if requested by PROCESSING directive*/
-      if (msLayerGetProcessingKey(lp, "FORCE_DRAW_LABEL_CACHE")) {
+      force_draw_label_cache = msLayerGetProcessingKey(lp, "FORCE_DRAW_LABEL_CACHE");
+      if (force_draw_label_cache &&
+	  strncasecmp(force_draw_label_cache,"FLUSH",5)==0) {
 	if(map->debug >= MS_DEBUGLEVEL_V)
-	  msDebug("msDrawMap(): PROCESSING FORCE_DRAW_LABEL_CACHE found.\n");
+	  msDebug("msDrawMap(): PROCESSING FORCE_DRAW_LABEL_CACHE=FLUSH found.\n");
 	if(msDrawLabelCache(map, image) != MS_SUCCESS) {
 	  msFreeImage(image);
 #if defined(USE_WMS_LYR) || defined(USE_WFS_LYR)


### PR DESCRIPTION
It can sometimes be useful to flush the labelcache in the middle of map rendering for various reasons.

This pull request introduces a PROCESSING FORCE_DRAW_LABEL_CACHE directive that can be added to a layer to force rendering and flushing the labelcache after the layer is done rendering. This would typically be used on the last layer of a group of layers that should be treated as an independent group with respect to the label cache, and before starting the rendering of another set of independent layers. Setting this directive to any value triggers this behavior.

e.g.
```
LAYER
   ...
   PROCESSING "FORCE_DRAW_LABEL_CACHE=1"
   ...
END