### PR TITLE
Labels leak through MASK

### DIFF
--- a/maplabel.c
+++ b/maplabel.c
@@ -372,6 +372,9 @@ int msAddLabelGroup(mapObj *map, int layerindex, int classindex, shapeObj *shape
           return MS_SUCCESS;
         }
 #endif
+      } else {
+        return MS_SUCCESS; /* label point does not intersect image extent, we cannot know if it intersects
+                             mask, so we discard it (#5237)*/
       }
     } else {
       msSetError(MS_MISCERR, "Layer (%s) references references a mask layer, but the selected renderer does not support them", "msAddLabelGroup()", layerPtr->name);
@@ -568,6 +571,9 @@ int msAddLabel(mapObj *map, labelObj *label, int layerindex, int classindex, sha
             return MS_SUCCESS;
           }
 #endif
+        } else {
+          return MS_SUCCESS; /* label point does not intersect image extent, we cannot know if it intersects
+                                mask, so we discard it (#5237)*/
         }
       } else if (labelpath) {
         int i = 0;
@@ -599,6 +605,10 @@ int msAddLabel(mapObj *map, labelObj *label, int layerindex, int classindex, sha
               return MS_SUCCESS;
             }
 #endif
+          } else {
+            msFreeLabelPathObj(labelpath);
+            return MS_SUCCESS; /* label point does not intersect image extent, we cannot know if it intersects
+                                  mask, so we discard it (#5237)*/
           }
         }
       }


### PR DESCRIPTION
It seems as if there is a border problem when masking out labelled layers. Sometimes labels at the very edge of the map leak through even when they should definitely be masked away.

Example:
Input dataset:
![image](https://cloud.githubusercontent.com/assets/1392735/12945884/c1c0473e-cff0-11e5-92f6-aa5fd5b3bcb2.png)

The above dataset masked with a mask which is a union of the polygons at the centre of the map:
![image](https://cloud.githubusercontent.com/assets/1392735/12945856/94bd5f24-cff0-11e5-97ce-65a402709ba7.png)
Geometries are correctly masked, but note the label "Nørre Broby".

Using v6.4.1