### PR TITLE
Reminder to fix EPSG parsing code to make it thread safe

### DIFF
--- a/mapgml.c
+++ b/mapgml.c
@@ -1390,7 +1390,7 @@ int msGMLWriteQuery(mapObj *map, char *filename, const char *namespaces)
   FILE *stream=stdout; /* defaults to stdout */
   char szPath[MS_MAXPATHLEN];
   char *value;
-  const char *pszMapSRS = NULL;
+  char *pszMapSRS = NULL;
 
   gmlGroupListObj *groupList=NULL;
   gmlItemListObj *itemList=NULL;
@@ -1423,11 +1423,11 @@ int msGMLWriteQuery(mapObj *map, char *filename, const char *namespaces)
   msOWSPrintEncodeMetadata(stream, &(map->web.metadata), namespaces, "description", OWS_NOERR, "\t<gml:description>%s</gml:description>\n", NULL);
 
   /* Look up map SRS. We need an EPSG code for GML, if not then we get null and we'll fall back on the layer's SRS */
-  pszMapSRS = msOWSGetEPSGProj(&(map->projection), NULL, namespaces, MS_TRUE);
+  msOWSGetEPSGProj(&(map->projection), NULL, namespaces, MS_TRUE, &pszMapSRS);
 
   /* step through the layers looking for query results */
   for(i=0; i<map->numlayers; i++) {
-    const char *pszOutputSRS = NULL;
+    char *pszOutputSRS = NULL;
     int nSRSDimension = 2;
     const char* geomtype;
 
@@ -1438,7 +1438,7 @@ int msGMLWriteQuery(mapObj *map, char *filename, const char *namespaces)
 #ifdef USE_PROJ
       /* Determine output SRS, if map has none, then try using layer's native SRS */
       if ((pszOutputSRS = pszMapSRS) == NULL) {
-        pszOutputSRS = msOWSGetEPSGProj(&(lp->projection), NULL, namespaces, MS_TRUE);
+        msOWSGetEPSGProj(&(lp->projection), NULL, namespaces, MS_TRUE, &pszOutputSRS);
         if (pszOutputSRS == NULL) {
           msSetError(MS_WMSERR, "No valid EPSG code in map or layer projection for GML output", "msGMLWriteQuery()");
           continue;  /* No EPSG code, cannot output this layer */
@@ -1557,12 +1557,16 @@ int msGMLWriteQuery(mapObj *map, char *filename, const char *namespaces)
 
       /* msLayerClose(lp); */
     }
+    if(pszOutputSRS!=pszMapSRS) {
+      msFree(pszOutputSRS);
+    }
   } /* next layer */
 
   /* end this document */
   msOWSPrintValidateMetadata(stream, &(map->web.metadata), namespaces, "rootname", OWS_NOERR, "</%s>\n", "msGMLOutput");
 
   if(filename && strlen(filename) > 0) fclose(stream);
+  msFree(pszMapSRS);
 
   return(MS_SUCCESS);
 
@@ -1604,12 +1608,9 @@ void msGMLWriteWFSBounds(mapObj *map, FILE *stream, const char *tab,
     }
     else
     {
-        const char* constsrs;
-        constsrs = msOWSGetEPSGProj(&(map->projection), NULL, "FGO", MS_TRUE);
-        if (!constsrs)
-            constsrs = msOWSGetEPSGProj(&(map->projection), &(map->web.metadata), "FGO", MS_TRUE);
-        if (constsrs)
-            srs = msStrdup(constsrs);
+        msOWSGetEPSGProj(&(map->projection), NULL, "FGO", MS_TRUE, &srs);
+        if (!srs)
+            msOWSGetEPSGProj(&(map->projection), &(map->web.metadata), "FGO", MS_TRUE, &srs);
     }
 
     gmlWriteBounds(stream, outputformat, &resultBounds, srs, tab,
@@ -1733,14 +1734,11 @@ int msGMLWriteWFSQuery(mapObj *map, FILE *stream, const char *default_namespace_
       }
       else
       {
-          const char* constsrs;
-          constsrs = msOWSGetEPSGProj(&(map->projection), NULL, "FGO", MS_TRUE);
-          if (!constsrs)
-            constsrs = msOWSGetEPSGProj(&(map->projection), &(map->web.metadata), "FGO", MS_TRUE);
-          if (!constsrs)
-            constsrs = msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "FGO", MS_TRUE);
-          if (constsrs)
-            srs = msStrdup(constsrs);
+          msOWSGetEPSGProj(&(map->projection), NULL, "FGO", MS_TRUE, &srs);
+          if (!srs)
+            msOWSGetEPSGProj(&(map->projection), &(map->web.metadata), "FGO", MS_TRUE, &srs);
+          if (!srs)
+            msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "FGO", MS_TRUE, &srs);
       }
 #endif
 

