### PR TITLE
Fixed case when drawing legend shapes with style geomtransforms. (#5193)

### DIFF
--- a/mapgeomtransform.c
+++ b/mapgeomtransform.c
@@ -180,6 +180,15 @@ int msDrawTransformedShape(mapObj *map, imageObj *image, shapeObj *shape, styleO
 
       p.shape = shape; /* set a few parser globals (hence the lock) */
       p.expr = &(style->_geomtransform);
+
+      if(p.expr->tokens == NULL) { /* this could happen if drawing originates from legend code (#5193) */
+        status = msTokenizeExpression(p.expr, NULL, NULL);
+        if(status != MS_SUCCESS) {
+          msSetError(MS_MISCERR, "Unable to tokenize expression.", "msDrawTransformedShape()");
+          return MS_FAILURE;
+        }
+      }
+
       p.expr->curtoken = p.expr->tokens; /* reset */
       p.type = MS_PARSE_TYPE_SHAPE;
 

--- a/maplegend.c
+++ b/maplegend.c
@@ -123,6 +123,7 @@ int msDrawLegendIcon(mapObj *map, layerObj *lp, classObj *theclass,
   box.numlines = 1;
   box.line[0].point = box_point;
   box.line[0].numpoints = 5;
+  box.type = MS_SHAPE_POLYGON;
 
   box.line[0].point[0].x = dstX + polygon_contraction;
   box.line[0].point[0].y = dstY + polygon_contraction;
@@ -198,6 +199,7 @@ int msDrawLegendIcon(mapObj *map, layerObj *lp, classObj *theclass,
       zigzag.numlines = 1;
       zigzag.line[0].point = zigzag_point;
       zigzag.line[0].numpoints = 4;
+      zigzag.type = MS_SHAPE_LINE;
 
       zigzag.line[0].point[0].x = dstX + offset;
       zigzag.line[0].point[0].y = dstY + height - offset;


### PR DESCRIPTION
This should fix issue #5193. If OK, it should be applied to the 6.4 and 7.0 branches. --Steve