### PR TITLE
modify encodeurl logic for spaces (issue #5232)

### DIFF
--- a/mapstring.c
+++ b/mapstring.c
@@ -421,7 +421,7 @@ void msStringToLower(char *string)
 void msStringInitCap(char *string)
 {
   int i;
-  int start = 1; 
+  int start = 1;
   if (string != NULL) {
     for (i = 0; i < (int)strlen(string); i++) {
       if (string[i] == ' ')
@@ -444,7 +444,7 @@ void msStringInitCap(char *string)
 void msStringFirstCap(char *string)
 {
   int i;
-  int start = 1; 
+  int start = 1;
   if (string != NULL) {
     for (i = 0; i < (int)strlen(string); i++) {
       if (string[i] != ' ') {
@@ -1135,9 +1135,7 @@ char *msEncodeUrlExcept(const char *data, const char except)
   code = (char*)msSmallMalloc(strlen(data)+inc+1);
 
   for (j=code, i=data; *i!='\0'; i++, j++) {
-    if (*i == ' ')
-      *j = '+';
-    else if ( except != '\0' && *i == except ) {
+    if ( except != '\0' && *i == except ) {
       *j = except;
     } else if (msEncodeChar(*i)) {
       ch = *i;
@@ -1164,7 +1162,7 @@ char* msEscapeJSonString(const char* pszJSonString)
     char* pszRet;
     int i = 0, j = 0;
     static const char* pszHex = "0123456789ABCDEF";
-    
+
     pszRet = (char*) msSmallMalloc(strlen(pszJSonString) * 6 + 1);
     /* From http://www.json.org/ */
     for(i = 0; pszJSonString[i] != '\0'; i++)
@@ -1532,7 +1530,7 @@ char *msCaseReplaceSubstring(char *str, const char *old, const char *new)
   */
   if( (tmp_ptr = (char *) strcasestr(str, old)) == NULL)
     return(str);
-  
+
   if(new == NULL)
     new = "";
 
@@ -2157,7 +2155,7 @@ char* msStringEscape( const char * pszString )
 
   for (i=0; pszString[i]; i++)
     ncharstoescape += ((pszString[i] == '\"')||(pszString[i] == '\''));
-  
+
   if(!ncharstoescape) {
     return (char*)pszString;
   }


### PR DESCRIPTION
No feedback yet on the testing, but I can see from server stats that 3 people have fully downloaded the experimental build with this change.  This is the change referenced in the thread: https://lists.osgeo.org/pipermail/mapserver-users/2014-August/076879.html