### PR TITLE
Correct compile error with -Werror=format-security

### DIFF
--- a/apache/mod_mapserver.c
+++ b/apache/mod_mapserver.c
@@ -40,7 +40,7 @@ static int
 msIO_apacheError (void *cbData, void *data, int byteCount)
 {
   /* error reporting is done through the log file... */
-  ap_log_error (APLOG_MARK, APLOG_ERR, 0, NULL, (char*) data);
+  ap_log_error (APLOG_MARK, APLOG_ERR, 0, NULL, "%s", (char*) data);
   return strlen ((char*) data);
 }
 


### PR DESCRIPTION
Build fails when built with -Werror=format-security