### PR TITLE
Fix memory leak when setting format options from mapfile

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -5060,8 +5060,9 @@ static int loadOutputFormat(mapObj *map)
             format->renderer = MS_RENDER_WITH_RAWDATA;
         }
 
-        format->numformatoptions = numformatoptions;
         if( numformatoptions > 0 ) {
+          msFreeCharArray(format->formatoptions,format->numformatoptions);
+          format->numformatoptions = numformatoptions;
           format->formatoptions = (char **)
           msSmallMalloc(sizeof(char *)*numformatoptions );
           memcpy( format->formatoptions, formatoptions,


### PR DESCRIPTION
Before setting any formatoption from mapfile, make sure to free previous formatoptions as allocated by the default formats.

This slightly modifies the behaviour. Previously it would always overwrite the numformatoptions and thus  preventing any use of the default format options. Now it preserves the default format options if none are specified. I'm not sure what behaviour is required. It should be easy to change though if needed.