### PR TITLE
Bump SOVERSION to 2 to account for removed symbols since 6.4.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ if(BUILD_DYNAMIC)
   add_library(mapserver SHARED ${mapserver_SOURCES} ${agg_SOURCES} ${v8_SOURCES})
   set_target_properties( mapserver  PROPERTIES
     VERSION ${MapServer_VERSION_STRING}
-    SOVERSION 1
+    SOVERSION 2
 ) 
 endif(BUILD_DYNAMIC)
 
@@ -258,7 +258,7 @@ if(BUILD_STATIC)
   add_library(mapserver_static STATIC ${mapserver_SOURCES} ${agg_SOURCES} ${v8_SOURCES})
   set_target_properties( mapserver_static PROPERTIES
     VERSION ${MapServer_VERSION_STRING}
-    SOVERSION 1
+    SOVERSION 2
   ) 
 endif(BUILD_STATIC)
 


### PR DESCRIPTION
Quite a number of symbols that were introduced in MapServer 6.2.1 are no longer availble in 7.0.0-beta2, to account for these removed symbols to library SOVERSION needs to be incremented.