### PR TITLE
PHP Mapscript maprendering.c:998: msDrawTextSymbol: Assertion `ts->textpath' failed

### DIFF
--- a/mapdraw.c
+++ b/mapdraw.c
@@ -2056,6 +2056,11 @@ int msDrawPoint(mapObj *map, layerObj *layer, pointObj *point, imageObj *image, 
             return(MS_FAILURE);
           }
         } else {
+          if(UNLIKELY(MS_FAILURE == msComputeTextPath(map,ts))) {
+            freeTextSymbol(ts);
+            free(ts);
+            return MS_FAILURE;
+          }
           ret = msDrawTextSymbol(map,image,*point,ts);
           freeTextSymbol(ts);
           free(ts); 


### PR DESCRIPTION
Using current master branch, I am having trouble manually drawing points with text on a map when `LABELCACHE OFF`.  I do have better luck, but sometimes crashes with `LABELCACHE ON`.  I am attaching a reproducer for me.

[ms.zip](https://github.com/mapserver/mapserver/files/128737/ms.zip)

```
$ php l.php
php: /home/akrherz/BUILD/mapserver/maprendering.c:998: msDrawTextSymbol: Assertion `ts->textpath' failed.
Aborted (core dumped)
```

If I enable LABELCACHE, I get this
![l](https://cloud.githubusercontent.com/assets/210858/13020947/d9cb5e82-d19d-11e5-9940-916b6bbb8fed.png)

This was working for me with PHP mapscript 6.4.  My environment is RedHat 7.2 64bit, thanks
