### PR TITLE
STYLEITEM doesn't work with inline features

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -956,7 +956,7 @@ static int loadFeature(layerObj *player, int type)
         }
         if (string) {
           if(shape->values) msFreeCharArray(shape->values, shape->numvalues);
-          shape->values = msStringSplitComplex(string, ';', &shape->numvalues,MS_ALLOWEMPTYTOKENS);
+          shape->values = msStringSplitComplex(string, ";", &shape->numvalues,MS_ALLOWEMPTYTOKENS);
           msFree(string); /* clean up */
         }
         break;

--- a/mapfile.c
+++ b/mapfile.c
@@ -956,7 +956,7 @@ static int loadFeature(layerObj *player, int type)
         }
         if (string) {
           if(shape->values) msFreeCharArray(shape->values, shape->numvalues);
-          shape->values = msStringSplit(string, ';', &shape->numvalues);
+          shape->values = msStringSplitComplex(string, ';', &shape->numvalues,MS_ALLOWEMPTYTOKENS);
           msFree(string); /* clean up */
         }
         break;


### PR DESCRIPTION
Try to perform the following command (MapServer version 6.4.2):

```bash
shp2img -m test.map -o test.png -e 83.8188439491 53.2546620046 83.8878089073 53.2673689983
```

on map-file:

```
MAP
  EXTENT -180 -90 180 90
  IMAGETYPE "png"
  MAXSIZE 4096
  NAME "MS"
  SIZE 800 600
  STATUS ON
  UNITS METERS

  OUTPUTFORMAT
    NAME "png"
    MIMETYPE "image/png"
    DRIVER "AGG/PNG"
    EXTENSION "png"
    IMAGEMODE RGBA
    TRANSPARENT TRUE
    FORMATOPTION "INTERLACE=OFF"
  END # OUTPUTFORMAT

  PROJECTION
    "init=epsg:4326"
  END # PROJECTION

  LAYER
    EXTENT -20037508.34 -20037508.34 20037508.34 20037508.34
    NAME "main"
    PROCESSING "ITEMS=ID,RegisterNo,Classifier,Code,Num,Descriptio,IsLinked,Name,No,Note,_1,OGR_STYLE"
    PROCESSING "APPROXIMATION_SCALE=full"
    PROCESSING "LABEL_NO_CLIP=true"
    PROJECTION
      "init=epsg:3857"
    END # PROJECTION
    STATUS DEFAULT
    TEMPLATE "dummy.html"
    TILEITEM "location"
    TYPE POLYGON
    UNITS METERS

    STYLEITEM "OGR_STYLE"
    CLASS
        NAME "CLASSNAME"
    END

    FEATURE
      POINTS
      9331285.55013047 7031147.14829634
      9331191.79710092 7031206.67085876
      9331227.7242601 7031291.64661181
      9331190.80409234 7031421.22444962
      9331269.87478197 7031562.87485792
      9331446.01694922 7031505.60564078
      9331398.43503303 7031285.67032192
      9331551.37291092 7031205.60840883
      9331654.04890265 7031434.3233041
      9331683.74694351 7031519.55212004
      9331709.32237557 7031637.59715126
      9331738.05529008 7031770.21783225
      9332151.37231156 7031784.09439794
      9332222.16574809 7031790.23144222
      9332324.46490457 7031754.6374417
      9332183.90451562 7031477.5280341
      9332334.53566344 7031393.0780837
      9332280.21269992 7031297.70518526
      9332066.07993751 7031418.74000335
      9331903.09697688 7031162.7702099
      9332199.23194252 7031000.18809
      9332408.01036206 7031381.65159203
      9332601.73783387 7031259.12683767
      9332511.60737812 7031075.39164255
      9332616.01443219 7031012.71483812
      9332575.95096881 7030913.66311898
      9332969.45668427 7030712.79847311
      9332895.29280673 7030540.61222434
      9332855.53105062 7030383.30217977
      9332817.2348082 7030291.16502674
      9332018.53151033 7030681.74616256
      9331285.55013047 7031147.14829634
      END # POINTS
    ITEMS "01A9003EFEF8;000100797697;Grad/TerrZone;549;4570;;T;;4570;;0;BRUSH(fc:#d3ff90,bc:#d3ff90,id:\"mapinfo-brush-2,ogr-brush-0\");PEN(w:1px,c:#000000,id:\"mapinfo-pen-2,ogr-pen-0\")"
    END # FEATURE
  END # LAYER
END # MAP
```

Result - is empty image. But if change section

```
STYLEITEM "OGR_STYLE"
CLASS
    NAME "CLASSNAME"
END
```

with

```
CLASS
  STYLE
    COLOR 141 211 199
    OUTLINECOLOR 64 64 64
  END
END
```

all works fine.