--- a/mapogcsos.c
+++ b/mapogcsos.c
@@ -350,17 +350,21 @@ void msSOSAddPropertyNode(xmlNsPtr psNsSwe, xmlNsPtr psNsXLink, xmlNodePtr psPar
 /*      possible.                                                       */
 /************************************************************************/
 void  msSOSAddGeometryNode(xmlNsPtr psNsGml, xmlNsPtr psNsMs, xmlNodePtr psParent, mapObj *map, layerObj *lp, shapeObj *psShape,
-                           const char *pszEpsg)
+                           const char *pszEpsg_in)
 {
   char *pszTmp = NULL;
   int i,j = 0;
   xmlNodePtr psPointNode, psNode, psLineNode, psPolygonNode;
   int *panOuterList = NULL, *panInnerList = NULL;
+  const char *pszEpsg = pszEpsg_in;
+  char *pszEpsg_buf = NULL;
+  
 
   if (psParent && psShape) {
     if (msProjectionsDiffer(&map->projection, &lp->projection) == MS_TRUE) {
       msProjectShape(&lp->projection, &map->projection, psShape);
-      pszEpsg = msOWSGetEPSGProj(&(map->projection), &(lp->metadata), "SO", MS_TRUE);
+      msOWSGetEPSGProj(&(map->projection), &(lp->metadata), "SO", MS_TRUE, &pszEpsg_buf);
+      pszEpsg = pszEpsg_buf;
     }
     switch(psShape->type) {
       case(MS_SHAPE_POINT):
@@ -508,6 +512,7 @@ void  msSOSAddGeometryNode(xmlNsPtr psNsGml, xmlNsPtr psNsMs, xmlNodePtr psParen
     }
 
   }
+  msFree(pszEpsg_buf);
 
 }
 
@@ -626,7 +631,8 @@ void msSOSAddMemberNode(xmlNsPtr psNsGml, xmlNsPtr psNsOm, xmlNsPtr psNsSwe, xml
                         int iFeatureId, const char *script_url, const char *opLayerName)
 {
   xmlNodePtr psObsNode, psNode, psLayerNode = NULL;
-  const char *pszEpsg = NULL, *pszValue = NULL;
+  const char *pszValue = NULL;
+  char *pszEpsg = NULL;
   int status,i,j;
   shapeObj sShape;
   char szTmp[256];
@@ -785,9 +791,9 @@ void msSOSAddMemberNode(xmlNsPtr psNsGml, xmlNsPtr psNsOm, xmlNsPtr psNsSwe, xml
 
     /*bbox*/
 #ifdef USE_PROJ
-    pszEpsg = msOWSGetEPSGProj(&(map->projection), &(lp->metadata), "SO", MS_TRUE);
+    msOWSGetEPSGProj(&(map->projection), &(lp->metadata), "SO", MS_TRUE, &pszEpsg);
     if (!pszEpsg)
-      pszEpsg = msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "SO", MS_TRUE);
+      msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "SO", MS_TRUE, &pszEpsg);
 
     if (msProjectionsDiffer(&map->projection, &lp->projection) == MS_TRUE)
       msProjectRect(&lp->projection, &map->projection, &sShape.bounds);
@@ -796,6 +802,7 @@ void msSOSAddMemberNode(xmlNsPtr psNsGml, xmlNsPtr psNsOm, xmlNsPtr psNsSwe, xml
 
     /*geometry*/
     msSOSAddGeometryNode(psNsGml, psNsMs, psLayerNode, map, lp, &sShape, pszEpsg);
+    msFree(pszEpsg);
 
     /*attributes */
     /* TODO only output attributes where there is a sos_%s_alias (to be discussed)*/
@@ -1369,7 +1376,7 @@ int msSOSGetCapabilities(mapObj *map, sosParamsObj *sosparams, cgiRequestObj *re
                  Check also what happen if epsg not present */
         value = msOWSLookupMetadata(&(lp->metadata), "S", "offering_extent");
         if (value) {
-          char **tokens;
+          char **tokens,*pszLayerEPSG;
           int n;
           tokens = msStringSplit(value, ',', &n);
           if (tokens==NULL || n != 4) {
@@ -1377,10 +1384,11 @@ int msSOSGetCapabilities(mapObj *map, sosParamsObj *sosparams, cgiRequestObj *re
                        "msSOSGetCapabilities()");
             return msSOSException(map, "sos_offering_extent", "InvalidParameterValue");
           }
-          value = msOWSGetEPSGProj(&(lp->projection),
-                                   &(lp->metadata), "SO", MS_TRUE);
-          if (value)
+          msOWSGetEPSGProj(&(lp->projection),&(lp->metadata), "SO", MS_TRUE,&pszLayerEPSG);
+          if (pszLayerEPSG) {
             psNode = xmlAddChild(psOfferingNode, msGML3BoundedBy(psNsGml, atof(tokens[0]), atof(tokens[1]), atof(tokens[2]), atof(tokens[3]), value));
+            msFree(pszLayerEPSG);
+          }
           msFreeCharArray(tokens, n);
 
         }
@@ -2284,10 +2292,11 @@ this request. Check sos/ows_enable_request settings.", "msSOSGetObservation()", 
 
   if (pszTmp) {
     char **tokens;
+    char *pszMapEpsg;
     int n;
     rectObj envelope;
 
-    pszTmp2 = msOWSGetEPSGProj(&(map->projection), &(lp->metadata), "SO", MS_TRUE);
+    msOWSGetEPSGProj(&(map->projection), &(lp->metadata), "SO", MS_TRUE, &pszMapEpsg);
 
     tokens = msStringSplit(pszTmp, ',', &n);
     if (tokens==NULL || n != 4) {
@@ -2308,8 +2317,9 @@ this request. Check sos/ows_enable_request settings.", "msSOSGetObservation()", 
       }
     }
 
-    psNode = xmlAddChild(psRootNode, msGML3BoundedBy(psNsGml, envelope.minx, envelope.miny, envelope.maxx, envelope.maxy, pszTmp2));
+    psNode = xmlAddChild(psRootNode, msGML3BoundedBy(psNsGml, envelope.minx, envelope.miny, envelope.maxx, envelope.maxy, pszMapEpsg));
     msFreeCharArray(tokens, n);
+    msFree(pszMapEpsg);
   }
 
   /* time

--- a/mapogcsos.c
+++ b/mapogcsos.c
@@ -1386,7 +1386,7 @@ int msSOSGetCapabilities(mapObj *map, sosParamsObj *sosparams, cgiRequestObj *re
           }
           msOWSGetEPSGProj(&(lp->projection),&(lp->metadata), "SO", MS_TRUE,&pszLayerEPSG);
           if (pszLayerEPSG) {
-            psNode = xmlAddChild(psOfferingNode, msGML3BoundedBy(psNsGml, atof(tokens[0]), atof(tokens[1]), atof(tokens[2]), atof(tokens[3]), value));
+            psNode = xmlAddChild(psOfferingNode, msGML3BoundedBy(psNsGml, atof(tokens[0]), atof(tokens[1]), atof(tokens[2]), atof(tokens[3]), pszLayerEPSG));
             msFree(pszLayerEPSG);
           }
           msFreeCharArray(tokens, n);

--- a/mapows.h
+++ b/mapows.h
@@ -293,7 +293,7 @@ void msOWSProcessException(layerObj *lp, const char *pszFname,
                            int nErrorCode, const char *pszFuncName);
 char *msOWSBuildURLFilename(const char *pszPath, const char *pszURL,
                             const char *pszExt);
-const char *msOWSGetEPSGProj(projectionObj *proj, hashTableObj *metadata, const char *namespaces, int bReturnOnlyFirstOne);
+void msOWSGetEPSGProj(projectionObj *proj, hashTableObj *metadata, const char *namespaces, int bReturnOnlyFirstOne, char **epsgProj);
 char *msOWSGetProjURN(projectionObj *proj, hashTableObj *metadata, const char *namespaces, int bReturnOnlyFirstOne);
 char *msOWSGetProjURI(projectionObj *proj, hashTableObj *metadata, const char *namespaces, int bReturnOnlyFirstOne);
 

--- a/mapwcs.c
+++ b/mapwcs.c
@@ -859,6 +859,8 @@ static int msWCSGetCapabilities_CoverageOfferingBrief(layerObj *layer, wcsParams
 
   /* done */
   msIO_printf("  </CoverageOfferingBrief>\n");
+  
+  msWCSFreeCoverageMetadata(&cm);
 
   return MS_SUCCESS;
 }
@@ -1097,6 +1099,7 @@ static int msWCSDescribeCoverage_CoverageOffering(layerObj *layer, wcsParamsObj 
   char **tokens;
   int numtokens;
   const char *value;
+  char *epsg_buf, *encoded_format;
   coverageMetadataObj cm;
   int i, status;
 
@@ -1153,12 +1156,16 @@ static int msWCSDescribeCoverage_CoverageOffering(layerObj *layer, wcsParamsObj 
   msIO_printf("        </gml:Envelope>\n");
 
   /* envelope in the native srs */
-  if((value = msOWSGetEPSGProj(&(layer->projection), &(layer->metadata), "CO", MS_TRUE)) != NULL)
-    msIO_printf("        <gml:Envelope srsName=\"%s\">\n", value);
-  else if((value = msOWSGetEPSGProj(&(layer->map->projection), &(layer->map->web.metadata), "CO", MS_TRUE)) != NULL)
-    msIO_printf("        <gml:Envelope srsName=\"%s\">\n", value);
-  else
+  msOWSGetEPSGProj(&(layer->projection), &(layer->metadata), "CO", MS_TRUE, &epsg_buf);
+  if(!epsg_buf) {
+    msOWSGetEPSGProj(&(layer->map->projection), &(layer->map->web.metadata), "CO", MS_TRUE, &epsg_buf);
+  }
+  if(epsg_buf) {
+    msIO_printf("        <gml:Envelope srsName=\"%s\">\n", epsg_buf);
+    msFree(epsg_buf);
+  } else {
     msIO_printf("        <!-- NativeCRSs ERROR: missing required information, no SRSs defined -->\n");
+  }
   msIO_printf("          <gml:pos>%.15g %.15g</gml:pos>\n", cm.extent.minx, cm.extent.miny);
   msIO_printf("          <gml:pos>%.15g %.15g</gml:pos>\n", cm.extent.maxx, cm.extent.maxy);
   msIO_printf("        </gml:Envelope>\n");
@@ -1181,6 +1188,8 @@ static int msWCSDescribeCoverage_CoverageOffering(layerObj *layer, wcsParamsObj 
   msIO_printf("        </gml:RectifiedGrid>\n");
 
   msIO_printf("      </spatialDomain>\n");
+  
+  msWCSFreeCoverageMetadata(&cm);
 
   /* TemporalDomain */
 
@@ -1232,30 +1241,33 @@ static int msWCSDescribeCoverage_CoverageOffering(layerObj *layer, wcsParamsObj 
   msIO_printf("    <supportedCRSs>\n");
 
   /* requestResposeCRSs: check the layer metadata/projection, and then the map metadata/projection if necessary (should never get to the error message) */
-  if((value = msOWSGetEPSGProj(&(layer->projection), &(layer->metadata), "CO", MS_FALSE)) != NULL) {
-    tokens = msStringSplit(value, ' ', &numtokens);
+  msOWSGetEPSGProj(&(layer->projection), &(layer->metadata), "CO", MS_FALSE, &epsg_buf);
+  if(!epsg_buf) {
+    msOWSGetEPSGProj(&(layer->map->projection), &(layer->map->web.metadata), "CO", MS_FALSE, &epsg_buf);
+  }
+  if(epsg_buf) {
+    tokens = msStringSplit(epsg_buf, ' ', &numtokens);
     if(tokens && numtokens > 0) {
       for(i=0; i<numtokens; i++)
         msIO_printf("      <requestResponseCRSs>%s</requestResponseCRSs>\n", tokens[i]);
       msFreeCharArray(tokens, numtokens);
     }
-  } else if((value = msOWSGetEPSGProj(&(layer->map->projection), &(layer->map->web.metadata), "CO", MS_FALSE)) != NULL) {
-    tokens = msStringSplit(value, ' ', &numtokens);
-    if(tokens && numtokens > 0) {
-      for(i=0; i<numtokens; i++)
-        msIO_printf("      <requestResponseCRSs>%s</requestResponseCRSs>\n", tokens[i]);
-      msFreeCharArray(tokens, numtokens);
-    }
-  } else
+    msFree(epsg_buf);
+  } else {
     msIO_printf("      <!-- requestResponseCRSs ERROR: missing required information, no SRSs defined -->\n");
+  }
 
   /* nativeCRSs (only one in our case) */
-  if((value = msOWSGetEPSGProj(&(layer->projection), &(layer->metadata), "CO", MS_TRUE)) != NULL)
-    msIO_printf("      <nativeCRSs>%s</nativeCRSs>\n", value);
-  else if((value = msOWSGetEPSGProj(&(layer->map->projection), &(layer->map->web.metadata), "CO", MS_TRUE)) != NULL)
-    msIO_printf("      <nativeCRSs>%s</nativeCRSs>\n", value);
-  else
+  msOWSGetEPSGProj(&(layer->projection), &(layer->metadata), "CO", MS_TRUE, &epsg_buf);
+  if(!epsg_buf) {
+    msOWSGetEPSGProj(&(layer->map->projection), &(layer->map->web.metadata), "CO", MS_TRUE, &epsg_buf);
+  }
+  if(epsg_buf) {
+    msIO_printf("      <nativeCRSs>%s</nativeCRSs>\n", epsg_buf);
+    msFree(epsg_buf);
+  } else {
     msIO_printf("      <!-- nativeCRSs ERROR: missing required information, no SRSs defined -->\n");
+  }
 
   msIO_printf("    </supportedCRSs>\n");
 
@@ -1265,15 +1277,15 @@ static int msWCSDescribeCoverage_CoverageOffering(layerObj *layer, wcsParamsObj 
   msOWSPrintEncodeMetadata(stdout, &(layer->metadata), "CO", "nativeformat", OWS_NOERR, " nativeFormat=\"%s\"", NULL);
   msIO_printf(">\n");
 
-  if( (value = msOWSGetEncodeMetadata( &(layer->metadata), "CO", "formats",
+  if( (encoded_format = msOWSGetEncodeMetadata( &(layer->metadata), "CO", "formats",
                                        "GTiff" )) != NULL ) {
-    tokens = msStringSplit(value, ' ', &numtokens);
+    tokens = msStringSplit(encoded_format, ' ', &numtokens);
     if(tokens && numtokens > 0) {
       for(i=0; i<numtokens; i++)
         msIO_printf("      <formats>%s</formats>\n", tokens[i]);
       msFreeCharArray(tokens, numtokens);
     }
-    msFree((char*)value);
+    msFree(encoded_format);
   }
   msIO_printf("    </supportedFormats>\n");
 
@@ -1649,8 +1661,10 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
         return msWCSException( map, NULL, NULL,params->version);
     } else if( strcasecmp(crs_to_use,"imageCRS") == 0 ) {
       /* use layer native CRS, and rework bounding box accordingly */
-      if( msWCSGetCoverage_ImageCRSSetup( map, request, params, &cm, lp ) != MS_SUCCESS )
+      if( msWCSGetCoverage_ImageCRSSetup( map, request, params, &cm, lp ) != MS_SUCCESS ) {
+        msWCSFreeCoverageMetadata(&cm);
         return MS_FAILURE;
+      }
     } else {  /* should we support WMS style AUTO: projections? (not for now) */
       msSetError(MS_WCSERR, "Unsupported SRS namespace (only EPSG currently supported).", "msWCSGetCoverage()");
       return msWCSException(map, "InvalidParameterValue", "srs", params->version);
@@ -1670,10 +1684,12 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
 
     /* check format of TIME parameter */
     if(strchr(params->time, ',')) {
+      msWCSFreeCoverageMetadata(&cm);
       msSetError( MS_WCSERR, "Temporal lists are not supported, only individual values.", "msWCSGetCoverage()" );
       return msWCSException(map, "InvalidParameterValue", "time", params->version);
     }
     if(strchr(params->time, '/')) {
+      msWCSFreeCoverageMetadata(&cm);
       msSetError( MS_WCSERR, "Temporal ranges are not supported, only individual values.", "msWCSGetCoverage()" );
       return msWCSException(map, "InvalidParameterValue", "time", params->version);
     }
@@ -1681,23 +1697,27 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
     /* TODO: will need to expand this check if a time period is supported */
     value = msOWSLookupMetadata(&(lp->metadata), "CO", "timeposition");
     if(!value) {
+      msWCSFreeCoverageMetadata(&cm);
       msSetError( MS_WCSERR, "The coverage does not support temporal subsetting.", "msWCSGetCoverage()" );
       return msWCSException(map, "InvalidParameterValue", "time", params->version );
     }
 
     /* check if timestamp is covered by the wcs_timeposition definition */
     if (msValidateTimeValue(params->time, value) == MS_FALSE) {
+      msWCSFreeCoverageMetadata(&cm);
       msSetError( MS_WCSERR, "The coverage does not have a time position of %s.", "msWCSGetCoverage()", params->time );
       return msWCSException(map, "InvalidParameterValue", "time", params->version);
     }
 
     /* make sure layer is tiled appropriately */
     if(!lp->tileindex) {
+      msWCSFreeCoverageMetadata(&cm);
       msSetError( MS_WCSERR, "Underlying layer is not tiled, unable to do temporal subsetting.", "msWCSGetCoverage()" );
       return msWCSException(map, NULL, NULL, params->version);
     }
     tli = msGetLayerIndex(map, lp->tileindex);
     if(tli == -1) {
+      msWCSFreeCoverageMetadata(&cm);
       msSetError( MS_WCSERR, "Underlying layer does not use appropriate tiling mechanism.", "msWCSGetCoverage()" );
       return msWCSException(map, NULL, NULL, params->version);
     }
@@ -1707,6 +1727,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
     /* make sure there is enough information to filter */
     value = msOWSLookupMetadata(&(lp->metadata), "CO", "timeitem");
     if(!tlp->filteritem && !value) {
+      msWCSFreeCoverageMetadata(&cm);
       msSetError( MS_WCSERR, "Not enough information available to filter.", "msWCSGetCoverage()" );
       return msWCSException(map, NULL, NULL, params->version);
     }
@@ -1726,8 +1747,10 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
     status = msWCSGetCoverageBands10( map, request, params, lp, &bandlist );
   else
     status = msWCSGetCoverageBands11( map, request, params, lp, &bandlist );
-  if( status != MS_SUCCESS )
+  if( status != MS_SUCCESS ) {
+    msWCSFreeCoverageMetadata(&cm);
     return status;
+  }
 
   /* did we get BBOX values? if not use the exent stored in the coverageMetadataObj */
   if( fabs((params->bbox.maxx - params->bbox.minx)) < 0.000000000001  || fabs(params->bbox.maxy - params->bbox.miny) < 0.000000000001 ) {
@@ -1755,8 +1778,10 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
     projectionObj tmp_proj;
 
     msInitProjection(&tmp_proj);
-    if (msLoadProjectionString(&tmp_proj, (char *) params->crs) != 0)
+    if (msLoadProjectionString(&tmp_proj, (char *) params->crs) != 0) {
+      msWCSFreeCoverageMetadata(&cm);
       return msWCSException( map, NULL, NULL, params->version);
+    }
     msProjectRect(&tmp_proj, &map->projection, &(params->bbox));
     msFreeProjection(&tmp_proj);
   }
@@ -1794,6 +1819,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
 
   /* are we still underspecified?  */
   if( (params->width == 0 || params->height == 0) && (params->resx == 0.0 || params->resy == 0.0 )) {
+    msWCSFreeCoverageMetadata(&cm);
     msSetError( MS_WCSERR, "A non-zero RESX/RESY or WIDTH/HEIGHT is required but neither was provided.", "msWCSGetCoverage()" );
     return msWCSException(map, "MissingParameterValue", "width/height/resx/resy", params->version);
   }
@@ -1815,6 +1841,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
     else if( strcasecmp(params->interpolation,"AVERAGE") == 0 )
       msLayerSetProcessingKey(lp, "RESAMPLE", "AVERAGE");
     else {
+      msWCSFreeCoverageMetadata(&cm);
       msSetError( MS_WCSERR, "INTERPOLATION=%s specifies an unsupported interpolation method.", "msWCSGetCoverage()", params->interpolation );
       return msWCSException(map, "InvalidParameterValue", "interpolation", params->version);
     }
@@ -1826,6 +1853,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
 
   /* Are we exceeding the MAXSIZE limit on result size? */
   if(map->width > map->maxsize || map->height > map->maxsize ) {
+    msWCSFreeCoverageMetadata(&cm);
     msSetError(MS_WCSERR, "Raster size out of range, width and height of resulting coverage must be no more than MAXSIZE=%d.", "msWCSGetCoverage()", map->maxsize);
 
     return msWCSException(map, "InvalidParameterValue",
@@ -1870,6 +1898,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
   covextent.maxy = cm.extent.maxy;
 
   if(msRectOverlap(&reqextent, &covextent) == MS_FALSE) {
+    msWCSFreeCoverageMetadata(&cm);
     msSetError(MS_WCSERR, "Requested BBOX (%.15g,%.15g,%.15g,%.15g) is outside requested coverage BBOX (%.15g,%.15g,%.15g,%.15g)",
                "msWCSGetCoverage()",
                reqextent.minx, reqextent.miny, reqextent.maxx, reqextent.maxy,
@@ -1879,11 +1908,13 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
 
   /* check and make sure there is a format, and that it's valid (TODO: make sure in the layer metadata) */
   if(!params->format) {
+    msWCSFreeCoverageMetadata(&cm);
     msSetError( MS_WCSERR,  "Missing required FORMAT parameter.", "msWCSGetCoverage()" );
     return msWCSException(map, "MissingParameterValue", "format", params->version);
   }
   msApplyDefaultOutputFormats(map);
   if(msGetOutputFormatIndex(map,params->format) == -1) {
+    msWCSFreeCoverageMetadata(&cm);
     msSetError( MS_WCSERR,  "Unrecognized value for the FORMAT parameter.", "msWCSGetCoverage()" );
     return msWCSException(map, "InvalidParameterValue", "format",
                           params->version );
@@ -1916,6 +1947,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
     layerObj *maskLayer;
     outputFormatObj *altFormat;
     if(maskLayerIdx == -1) {
+      msWCSFreeCoverageMetadata(&cm);
       msSetError(MS_MISCERR, "Layer (%s) references unknown mask layer (%s)", "msDrawLayer()",
                  lp->name,lp->mask);
       return msWCSException(map, NULL, NULL, params->version );
@@ -1931,6 +1963,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
       maskLayer->maskimage= msImageCreate(map->width, map->height, altFormat,
                                           map->web.imagepath, map->web.imageurl, map->resolution, map->defresolution, NULL);
       if (!maskLayer->maskimage) {
+        msWCSFreeCoverageMetadata(&cm);
         msSetError(MS_MISCERR, "Unable to initialize mask image.", "msDrawLayer()");
         msFree(origImageType);
         return msWCSException(map, NULL, NULL, params->version );
@@ -1951,6 +1984,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
       maskLayer->status = origstatus;
       maskLayer->labelcache = origlabelcache;
       if(retcode != MS_SUCCESS) {
+        msWCSFreeCoverageMetadata(&cm);
         /* set the imagetype from the original outputformat back (it was removed by msSelectOutputFormat() */
         msFree(map->imagetype);
         map->imagetype = origImageType;
@@ -1980,22 +2014,27 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
   
   /* create the image object  */
   if(!map->outputformat) {
+    msWCSFreeCoverageMetadata(&cm);
     msSetError(MS_WCSERR, "The map outputformat is missing!", "msWCSGetCoverage()");
     return msWCSException(map, NULL, NULL, params->version );
   } else if( MS_RENDERER_RAWDATA(map->outputformat) || MS_RENDERER_PLUGIN(map->outputformat) ) {
     image = msImageCreate(map->width, map->height, map->outputformat, map->web.imagepath, map->web.imageurl, map->resolution, map->defresolution, NULL);
   } else {
+    msWCSFreeCoverageMetadata(&cm);
     msSetError(MS_WCSERR, "Map outputformat not supported for WCS!", "msWCSGetCoverage()");
     return msWCSException(map, NULL, NULL, params->version );
   }
 
-  if( image == NULL )
+  if( image == NULL ) {
+    msWCSFreeCoverageMetadata(&cm);
     return msWCSException(map, NULL, NULL, params->version );
+  }
   if( MS_RENDERER_RAWDATA(map->outputformat) ) {
     status = msDrawRasterLayerLow( map, lp, image, NULL );
   } else {
     status = MS_IMAGE_RENDERER(image)->getRasterBufferHandle(image,&rb);
     if(UNLIKELY(status == MS_FAILURE)) {
+      msWCSFreeCoverageMetadata(&cm);
       return MS_FAILURE;
     }
 
@@ -2003,6 +2042,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
     status = msDrawRasterLayerLow( map, lp, image, &rb );
   }
   if( status != MS_SUCCESS ) {
+    msWCSFreeCoverageMetadata(&cm);
     msFreeImage(image);
     return msWCSException(map, NULL, NULL, params->version );
   }
@@ -2028,6 +2068,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
       /* unfortunately, the image content type will have already been sent
          but that is hard for us to avoid.  The main error that could happen
          here is a misconfigured tmp directory or running out of space. */
+      msWCSFreeCoverageMetadata(&cm);
       return msWCSException(map, NULL, NULL, params->version );
     }
   }
@@ -2037,6 +2078,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage()", par
   msApplyOutputFormat(&(map->outputformat), NULL, MS_NOOVERRIDE, MS_NOOVERRIDE, MS_NOOVERRIDE);
   /* msFreeOutputFormat(format); */
 
+  msWCSFreeCoverageMetadata(&cm);
   return status;
 }
 #endif /* def USE_WCS_SVR */
@@ -2281,6 +2323,11 @@ int msWCSDispatch(mapObj *map, cgiRequestObj *request, owsRequestObj *ows_reques
 /************************************************************************/
 
 #ifdef USE_WCS_SVR
+
+void msWCSFreeCoverageMetadata(coverageMetadataObj *cm) {
+  msFree(cm->srs_epsg);
+}
+
 int msWCSGetCoverageMetadata( layerObj *layer, coverageMetadataObj *cm )
 {
   char  *srs_urn = NULL;
@@ -2291,8 +2338,10 @@ int msWCSGetCoverageMetadata( layerObj *layer, coverageMetadataObj *cm )
   /* -------------------------------------------------------------------- */
   /*      Get the SRS in WCS 1.0 format (eg. EPSG:n)                      */
   /* -------------------------------------------------------------------- */
-  if((cm->srs = msOWSGetEPSGProj(&(layer->projection), &(layer->metadata), "CO", MS_TRUE)) == NULL) {
-    if((cm->srs = msOWSGetEPSGProj(&(layer->map->projection), &(layer->map->web.metadata), "CO", MS_TRUE)) == NULL) {
+  msOWSGetEPSGProj(&(layer->projection), &(layer->metadata), "CO", MS_TRUE, &(cm->srs_epsg));
+  if(!cm->srs_epsg) {
+    msOWSGetEPSGProj(&(layer->map->projection), &(layer->map->web.metadata), "CO", MS_TRUE, &(cm->srs_epsg));
+    if(!cm->srs_epsg) {
       msSetError(MS_WCSERR, "Unable to determine the SRS for this layer, no projection defined and no metadata available.", "msWCSGetCoverageMetadata()");
       return MS_FAILURE;
     }
@@ -2534,7 +2583,7 @@ int msWCSGetCoverageMetadata( layerObj *layer, coverageMetadataObj *cm )
 
     msInitProjection(&proj); /* or bad things happen */
 
-    snprintf(projstring, sizeof(projstring), "init=epsg:%.20s", cm->srs+5);
+    snprintf(projstring, sizeof(projstring), "init=epsg:%.20s", cm->srs_epsg+5);
     if (msLoadProjectionString(&proj, projstring) != 0) return MS_FAILURE;
     msProjectRect(&proj, NULL, &(cm->llextent));
   }

--- a/mapwcs.h
+++ b/mapwcs.h
@@ -56,7 +56,7 @@ enum {
 ** Structure to hold metadata taken from the image or image tile index
 */
 typedef struct {
-  const char *srs;
+  char *srs_epsg;
   char srs_urn[500];
   rectObj extent, llextent;
   double geotransform[6];
@@ -97,6 +97,7 @@ int msWCSException(mapObj *map, const char *code, const char *locator,
                    const char *version);
 int msWCSIsLayerSupported(layerObj *layer);
 int msWCSGetCoverageMetadata( layerObj *layer, coverageMetadataObj *cm );
+void msWCSFreeCoverageMetadata(coverageMetadataObj *cm);
 void msWCSSetDefaultBandsRangeSetInfo( wcsParamsObj *params,
                                        coverageMetadataObj *cm,
                                        layerObj *lp );
@@ -210,7 +211,7 @@ typedef wcs20rasterbandMetadataObj * wcs20rasterbandMetadataObjPtr;
 
 typedef struct {
   char *native_format;    /* mime type of the native format */
-  const char *srs;
+  char *srs_epsg;
   char srs_uri[200];
   rectObj extent;
   double geotransform[6];

--- a/mapwcs11.c
+++ b/mapwcs11.c
@@ -347,6 +347,7 @@ static int msWCSGetCapabilities11_CoverageSummary(
                            format_list, ',' );
 
   msFree( format_list );
+  msWCSFreeCoverageMetadata(&cm);
 
   /* -------------------------------------------------------------------- */
   /*      Identifier (layer name)                                         */
@@ -871,6 +872,7 @@ msWCSDescribeCoverage_CoverageDescription11(
 
     msFree( format_list );
   }
+  msWCSFreeCoverageMetadata(&cm);
 
   return MS_SUCCESS;
 }

--- a/mapwcs20.c
+++ b/mapwcs20.c
@@ -2463,10 +2463,11 @@ static int msWCSGetCoverageMetadata20(layerObj *layer, wcs20coverageMetadataObj 
   if ( msCheckParentPointer(layer->map,"map") == MS_FAILURE )
     return MS_FAILURE;
 
-  if((cm->srs = msOWSGetEPSGProj(&(layer->projection),
-                                 &(layer->metadata), "CO", MS_TRUE)) == NULL) {
-    if((cm->srs = msOWSGetEPSGProj(&(layer->map->projection),
-                                   &(layer->map->web.metadata), "CO", MS_TRUE)) == NULL) {
+  msOWSGetEPSGProj(&(layer->projection), &(layer->metadata), "CO", MS_TRUE, &(cm->srs_epsg));
+  if(!cm->srs_epsg) {
+    msOWSGetEPSGProj(&(layer->map->projection),
+                                   &(layer->map->web.metadata), "CO", MS_TRUE, &cm->srs_epsg);
+    if(!cm->srs_epsg) {
       msSetError(MS_WCSERR, "Unable to determine the SRS for this layer, "
                  "no projection defined and no metadata available.",
                  "msWCSGetCoverageMetadata20()");
@@ -2943,6 +2944,7 @@ static int msWCSClearCoverageMetadata20(wcs20coverageMetadataObj *cm)
     }
   }
   msFree(cm->bands);
+  msFree(cm->srs_epsg);
   return MS_SUCCESS;
 }
 
@@ -4123,11 +4125,11 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage20()", p
   /************************************************************************/
 
   msInitProjection(&imageProj);
-  if (msLoadProjectionString(&imageProj, cm.srs) == -1) {
+  if (msLoadProjectionString(&imageProj, cm.srs_epsg) == -1) {
     msWCSClearCoverageMetadata20(&cm);
     msSetError(MS_WCSERR,
                "Error loading CRS %s.",
-               "msWCSGetCoverage20()", cm.srs);
+               "msWCSGetCoverage20()", cm.srs_epsg);
     return msWCSException(map, "InvalidParameterValue",
                           "projection", params->version);
   }
@@ -4169,7 +4171,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage20()", p
   /* if no subsetCRS was specified use the coverages CRS 
      (Requirement 27 of the WCS 2.0 specification) */
   if (!params->subsetcrs) {
-    params->subsetcrs = msStrdup(cm.srs);
+    params->subsetcrs = msStrdup(cm.srs_epsg);
   }
 
   if(EQUAL(params->subsetcrs, "imageCRS")) {

--- a/mapwfs.c
+++ b/mapwfs.c
@@ -358,8 +358,7 @@ int msWFSLocateSRSInList(const char *pszList, const char *srs)
 */
 static int msWFSGetFeatureApplySRS(mapObj *map, const char *srs, int nWFSVersion)
 {
-  const char *pszLayerSRS=NULL;
-  const char *pszMapSRS=NULL;
+  char *pszMapSRS=NULL;
   char *pszOutputSRS=NULL;
   layerObj *lp;
   int i;
@@ -374,7 +373,7 @@ static int msWFSGetFeatureApplySRS(mapObj *map, const char *srs, int nWFSVersion
    * make sure we reproject the map extent if a projection was 
    * already set 
    */
-  pszMapSRS = msOWSGetEPSGProj(&(map->projection), &(map->web.metadata), "FO", MS_TRUE);
+  msOWSGetEPSGProj(&(map->projection), &(map->web.metadata), "FO", MS_TRUE, &pszMapSRS);
   if(pszMapSRS && nWFSVersion >  OWS_1_0_0){
     projectionObj proj;
     msInitProjection(&proj);
@@ -387,6 +386,7 @@ static int msWFSGetFeatureApplySRS(mapObj *map, const char *srs, int nWFSVersion
 
   if (srs == NULL || nWFSVersion == OWS_1_0_0) {
     for (i=0; i<map->numlayers; i++) {
+      char *pszLayerSRS;
       lp = GET_LAYER(map, i);
       if (lp->status != MS_ON)
         continue;
@@ -394,7 +394,7 @@ static int msWFSGetFeatureApplySRS(mapObj *map, const char *srs, int nWFSVersion
       if (pszMapSRS)
         pszLayerSRS = pszMapSRS;
       else
-        pszLayerSRS = msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "FO", MS_TRUE);
+        msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "FO", MS_TRUE, &pszLayerSRS);
 
       if (pszLayerSRS == NULL) {
         msSetError(MS_WFSERR,
@@ -402,6 +402,7 @@ static int msWFSGetFeatureApplySRS(mapObj *map, const char *srs, int nWFSVersion
                    "msWFSGetFeature()");
         if (pszOutputSRS)
           msFree(pszOutputSRS);
+        /*pszMapSrs would also be NULL, no use freeing*/
         return MS_FAILURE;
       }
       if (pszOutputSRS == NULL)
@@ -412,39 +413,49 @@ static int msWFSGetFeatureApplySRS(mapObj *map, const char *srs, int nWFSVersion
                    "msWFSGetFeature()");
         if (pszOutputSRS)
           msFree(pszOutputSRS);
+        if(pszLayerSRS != pszMapSRS)
+          msFree(pszLayerSRS);
+        msFree(pszMapSRS);
         return MS_FAILURE;
       }
-
+      if(pszLayerSRS != pszMapSRS)
+        msFree(pszLayerSRS);
     }
   } else { /*srs is given so it should be valid for all layers*/
     /*get all the srs defined at the map level and check them aginst the srsName passed
       as argument*/
-    pszMapSRS = msOWSGetEPSGProj(&(map->projection), &(map->web.metadata), "FO", MS_FALSE);
+    msFree(pszMapSRS);
+    msOWSGetEPSGProj(&(map->projection), &(map->web.metadata), "FO", MS_FALSE, &pszMapSRS);
     if (pszMapSRS) {
       if (!msWFSLocateSRSInList(pszMapSRS, srs)) {
         msSetError(MS_WFSERR,
                    "Invalid GetFeature Request:Invalid SRS.  Please check the capabilities and reformulate your request.",
                    "msWFSGetFeature()");
+        msFree(pszMapSRS);
         return MS_FAILURE;
       }
       pszOutputSRS = msStrdup(srs);
     } else {
       for (i=0; i<map->numlayers; i++) {
+        char *pszLayerSRS=NULL;
         lp = GET_LAYER(map, i);
         if (lp->status != MS_ON)
           continue;
 
-        pszLayerSRS = msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "FO", MS_FALSE);
+        msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "FO", MS_FALSE, &pszLayerSRS);
         if (!pszLayerSRS) {
           msSetError(MS_WFSERR,
                      "Server config error: SRS must be set at least at the map or at the layer level.",
                      "msWFSGetFeature()");
+          msFree(pszMapSRS);
           return MS_FAILURE;
         }
         if (!msWFSLocateSRSInList(pszLayerSRS, srs)) {
           msSetError(MS_WFSERR,
                      "Invalid GetFeature Request:Invalid SRS.  Please check the capabilities and reformulate your request.",
                      "msWFSGetFeature()");
+          msFree(pszMapSRS);
+          msFree(pszLayerSRS);
           return MS_FAILURE;
         }
       }
@@ -481,8 +492,8 @@ static int msWFSGetFeatureApplySRS(mapObj *map, const char *srs, int nWFSVersion
     }
   }
 
-  if (pszOutputSRS)
-    msFree(pszOutputSRS);
+  msFree(pszOutputSRS);
+  msFree(pszMapSRS);
   return MS_SUCCESS;
 }
 
@@ -535,7 +546,7 @@ static layerObj* msWFSGetLayerByName(mapObj* map, owsRequestObj *ows_request, co
 int msWFSDumpLayer(mapObj *map, layerObj *lp)
 {
   rectObj ext;
-  const char *pszWfsSrs = NULL;
+  char *pszWfsSrs = NULL;
   projectionObj poWfs;
 
   msIO_printf("    <FeatureType>\n");
@@ -571,12 +582,12 @@ int msWFSDumpLayer(mapObj *map, layerObj *lp)
   /* each layer is advertized in its own projection as defined in the */
   /* layer's projection object or wfs_srs metadata. */
   /*  */
-  if (msOWSGetEPSGProj(&(map->projection),&(map->web.metadata),"FO",MS_TRUE) != NULL) {
-    /* Map has a SRS.  Use it for all layers. */
-    pszWfsSrs = msOWSGetEPSGProj(&(map->projection),&(map->web.metadata), "FO", MS_TRUE);
-  } else {
+  
+  /* if Map has a SRS,  Use it for all layers. */
+  msOWSGetEPSGProj(&(map->projection),&(map->web.metadata),"FO",MS_TRUE, &pszWfsSrs);
+  if(!pszWfsSrs) {
     /* Map has no SRS.  Use layer SRS or produce a warning. */
-    pszWfsSrs = msOWSGetEPSGProj(&(lp->projection),&(lp->metadata), "FO", MS_TRUE);
+    msOWSGetEPSGProj(&(lp->projection),&(lp->metadata), "FO", MS_TRUE, &pszWfsSrs);
   }
 
   msOWSPrintEncodeParam(stdout, "(at least one of) MAP.PROJECTION, LAYER.PROJECTION or wfs_srs metadata",
@@ -612,6 +623,7 @@ int msWFSDumpLayer(mapObj *map, layerObj *lp)
 
   msIO_printf("    </FeatureType>\n");
 
+  msFree(pszWfsSrs);
   return MS_SUCCESS;
 }
 
@@ -2044,15 +2056,17 @@ static int msWFSRunFilter(mapObj* map,
     if( nWFSVersion >= OWS_1_1_0 )
     {
           int bDefaultSRSNeedsAxisSwapping = MS_FALSE;
-          const char* srs = msOWSGetEPSGProj(&(map->projection),&(map->web.metadata),"FO",MS_TRUE);
+          char* srs;
+          msOWSGetEPSGProj(&(map->projection),&(map->web.metadata),"FO",MS_TRUE,&srs);
           if (!srs)
           {
-              srs = msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "FO", MS_TRUE);
+              msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "FO", MS_TRUE, &srs);
           }
           if ( srs && strncasecmp(srs, "EPSG:", 5) == 0 )
           {
               bDefaultSRSNeedsAxisSwapping = msIsAxisInverted(atoi(srs+5));
           }
+          msFree(srs);
           FLTDoAxisSwappingIfNecessary(psNode, bDefaultSRSNeedsAxisSwapping);
     }
 
@@ -2131,7 +2145,6 @@ static int msWFSRunBasicGetFeature(mapObj* map,
                                    const wfsParamsObj *paramsObj,
                                    int nWFSVersion)
 {
-    const char *pszMapSRS=NULL, *pszLayerSRS=NULL;
     rectObj ext;
     int status;
     
@@ -2140,12 +2153,14 @@ static int msWFSRunBasicGetFeature(mapObj* map,
     map->query.rect = map->extent;
     map->query.layer = lp->index;
 
-    /*if srsName was given for wfs 1.1.0, It is at this point loaded into the
-    map object and should be used*/
-    if(!paramsObj->pszSrs)
-        pszMapSRS = msOWSGetEPSGProj(&(map->projection), &(map->web.metadata), "FO", MS_TRUE);
 
     if (msOWSGetLayerExtent(map, lp, "FO", &ext) == MS_SUCCESS) {
+        char *pszMapSRS=NULL;
+        
+        /*if srsName was given for wfs 1.1.0, It is at this point loaded into the
+        map object and should be used*/
+        if(!paramsObj->pszSrs)
+          msOWSGetEPSGProj(&(map->projection), &(map->web.metadata), "FO", MS_TRUE, &pszMapSRS);
 
         /* For a single point layer, to avoid numerical precision issues */
         /* when reprojection is involved */
@@ -2164,16 +2179,19 @@ static int msWFSRunBasicGetFeature(mapObj* map,
             if (status != 0) {
                 msSetError(MS_WFSERR, "msLoadProjectionString() failed: %s",
                             "msWFSGetFeature()", pszMapSRS);
+                msFree(pszMapSRS);
                 return msWFSException(map, "mapserv", MS_OWS_ERROR_NO_APPLICABLE_CODE,
                                 paramsObj->pszVersion);
             }
+            msFree(pszMapSRS);
 
         }
 
         /*make sure that the layer projection is loaded.
             It could come from a ows/wfs_srs metadata*/
         if (lp->projection.numargs == 0) {
-            pszLayerSRS = msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "FO", MS_TRUE);
+            char *pszLayerSRS;
+            msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "FO", MS_TRUE, &pszLayerSRS);
             if (pszLayerSRS) {
                 if (strncmp(pszLayerSRS, "EPSG:", 5) == 0) {
                     if( nWFSVersion >= OWS_1_1_0 )
@@ -2182,6 +2200,7 @@ static int msWFSRunBasicGetFeature(mapObj* map,
                         msLoadProjectionString(&(lp->projection), pszLayerSRS);
                 }
             }
+            msFree(pszLayerSRS);
         }
 
         if (msProjectionsDiffer(&map->projection, &lp->projection) == MS_TRUE) {
@@ -2573,13 +2592,10 @@ this request. Check wfs/ows_enable_request settings.", "msWFSGetFeature()",
       /* issue at that point, since it can influence axis ordering */
       if( nWFSVersion >= OWS_2_0_0 && sBBoxSrs == NULL )
       {
-          const char* srsConst;
           projectionObj sProjTmp;
 
           msInitProjection(&sProjTmp);
-          srsConst = msOWSGetEPSGProj(&sProjTmp,&(map->web.metadata),"FO",MS_TRUE);
-          if( srsConst != NULL )
-              sBBoxSrs = msStrdup(srsConst);
+          msOWSGetEPSGProj(&sProjTmp,&(map->web.metadata),"FO",MS_TRUE, &sBBoxSrs);
           msFreeProjection(&sProjTmp);
       }
 

--- a/mapwfslayer.c
+++ b/mapwfslayer.c
@@ -424,9 +424,9 @@ static char *msBuildWFSLayerGetURL(mapObj *map, layerObj *lp, rectObj *bbox,
 	   * take care about the axis order for WFS 1.1
 	   */
 	  char *projUrn;
-	  const char *projEpsg;
+	  char *projEpsg;
 	  projUrn = msOWSGetProjURN(&(lp->projection), &(lp->metadata), "FO", 1);
-	  projEpsg = msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "FO", 1);
+	  msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "FO", 1, &projEpsg);
 
 	  /*
 	   * WFS 1.1 supports including the SRS in the BBOX parameter, should
@@ -455,6 +455,7 @@ static char *msBuildWFSLayerGetURL(mapObj *map, layerObj *lp, rectObj *bbox,
 	  }
 
 	  msFree(projUrn);
+	  msFree(projEpsg);
   }
 
   if (psParams->nMaxFeatures > 0)

--- a/mapwms.c
+++ b/mapwms.c
@@ -3133,7 +3133,6 @@ int msWMSGetCapabilities(mapObj *map, int nVersion, cgiRequestObj *req, owsReque
                                   OWS_WARN, ' ', NULL, NULL,
                                   "    <SRS>%s</SRS>\n", "");
       }
-      msFree(pszMapEPSG);
     } else {
       /* If map has no proj then every layer MUST have one or produce a warning */
       msOWSPrintEncodeParam(stdout, "MAP.PROJECTION (or wms_srs metadata)",

--- a/mapwmslayer.c
+++ b/mapwmslayer.c
@@ -584,25 +584,23 @@ msBuildWMSLayerURL(mapObj *map, layerObj *lp, int nRequestType,
   /* No need to set lp->proj if it's already set to the right EPSG code */
   msOWSGetEPSGProj(&(lp->projection), NULL, "MO", MS_TRUE, &pszTmp);
   if (pszTmp == NULL || strcasecmp(pszEPSG, pszTmp) != 0) {
+    char *ows_srs;
+    msOWSGetEPSGProj(NULL,&(lp->metadata), "MO", MS_FALSE, &ows_srs);
     msFree(pszTmp);
     /* no need to set lp->proj if it is already set and there is only
        one item in the _srs metadata for this layer - we will assume
        the projection block matches the _srs metadata (the search for ' '
        in ows_srs is a test to see if there are multiple EPSG: codes) */
-    if( lp->projection.numargs == 0 ) {
-      char *ows_srs;
-      msOWSGetEPSGProj(NULL,&(lp->metadata), "MO", MS_FALSE, &ows_srs);
-      if(ows_srs == NULL || (strchr(ows_srs,' ') != NULL) ) {
-        msFree(ows_srs);
-        if (strncasecmp(pszEPSG, "EPSG:", 5) == 0) {
-          char szProj[20];
-          snprintf(szProj, sizeof(szProj), "init=epsg:%s", pszEPSG+5);
-          if (msLoadProjectionString(&(lp->projection), szProj) != 0)
-            return MS_FAILURE;
-        } else {
-          if (msLoadProjectionString(&(lp->projection), pszEPSG) != 0)
-            return MS_FAILURE;
-        }
+    if( lp->projection.numargs == 0 || ows_srs == NULL || (strchr(ows_srs,' ') != NULL) ) {
+      msFree(ows_srs);
+      if (strncasecmp(pszEPSG, "EPSG:", 5) == 0) {
+        char szProj[20];
+        snprintf(szProj, sizeof(szProj), "init=epsg:%s", pszEPSG+5);
+        if (msLoadProjectionString(&(lp->projection), szProj) != 0)
+          return MS_FAILURE;
+      } else {
+        if (msLoadProjectionString(&(lp->projection), pszEPSG) != 0)
+          return MS_FAILURE;
       }
     }
   }

--- a/mapwmslayer.c
+++ b/mapwmslayer.c
@@ -415,8 +415,8 @@ msBuildWMSLayerURL(mapObj *map, layerObj *lp, int nRequestType,
                    wmsParamsObj *psWMSParams)
 {
 #ifdef USE_WMS_LYR
-  char *pszEPSG = NULL;
-  const char *pszVersion, *pszTmp, *pszRequestParam, *pszExceptionsParam,
+  char *pszEPSG = NULL, *pszTmp;
+  const char *pszVersion, *pszRequestParam, *pszExceptionsParam,
         *pszLayer=NULL, *pszQueryLayers=NULL;
   rectObj bbox;
   int bbox_width = map->width, bbox_height = map->height;
@@ -515,12 +515,12 @@ msBuildWMSLayerURL(mapObj *map, layerObj *lp, int nRequestType,
    * - If map SRS is valid for this layer then use it
    * - Otherwise request layer in its default SRS and we'll reproject later
    * ------------------------------------------------------------------ */
-  if ((pszEPSG = (char*)msOWSGetEPSGProj(&(map->projection),
-                                         NULL, NULL, MS_TRUE)) != NULL &&
-      (pszEPSG = msStrdup(pszEPSG)) != NULL &&
+  msOWSGetEPSGProj(&(map->projection),NULL, NULL, MS_TRUE, &pszEPSG);
+  if ( pszEPSG &&
       (strncasecmp(pszEPSG, "EPSG:", 5) == 0 ||
        strncasecmp(pszEPSG, "AUTO:", 5) == 0) ) {
-    const char *pszLyrEPSG, *pszFound;
+    const char *pszFound;
+    char *pszLyrEPSG;
     int nLen;
     char *pszPtr = NULL;
 
@@ -533,8 +533,7 @@ msBuildWMSLayerURL(mapObj *map, layerObj *lp, int nRequestType,
 
     nLen = strlen(pszEPSG);
 
-    pszLyrEPSG = msOWSGetEPSGProj(&(lp->projection), &(lp->metadata),
-                                  "MO", MS_FALSE);
+    msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "MO", MS_FALSE, &pszLyrEPSG);
 
     if (pszLyrEPSG == NULL ||
         (pszFound = strstr(pszLyrEPSG, pszEPSG)) == NULL ||
@@ -543,19 +542,18 @@ msBuildWMSLayerURL(mapObj *map, layerObj *lp, int nRequestType,
       free(pszEPSG);
       pszEPSG = NULL;
     }
+    msFree(pszLyrEPSG);
     if (pszEPSG && pszPtr)
       *pszPtr = ',';  /* Restore full AUTO:... definition */
   }
 
-  if (pszEPSG == NULL &&
-      ((pszEPSG = (char*)msOWSGetEPSGProj(&(lp->projection), &(lp->metadata),
-                                          "MO", MS_TRUE)) == NULL ||
-       (pszEPSG = msStrdup(pszEPSG)) == NULL ||
-       (strncasecmp(pszEPSG, "EPSG:", 5) != 0 &&
-        strncasecmp(pszEPSG, "AUTO:", 5) != 0 ) ) ) {
-    msSetError(MS_WMSCONNERR, "Layer must have an EPSG or AUTO projection code (in its PROJECTION object or wms_srs metadata)", "msBuildWMSLayerURL()");
-    if (pszEPSG) free(pszEPSG);
-    return MS_FAILURE;
+  if (pszEPSG == NULL) {
+      msOWSGetEPSGProj(&(lp->projection), &(lp->metadata),"MO", MS_TRUE, &pszEPSG);
+      if( pszEPSG == NULL || (strncasecmp(pszEPSG, "EPSG:", 5) != 0 && strncasecmp(pszEPSG, "AUTO:", 5) != 0) )  {
+        msSetError(MS_WMSCONNERR, "Layer must have an EPSG or AUTO projection code (in its PROJECTION object or wms_srs metadata)", "msBuildWMSLayerURL()");
+        msFree(pszEPSG);
+        return MS_FAILURE;
+      }
   }
 
   /* ------------------------------------------------------------------
@@ -584,26 +582,27 @@ msBuildWMSLayerURL(mapObj *map, layerObj *lp, int nRequestType,
    * Set layer SRS.
    * ------------------------------------------------------------------ */
   /* No need to set lp->proj if it's already set to the right EPSG code */
-  if ((pszTmp = msOWSGetEPSGProj(&(lp->projection), NULL, "MO", MS_TRUE)) == NULL ||
-      strcasecmp(pszEPSG, pszTmp) != 0) {
-    const char *ows_srs;
-
+  msOWSGetEPSGProj(&(lp->projection), NULL, "MO", MS_TRUE, &pszTmp);
+  if (pszTmp == NULL || strcasecmp(pszEPSG, pszTmp) != 0) {
+    msFree(pszTmp);
     /* no need to set lp->proj if it is already set and there is only
        one item in the _srs metadata for this layer - we will assume
        the projection block matches the _srs metadata (the search for ' '
        in ows_srs is a test to see if there are multiple EPSG: codes) */
-    if( lp->projection.numargs == 0
-        || (ows_srs = msOWSGetEPSGProj(NULL,&(lp->metadata), "MO", MS_FALSE)) == NULL
-        || (strchr(ows_srs,' ') != NULL) ) {
-      if (strncasecmp(pszEPSG, "EPSG:", 5) == 0) {
-        char szProj[20];
-        snprintf(szProj, sizeof(szProj), "init=epsg:%s", pszEPSG+5);
-
-        if (msLoadProjectionString(&(lp->projection), szProj) != 0)
-          return MS_FAILURE;
-      } else {
-        if (msLoadProjectionString(&(lp->projection), pszEPSG) != 0)
-          return MS_FAILURE;
+    if( lp->projection.numargs == 0 ) {
+      char *ows_srs;
+      msOWSGetEPSGProj(NULL,&(lp->metadata), "MO", MS_FALSE, &ows_srs);
+      if(ows_srs == NULL || (strchr(ows_srs,' ') != NULL) ) {
+        msFree(ows_srs);
+        if (strncasecmp(pszEPSG, "EPSG:", 5) == 0) {
+          char szProj[20];
+          snprintf(szProj, sizeof(szProj), "init=epsg:%s", pszEPSG+5);
+          if (msLoadProjectionString(&(lp->projection), szProj) != 0)
+            return MS_FAILURE;
+        } else {
+          if (msLoadProjectionString(&(lp->projection), pszEPSG) != 0)
+            return MS_FAILURE;
+        }
       }
     }
   }
@@ -676,11 +675,10 @@ msBuildWMSLayerURL(mapObj *map, layerObj *lp, int nRequestType,
   /*      consider restricting the BBOX to match the limits.              */
   /* -------------------------------------------------------------------- */
   if( bbox_width != 0 ) {
-    const char *ows_srs;
+    char *ows_srs;
     rectObj  layer_rect;
 
-    ows_srs = msOWSGetEPSGProj(&(lp->projection), &(lp->metadata),
-                               "MO", MS_FALSE);
+    msOWSGetEPSGProj(&(lp->projection), &(lp->metadata), "MO", MS_FALSE, &ows_srs);
 
     if( ows_srs && strchr(ows_srs,' ') == NULL
         && msOWSGetLayerExtent( map, lp, "MO", &layer_rect) == MS_SUCCESS ) {
@@ -711,6 +709,7 @@ msBuildWMSLayerURL(mapObj *map, layerObj *lp, int nRequestType,
         }
       }
     }
+    msFree(ows_srs);
   }
 
   /* -------------------------------------------------------------------- */


### PR DESCRIPTION
While adding Java mapscript to the test target I have received a segfault
in the WxS threaded tests that come with Java mapscript.

In an attempt to fix it I have, for now, blocked concurrent access to **msWMSGetCapabilities**, but this is probably too coarse.

The original pull request with discussion is here:
https://github.com/mapserver/mapserver/pull/4728

This ticket is a reminder to fix the EPSG parsing code, with a hint that the cause of the segfaults could be the use of the static variable **epsgCode** mentioned here:

http://lists.osgeo.org/pipermail/mapserver-dev/2013-August/013509.html

Once the EPSG parsing code has been fixed the locks around msWMSGetCapabilities must be removed.