### PR TITLE
Don't install mapserver target twice (rebased for branch-7-0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -974,17 +974,19 @@ endif(USE_MSSQL2008)
 INSTALL(TARGETS sortshp shptree shptreevis msencrypt legend scalebar tile4ms shptreetst shp2img mapserv
         RUNTIME DESTINATION ${INSTALL_BIN_DIR} COMPONENT bin
 )
-INSTALL(TARGETS mapserver
-        EXPORT mapserverTargets
-        LIBRARY DESTINATION ${INSTALL_LIB_DIR} COMPONENT shlib
-        PUBLIC_HEADER DESTINATION ${INSTALL_INCLUDE_DIR}/mapserver COMPONENT dev
-)
 
 if(BUILD_STATIC)
-   INSTALL(TARGETS mapserver_static DESTINATION ${INSTALL_LIB_DIR})
+   INSTALL(TARGETS mapserver_static
+           DESTINATION ${INSTALL_LIB_DIR} COMPONENT staticlib
+   )
 endif(BUILD_STATIC)
 if(BUILD_DYNAMIC)
-   INSTALL(TARGETS mapserver DESTINATION ${INSTALL_LIB_DIR})
+   INSTALL(TARGETS mapserver
+           EXPORT mapserverTargets
+           ARCHIVE DESTINATION ${INSTALL_LIB_DIR} COMPONENT shlib
+           LIBRARY DESTINATION ${INSTALL_LIB_DIR} COMPONENT shlib
+           PUBLIC_HEADER DESTINATION ${INSTALL_INCLUDE_DIR}/mapserver COMPONENT dev
+   )
 endif(BUILD_DYNAMIC)
 
 # Add all targets to the build-tree export set


### PR DESCRIPTION
GitHub doesn't like recreating branches apparently, this rebase should have replaced the commits for #5165 instead of a new PR.

The mapserver target only needs to be installed when BUILD_DYNAMIC is true.

For convenience the mapserver_static target is assigned to the staticlib component.

This change also includes the ARCHIVE target from #5164.