### PR TITLE
Make return compatible with 64bits checks.

### DIFF
--- a/mapthread.c
+++ b/mapthread.c
@@ -188,7 +188,7 @@ void msThreadInit()
 void* msGetThreadId()
 
 {
-  return pthread_self();
+  return (void*) pthread_self();
 }
 
 /************************************************************************/


### PR DESCRIPTION
Modify as suggested to make gcc check happy in 64 bits world.
