### PR TITLE
Fix buffer overflow / memory leak in mapuvraster.c

### DIFF
--- a/mapuvraster.c
+++ b/mapuvraster.c
@@ -461,7 +461,7 @@ int msUVRASTERLayerWhichShapes(layerObj *layer, rectObj rect, int isQuery)
       layer->processing = savedProcessing;
       CSLDestroy(alteredProcessing);
     }
-    msFree(map_tmp);
+    msFreeMap(map_tmp);
     msFreeImage(image_tmp);
     return MS_FAILURE;
   }

--- a/mapuvraster.c
+++ b/mapuvraster.c
@@ -456,6 +456,13 @@ int msUVRASTERLayerWhichShapes(layerObj *layer, rectObj rect, int isQuery)
   if (msDrawRasterLayerLow(map_tmp, layer, image_tmp, NULL ) == MS_FAILURE) {
     msSetError(MS_MISCERR, "Unable to draw raster data.", "msUVRASTERLayerWhichShapes()");
     layer->mask = saved_layer_mask;
+
+    if (alteredProcessing != NULL) {
+      layer->processing = savedProcessing;
+      CSLDestroy(alteredProcessing);
+    }
+    msFree(map_tmp);
+    msFreeImage(image_tmp);
     return MS_FAILURE;
   }
 
@@ -477,7 +484,7 @@ int msUVRASTERLayerWhichShapes(layerObj *layer, rectObj rect, int isQuery)
   }
 
   if (uvlinfo->v) {
-    for (i=0; i<uvlinfo->height; ++i) {
+    for (i=0; i<uvlinfo->width; ++i) {
       free(uvlinfo->v[i]);
     }
     free(uvlinfo->v);

--- a/mapuvraster.c
+++ b/mapuvraster.c
@@ -116,7 +116,7 @@ static int msUVRASTERLayerInitItemInfo(layerObj *layer)
     /* OGR style strings.  We use special attribute snames. */
     if (EQUAL(layer->items[i], MSUVRASTER_ANGLE))
       itemindexes[i] = MSUVRASTER_ANGLEINDEX;
-    if (EQUAL(layer->items[i], MSUVRASTER_MINUS_ANGLE))
+    else if (EQUAL(layer->items[i], MSUVRASTER_MINUS_ANGLE))
       itemindexes[i] = MSUVRASTER_MINUSANGLEINDEX;
     else if (EQUAL(layer->items[i], MSUVRASTER_LENGTH))
       itemindexes[i] = MSUVRASTER_LENGTHINDEX;

--- a/mapuvraster.c
+++ b/mapuvraster.c
@@ -125,8 +125,7 @@ static int msUVRASTERLayerInitItemInfo(layerObj *layer)
       itemindexes[i] = MSUVRASTER_UINDEX;
     else if (EQUAL(layer->items[i], MSUVRASTER_V))
       itemindexes[i] = MSUVRASTER_VINDEX;
-
-    if(itemindexes[i] == -1) {
+    else {
       msSetError(MS_OGRERR,
                  "Invalid Field name: %s",
                  "msUVRASTERLayerInitItemInfo()",

--- a/mapuvraster.c
+++ b/mapuvraster.c
@@ -233,7 +233,7 @@ int msUVRASTERLayerClose(layerObj *layer)
   if( uvlinfo != NULL ) {
     uvlinfo->refcount--;
 
-    if( uvlinfo->refcount < 0 )
+    if( uvlinfo->refcount < 1 )
       msUVRasterLayerInfoFree( layer );
   }
   return MS_SUCCESS;


### PR DESCRIPTION
Using uvlinfo->height instead of uvlinfo->width will either get you a buffer overflow or memory leak depending on whether width or height is larger.