### PR TITLE
Fix segfault with expression bindings on database backends

### DIFF
--- a/mapserver.h
+++ b/mapserver.h
@@ -2410,6 +2410,7 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   MS_DLL_EXPORT int msClusterLayerOpen(layerObj *layer); /* in mapcluster.c */
   MS_DLL_EXPORT int msLayerIsOpen(layerObj *layer);
   MS_DLL_EXPORT void msLayerClose(layerObj *layer);
+  MS_DLL_EXPORT void msLayerFreeExpressions(layerObj *layer);
   MS_DLL_EXPORT int msLayerWhichShapes(layerObj *layer, rectObj rect, int isQuery);
   MS_DLL_EXPORT int msLayerGetItemIndex(layerObj *layer, char *item);
   MS_DLL_EXPORT int msLayerWhichItems(layerObj *layer, int get_all, const char *metadata);


### PR DESCRIPTION
In some situations, attribute bindings may cause a segmentation fault, when executing multiple MapScript operations, e.g. `queryByPoint()` followed by `draw()` on the same layer. This is because the expression is tokenized only once - when uninitialized. In case of an attribute binding, the token bindval index points to the sql column-index built from the list of required attributes, in case of `queryByPoint()` all attributes are requested. A possibly following `draw()` will reduce the number of attributes to be queried from the database, so the column index in the resultset changes, but the expression token is still the same.

The fix is to free the expression object, when `msLayerFreeItemInfo()` is called, which is currently done at `LayerClose()` only.
