### PR TITLE
using defined(WIN32) for c# windows mapscript specific

### DIFF
--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -58,6 +58,11 @@
 #include "pygdioctx/pygdioctx.h"
 #endif
 
+#if defined(WIN32) && defined(SWIGCSHARP)
+/* <windows.h> is needed for GetExceptionCode() for unhandled exception */
+#include <windows.h>
+#endif
+
 %}
 
 /* Problem with SWIG CSHARP typemap for pointers */

--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -210,7 +210,7 @@
 
   %newobject draw;
   imageObj *draw() {
-#if defined(SWIGWIN) && defined(SWIGCSHARP)
+#if defined(WIN32) && defined(SWIGCSHARP)
     __try {
         return msDrawMap(self, MS_FALSE);
     }    


### PR DESCRIPTION
SWIGWIN hashdef is not defined when building c# windows mapscript,
(contrary to what swig 1.3 documentation says)
so WIN32 hashdef is used instead