### PR TITLE
Fix type inconsistencies.

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -62,7 +62,7 @@ extern char *msyystring;
 extern char *msyybasepath;
 extern int msyyreturncomments;
 extern char *msyystring_buffer;
-extern char msyystring_icase;
+extern int msyystring_icase;
 
 extern int loadSymbol(symbolObj *s, char *symbolpath); /* in mapsymbol.c */
 extern void writeSymbol(symbolObj *s, FILE *stream); /* in mapsymbol.c */


### PR DESCRIPTION
I'm forwarding the patch by Michael Tautschnig, as reported in [Debian Bug #812685](https://bugs.debian.org/812685):
> During a rebuild of all Debian packages in a clean sid chroot (using cowbuilder
and pbuilder) the build failed with the following error. Please note that we
use our research compiler tool-chain (using tools from the cbmc package), which
permits extended reporting on type inconsistencies at link time.
> 
> ```
> mapfile.c line 65: error: conflicting types for variable `msyystring_icase'
> old definition in module `maplexer' file maplexer.l line 51
> signed int
> new definition in module `mapfile' file mapfile.c line 65
> char
> ```
> 
> Depending on endianness of the platform, the lexer may use the wrong byte of
msyystring_icase. The attached patch fixes this problem.

The patch has been included in the mapserver Debian package.