### PR TITLE
Label outline not changing when OUTLINEWIDTH value changed

### DIFF
--- a/maprendering.c
+++ b/maprendering.c
@@ -1023,7 +1023,8 @@ int msDrawTextSymbol(mapObj *map, imageObj *image, pointObj labelPnt, textSymbol
     c = &ts->label->color;
   if(MS_VALID_COLOR(ts->label->outlinecolor))
     oc = &ts->label->outlinecolor;
-  ow = ts->label->outlinewidth * (ts->textpath->glyph_size / ts->label->size);
+  ow = MS_NINT((double)ts->label->outlinewidth * ((double)ts->textpath->glyph_size / (double)ts->label->size));
+  msDebug("setting outlinewidth to %d (%d, %d, %d)\n",ow,ts->label->outlinewidth, ts->textpath->glyph_size, ts->label->size);
   if(!renderer->renderGlyphs) return MS_FAILURE;
   return renderer->renderGlyphs(image,ts->textpath,c,oc,ow);
   


### PR DESCRIPTION
I have a mapfile that has several layers that use SIZEUNITS METERS for styling the layers.  Specific to this issue is that the layers are labelled.  The text seems to be sized properly in meters, but the outline on the text is not.  It seems to always be the same no matter what value I set OUTLINEWIDTH to.

Sample mapfile: https://www.dropbox.com/s/rg9bph3awkmujr2/outlinewidth.map?dl=0

This seems to have started happening after the fix for #4942.

I checked out 3e7ecf7d1ca3512c6c66f30ebed739cdd484a841, and the problem did not happen, but checking out d0043f27538ff70c7911fa22707d4839ccfeae80 makes it happen.  It also happens with an up-to-date branch-7-0