### PR TITLE
Layer class LIST Expression

### DIFF
--- a/maputil.c
+++ b/maputil.c
@@ -485,9 +485,10 @@ int msEvalExpression(layerObj *layer, shapeObj *shape, expressionObj *expression
       }
       {
         char *start,*end;
+        int value_len = strlen(shape->values[itemindex]);
         start = expression->string;
         while((end = strchr(start,',')) != NULL) {
-          if(!strncmp(start,shape->values[itemindex],end-start)) return MS_TRUE;
+          if(value_len == end-start && !strncmp(start,shape->values[itemindex],end-start)) return MS_TRUE;
           start = end+1;
         }
         if(!strcmp(start,shape->values[itemindex])) return MS_TRUE;


### PR DESCRIPTION
It seems that each list item is compared to the string attribute item but it is not checked if it is the whole string. 
```
CLASSITEM 'event'  
EXPRESSION {rain,drizzle}
```
This expression above returns true if "event" string  attribute = "freezing rain"
A user suggested this fix
From  https://github.com/mapserver/mapserver/blob/157fa474ff8748ec42652f49dc4e2be4ca89042e/maputil.c#L490
Line 490 should probably read:
if(!strncmp(start,shape->values[itemindex],end-start) && shape->values[itemindex][end-start] == '\0') return MS_TRUE;

Here are other examples where Expression returns true, but might not be the same problem/solution
```
String=freezing rain
EXPRESSION {rain,freezing drizzle} #doc says no space should be used though
```
```
String=freezing rain
EXPRESSION {rain,freezing,drizzle}
```

