### PR TITLE
WFS request with chinese keywords does not have any result

### DIFF
--- a/maplayer.c
+++ b/maplayer.c
@@ -330,6 +330,14 @@ int msLayerNextShape(layerObj *layer, shapeObj *shape)
     if(rv != MS_SUCCESS) return rv;
 
     filter_passed = MS_TRUE;  /* By default accept ANY shape */
+    
+    /* attributes need to be iconv'd to UTF-8 before any filter logic is applied */
+    if(layer->encoding) {
+      rv = msLayerEncodeShapeAttributes(layer,shape);
+      if(rv != MS_SUCCESS)
+        return rv;
+    }
+    
     // if(layer->numitems > 0 && layer->iteminfo) {
       filter_passed = msEvalExpression(layer, shape, &(layer->filter), layer->filteritemindex);
     // }
@@ -344,11 +352,6 @@ int msLayerNextShape(layerObj *layer, shapeObj *shape)
       return rv;
   }
 
-  if(layer->encoding) {
-    rv = msLayerEncodeShapeAttributes(layer,shape);
-    if(rv != MS_SUCCESS)
-      return rv;
-  }
   
   return rv;
 }


### PR DESCRIPTION
My WFS request is the following code:
```
          <?xml version='1.0' encoding='UTF-8'?>
            <wfs:GetFeature  service='WFS' version='1.0.0' 
            xmlns:wfs='http://www.opengis.net/wfs' 
            xmlns:gml='http://www.opengis.net/gml' 
            xmlns:ogc='http://www.opengis.net/ogc' 
           xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' 
            xsi:schemaLocation='http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/wfs.xsd'>           
 <wfs:Query typeName='district' srsName='EPSG:3830'>
            <ogc:Filter>
            <ogc:PropertyIsEqualTo>
            <ogc:PropertyName>TField</ogc:PropertyName>
            <ogc:Literal>高新区</ogc:Literal>
            </ogc:PropertyIsEqualTo>
           </ogc:Filter>
           </wfs:Query>
           </wfs:GetFeature>
```
I want to search the feature that the value of field named TField is 高新区. I set the the layer's encoding to GBK, ant the above request returns the message that No matching record(s) found. however, if I set the keyword to english words or number, then I can get the result. The code above works well on Geoserver WFS, but can't got result from mapserver' WFS. Additional, "高新区" is Chinese words.