### PR TITLE
Correct calls to MAX/MIN to MS_MAX/MS_MIN

### DIFF
--- a/mapcontour.c
+++ b/mapcontour.c
@@ -345,11 +345,11 @@ static int msContourLayerReadRaster(layerObj *layer, rectObj rect)
     ury = floor(ury / virtual_grid_step_y) * virtual_grid_step_y - (virtual_grid_step_x*5);
     lly = ceil(lly / virtual_grid_step_y) * virtual_grid_step_y + (virtual_grid_step_x*5);
     
-    src_xoff = MAX(0,(int) floor(llx+0.5));
-    src_yoff = MAX(0,(int) floor(ury+0.5));
-    src_xsize = MIN(MAX(0,(int) (urx - llx + 0.5)),
+    src_xoff = MS_MAX(0,(int) floor(llx+0.5));
+    src_yoff = MS_MAX(0,(int) floor(ury+0.5));
+    src_xsize = MS_MIN(MS_MAX(0,(int) (urx - llx + 0.5)),
                     GDALGetRasterXSize(clinfo->hOrigDS) - src_xoff);
-    src_ysize = MIN(MAX(0,(int) (lly - ury + 0.5)),
+    src_ysize = MS_MIN(MS_MAX(0,(int) (lly - ury + 0.5)),
                     GDALGetRasterYSize(clinfo->hOrigDS) - src_yoff);
 
     /* Update the geographic extent (buffer added) */
@@ -386,8 +386,8 @@ static int msContourLayerReadRaster(layerObj *layer, rectObj rect)
   } else {
     src_xoff = 0;
     src_yoff = 0;
-    dst_xsize = src_xsize = MIN(map->width,src_xsize);
-    dst_ysize = src_ysize = MIN(map->height,src_ysize);
+    dst_xsize = src_xsize = MS_MIN(map->width,src_xsize);
+    dst_ysize = src_ysize = MS_MIN(map->height,src_ysize);
     copyRect.minx = copyRect.miny = 0;
     copyRect.maxx = map->width;
     copyRect.maxy = map->height;
@@ -436,7 +436,7 @@ static int msContourLayerReadRaster(layerObj *layer, rectObj rect)
   adfGeoTransform[4] = 0;
   adfGeoTransform[5] = -dst_cellsize_y;
 
-  clinfo->cellsize = MAX(dst_cellsize_x, dst_cellsize_y);
+  clinfo->cellsize = MS_MAX(dst_cellsize_x, dst_cellsize_y);
   {
     char buf[64];
     sprintf(buf, "%lf", clinfo->cellsize);

--- a/mapdrawgdal.c
+++ b/mapdrawgdal.c
@@ -217,21 +217,21 @@ int msDrawRasterLayerGDAL(mapObj *map, layerObj *layer, imageObj *image,
     urx = GEO_TRANS(adfInvGeoTransform+0,copyRect.maxx,copyRect.maxy);
     ury = GEO_TRANS(adfInvGeoTransform+3,copyRect.maxx,copyRect.maxy);
 
-    src_xoff = MAX(0,(int) floor(llx+0.5));
-    src_yoff = MAX(0,(int) floor(ury+0.5));
-    src_xsize = MIN(MAX(0,(int) (urx - llx + 0.5)),
+    src_xoff = MS_MAX(0,(int) floor(llx+0.5));
+    src_yoff = MS_MAX(0,(int) floor(ury+0.5));
+    src_xsize = MS_MIN(MS_MAX(0,(int) (urx - llx + 0.5)),
                     GDALGetRasterXSize(hDS) - src_xoff);
-    src_ysize = MIN(MAX(0,(int) (lly - ury + 0.5)),
+    src_ysize = MS_MIN(MS_MAX(0,(int) (lly - ury + 0.5)),
                     GDALGetRasterYSize(hDS) - src_yoff);
 
     /* We want very small windows to use at least one source pixel (#4172) */
     if( src_xsize == 0 && (urx - llx) > 0.0 ) {
       src_xsize = 1;
-      src_xoff = MIN(src_xoff,GDALGetRasterXSize(hDS)-1);
+      src_xoff = MS_MIN(src_xoff,GDALGetRasterXSize(hDS)-1);
     }
     if( src_ysize == 0 && (lly - ury) > 0.0 ) {
       src_ysize = 1;
-      src_yoff = MIN(src_yoff,GDALGetRasterYSize(hDS)-1);
+      src_yoff = MS_MIN(src_yoff,GDALGetRasterYSize(hDS)-1);
     }
 
     if( src_xsize == 0 || src_ysize == 0 ) {
@@ -251,11 +251,11 @@ int msDrawRasterLayerGDAL(mapObj *map, layerObj *layer, imageObj *image,
 
     dst_lrx = (int) ((copyRect.maxx - mapRect.minx) / map->cellsize + 0.5);
     dst_lry = (int) ((mapRect.maxy - copyRect.miny) / map->cellsize + 0.5);
-    dst_lrx = MAX(0,MIN(image->width,dst_lrx));
-    dst_lry = MAX(0,MIN(image->height,dst_lry));
+    dst_lrx = MS_MAX(0,MS_MIN(image->width,dst_lrx));
+    dst_lry = MS_MAX(0,MS_MIN(image->height,dst_lry));
 
-    dst_xsize = MAX(0,MIN(image->width,dst_lrx - dst_xoff));
-    dst_ysize = MAX(0,MIN(image->height,dst_lry - dst_yoff));
+    dst_xsize = MS_MAX(0,MS_MIN(image->width,dst_lrx - dst_xoff));
+    dst_ysize = MS_MAX(0,MS_MIN(image->height,dst_lry - dst_yoff));
 
     if( dst_xsize == 0 || dst_ysize == 0 ) {
       if( layer->debug )
@@ -290,8 +290,8 @@ int msDrawRasterLayerGDAL(mapObj *map, layerObj *layer, imageObj *image,
   else {
     dst_xoff = src_xoff = 0;
     dst_yoff = src_yoff = 0;
-    dst_xsize = src_xsize = MIN(image->width,src_xsize);
-    dst_ysize = src_ysize = MIN(image->height,src_ysize);
+    dst_xsize = src_xsize = MS_MIN(image->width,src_xsize);
+    dst_ysize = src_ysize = MS_MIN(image->height,src_ysize);
   }
 
   /*
@@ -533,7 +533,7 @@ int msDrawRasterLayerGDAL(mapObj *map, layerObj *layer, imageObj *image,
       return -1;
     }
 
-    color_count = MIN(256,GDALGetColorEntryCount(hColorMap));
+    color_count = MS_MIN(256,GDALGetColorEntryCount(hColorMap));
     for(i=0; i < color_count; i++) {
       colorObj pixel;
       int colormap_index;
@@ -598,7 +598,7 @@ int msDrawRasterLayerGDAL(mapObj *map, layerObj *layer, imageObj *image,
     cmap_set = TRUE;
 #endif
 
-    color_count = MIN(256,GDALGetColorEntryCount(hColorMap));
+    color_count = MS_MIN(256,GDALGetColorEntryCount(hColorMap));
 
     for(i=0; i < color_count; i++) {
       GDALColorEntry sEntry;
@@ -889,8 +889,8 @@ static int ParseDefaultLUT( const char *lut_def, GByte *lut )
         lut_read++;
     }
 
-    this_in = MAX(0,MIN(255,this_in));
-    this_out = MAX(0,MIN(255,this_out));
+    this_in = MS_MAX(0,MS_MIN(255,this_in));
+    this_out = MS_MAX(0,MS_MIN(255,this_out));
 
     /* apply linear values from last in:out to this in:out */
     for( lut_i = last_in; lut_i <= this_in; lut_i++ ) {
@@ -1275,8 +1275,8 @@ LoadGDALImages( GDALDatasetH hDS, int band_numbers[4], int band_count,
           bMinMaxSet = TRUE;
         }
 
-        dfScaleMin = MIN(dfScaleMin,pafRawData[i]);
-        dfScaleMax = MAX(dfScaleMax,pafRawData[i]);
+        dfScaleMin = MS_MIN(dfScaleMin,pafRawData[i]);
+        dfScaleMax = MS_MAX(dfScaleMax,pafRawData[i]);
       }
 
       if( dfScaleMin == dfScaleMax )
@@ -1768,8 +1768,8 @@ msDrawRasterLayerGDAL_16BitClassification(
       fDataMin = fDataMax = pafRawData[i];
       bGotFirstValue = TRUE;
     } else {
-      fDataMin = MIN(fDataMin,pafRawData[i]);
-      fDataMax = MAX(fDataMax,pafRawData[i]);
+      fDataMin = MS_MIN(fDataMin,pafRawData[i]);
+      fDataMax = MS_MAX(fDataMax,pafRawData[i]);
     }
   }
 
@@ -2018,7 +2018,7 @@ int *msGetGDALBandList( layerObj *layer, void *hDS,
   /* -------------------------------------------------------------------- */
   if( CSLFetchNameValue( layer->processing, "BANDS" ) == NULL ) {
     if( max_bands > 0 )
-      *band_count = MIN(file_bands,max_bands);
+      *band_count = MS_MIN(file_bands,max_bands);
     else
       *band_count = file_bands;
 

--- a/maprasterquery.c
+++ b/maprasterquery.c
@@ -330,11 +330,11 @@ static void msRasterQueryAddPixel( layerObj *layer, pointObj *location,
   /* -------------------------------------------------------------------- */
   else {
     if( rlinfo->band_count >= 3 ) {
-      red = (int) MAX(0,MIN(255,values[0]));
-      green = (int) MAX(0,MIN(255,values[1]));
-      blue = (int) MAX(0,MIN(255,values[2]));
+      red = (int) MS_MAX(0,MS_MIN(255,values[0]));
+      green = (int) MS_MAX(0,MS_MIN(255,values[1]));
+      blue = (int) MS_MAX(0,MS_MIN(255,values[2]));
     } else {
-      red = green = blue = (int) MAX(0,MIN(255,values[0]));
+      red = green = blue = (int) MS_MAX(0,MS_MIN(255,values[0]));
     }
   }
 
@@ -454,35 +454,35 @@ msRasterQueryByRectLow(mapObj *map, layerObj *layer, GDALDatasetH hDS,
   /* top right */
   dfX = GEO_TRANS(adfInvGeoTransform  , searchrect.maxx, searchrect.maxy);
   dfY = GEO_TRANS(adfInvGeoTransform+3, searchrect.maxx, searchrect.maxy);
-  dfXMin = MIN(dfXMin,dfX);
-  dfXMax = MAX(dfXMax,dfX);
-  dfYMin = MIN(dfYMin,dfY);
-  dfYMax = MAX(dfYMax,dfY);
+  dfXMin = MS_MIN(dfXMin,dfX);
+  dfXMax = MS_MAX(dfXMax,dfX);
+  dfYMin = MS_MIN(dfYMin,dfY);
+  dfYMax = MS_MAX(dfYMax,dfY);
 
   /* bottom left */
   dfX = GEO_TRANS(adfInvGeoTransform  , searchrect.minx, searchrect.miny);
   dfY = GEO_TRANS(adfInvGeoTransform+3, searchrect.minx, searchrect.miny);
-  dfXMin = MIN(dfXMin,dfX);
-  dfXMax = MAX(dfXMax,dfX);
-  dfYMin = MIN(dfYMin,dfY);
-  dfYMax = MAX(dfYMax,dfY);
+  dfXMin = MS_MIN(dfXMin,dfX);
+  dfXMax = MS_MAX(dfXMax,dfX);
+  dfYMin = MS_MIN(dfYMin,dfY);
+  dfYMax = MS_MAX(dfYMax,dfY);
 
   /* bottom right */
   dfX = GEO_TRANS(adfInvGeoTransform  , searchrect.maxx, searchrect.miny);
   dfY = GEO_TRANS(adfInvGeoTransform+3, searchrect.maxx, searchrect.miny);
-  dfXMin = MIN(dfXMin,dfX);
-  dfXMax = MAX(dfXMax,dfX);
-  dfYMin = MIN(dfYMin,dfY);
-  dfYMax = MAX(dfYMax,dfY);
+  dfXMin = MS_MIN(dfXMin,dfX);
+  dfXMax = MS_MAX(dfXMax,dfX);
+  dfYMin = MS_MIN(dfYMin,dfY);
+  dfYMax = MS_MAX(dfYMax,dfY);
 
   /* -------------------------------------------------------------------- */
   /*      Trim the rectangle to the area of the file itself, but out      */
   /*      to the edges of the touched edge pixels.                        */
   /* -------------------------------------------------------------------- */
-  dfXMin = MAX(0.0,MIN(nRXSize,floor(dfXMin)));
-  dfYMin = MAX(0.0,MIN(nRYSize,floor(dfYMin)));
-  dfXMax = MAX(0.0,MIN(nRXSize,ceil(dfXMax)));
-  dfYMax = MAX(0.0,MIN(nRYSize,ceil(dfYMax)));
+  dfXMin = MS_MAX(0.0,MS_MIN(nRXSize,floor(dfXMin)));
+  dfYMin = MS_MAX(0.0,MS_MIN(nRYSize,floor(dfYMin)));
+  dfXMax = MS_MAX(0.0,MS_MIN(nRXSize,ceil(dfXMax)));
+  dfYMax = MS_MAX(0.0,MS_MIN(nRYSize,ceil(dfYMax)));
 
   /* -------------------------------------------------------------------- */
   /*      Convert to integer offset/size values.                          */

--- a/mapresample.c
+++ b/mapresample.c
@@ -34,8 +34,8 @@
 
 
 #ifndef MAX
-#  define MIN(a,b)      ((a<b) ? a : b)
-#  define MAX(a,b)      ((a>b) ? a : b)
+#  define MS_MIN(a,b)      ((a<b) ? a : b)
+#  define MS_MAX(a,b)      ((a>b) ? a : b)
 #endif
 
 #define SKIP_MASK(x,y) (mask_rb && !*(mask_rb->data.rgba.a+(y)*mask_rb->data.rgba.row_step+(x)*mask_rb->data.rgba.pixel_step))
@@ -319,7 +319,7 @@ msBilinearRasterResampler( imageObj *psSrcImage, rasterBufferObj *src_rb,
   int   nSrcYSize = psSrcImage->height;
   int   nFailedPoints = 0, nSetPoints = 0;
   double     *padfPixelSum;
-  int         bandCount = MAX(4,psSrcImage->format->bands);
+  int         bandCount = MS_MAX(4,psSrcImage->format->bands);
 
   padfPixelSum = (double *) msSmallMalloc(sizeof(double) * bandCount);
 
@@ -369,10 +369,10 @@ msBilinearRasterResampler( imageObj *psSrcImage, rasterBufferObj *src_rb,
         continue;
 
       /* Trim in stuff one pixel off the edge */
-      nSrcX = MAX(nSrcX,0);
-      nSrcY = MAX(nSrcY,0);
-      nSrcX2 = MIN(nSrcX2,nSrcXSize-1);
-      nSrcY2 = MIN(nSrcY2,nSrcYSize-1);
+      nSrcX = MS_MAX(nSrcX,0);
+      nSrcY = MS_MAX(nSrcY,0);
+      nSrcX2 = MS_MIN(nSrcX2,nSrcXSize-1);
+      nSrcY2 = MS_MIN(nSrcY2,nSrcYSize-1);
 
       memset( padfPixelSum, 0, sizeof(double) * bandCount);
 
@@ -407,10 +407,10 @@ msBilinearRasterResampler( imageObj *psSrcImage, rasterBufferObj *src_rb,
           int dst_rb_off = nDstX * dst_rb->data.rgba.pixel_step + nDstY * dst_rb->data.rgba.row_step;
           unsigned char red, green, blue, alpha;
 
-          red   = (unsigned char) MAX(0,MIN(255,padfPixelSum[0]));
-          green = (unsigned char) MAX(0,MIN(255,padfPixelSum[1]));
-          blue  = (unsigned char) MAX(0,MIN(255,padfPixelSum[2]));
-          alpha = (unsigned char)MAX(0,MIN(255,255.5*dfWeightSum));
+          red   = (unsigned char) MS_MAX(0,MS_MIN(255,padfPixelSum[0]));
+          green = (unsigned char) MS_MAX(0,MS_MIN(255,padfPixelSum[1]));
+          blue  = (unsigned char) MS_MAX(0,MS_MIN(255,padfPixelSum[2]));
+          alpha = (unsigned char)MS_MAX(0,MS_MIN(255,255.5*dfWeightSum));
 
           msAlphaBlendPM( red, green, blue, alpha,
                           dst_rb->data.rgba.r + dst_rb_off,
@@ -436,7 +436,7 @@ msBilinearRasterResampler( imageObj *psSrcImage, rasterBufferObj *src_rb,
               = (float) padfPixelSum[band];
           } else if( psSrcImage->format->imagemode == MS_IMAGEMODE_BYTE ) {
             psDstImage->img.raw_byte[dst_off]
-              = (unsigned char)MAX(0,MIN(255,padfPixelSum[band]));
+              = (unsigned char)MS_MAX(0,MS_MIN(255,padfPixelSum[band]));
           }
 
           dst_off += psDstImage->width*psDstImage->height;
@@ -489,14 +489,14 @@ msAverageSample( imageObj *psSrcImage, rasterBufferObj *src_rb,
   for( iY = nYMin; iY < nYMax; iY++ ) {
     double dfYCellMin, dfYCellMax;
 
-    dfYCellMin = MAX(iY,dfYMin);
-    dfYCellMax = MIN(iY+1,dfYMax);
+    dfYCellMin = MS_MAX(iY,dfYMin);
+    dfYCellMax = MS_MIN(iY+1,dfYMax);
 
     for( iX = nXMin; iX < nXMax; iX++ ) {
       double dfXCellMin, dfXCellMax, dfWeight;
 
-      dfXCellMin = MAX(iX,dfXMin);
-      dfXCellMax = MIN(iX+1,dfXMax);
+      dfXCellMin = MS_MAX(iX,dfXMin);
+      dfXCellMax = MS_MIN(iX+1,dfXMax);
 
       dfWeight = (dfXCellMax-dfXCellMin) * (dfYCellMax-dfYCellMin);
 
@@ -537,7 +537,7 @@ msAverageRasterResampler( imageObj *psSrcImage, rasterBufferObj *src_rb,
   int   nFailedPoints = 0, nSetPoints = 0;
   double     *padfPixelSum;
 
-  int         bandCount = MAX(4,psSrcImage->format->bands);
+  int         bandCount = MS_MAX(4,psSrcImage->format->bands);
 
   padfPixelSum = (double *) msSmallMalloc(sizeof(double) * bandCount);
 
@@ -573,19 +573,19 @@ msAverageRasterResampler( imageObj *psSrcImage, rasterBufferObj *src_rb,
         continue;
       }
 
-      dfXMin = MIN(MIN(x1[nDstX],x1[nDstX+1]),
-                   MIN(x2[nDstX],x2[nDstX+1]));
-      dfYMin = MIN(MIN(y1[nDstX],y1[nDstX+1]),
-                   MIN(y2[nDstX],y2[nDstX+1]));
-      dfXMax = MAX(MAX(x1[nDstX],x1[nDstX+1]),
-                   MAX(x2[nDstX],x2[nDstX+1]));
-      dfYMax = MAX(MAX(y1[nDstX],y1[nDstX+1]),
-                   MAX(y2[nDstX],y2[nDstX+1]));
+      dfXMin = MS_MIN(MS_MIN(x1[nDstX],x1[nDstX+1]),
+                   MS_MIN(x2[nDstX],x2[nDstX+1]));
+      dfYMin = MS_MIN(MS_MIN(y1[nDstX],y1[nDstX+1]),
+                   MS_MIN(y2[nDstX],y2[nDstX+1]));
+      dfXMax = MS_MAX(MS_MAX(x1[nDstX],x1[nDstX+1]),
+                   MS_MAX(x2[nDstX],x2[nDstX+1]));
+      dfYMax = MS_MAX(MS_MAX(y1[nDstX],y1[nDstX+1]),
+                   MS_MAX(y2[nDstX],y2[nDstX+1]));
 
-      dfXMin = MIN(MAX(dfXMin,0),psSrcImage->width+1);
-      dfYMin = MIN(MAX(dfYMin,0),psSrcImage->height+1);
-      dfXMax = MIN(MAX(-1,dfXMax),psSrcImage->width);
-      dfYMax = MIN(MAX(-1,dfYMax),psSrcImage->height);
+      dfXMin = MS_MIN(MS_MAX(dfXMin,0),psSrcImage->width+1);
+      dfYMin = MS_MIN(MS_MAX(dfYMin,0),psSrcImage->height+1);
+      dfXMax = MS_MIN(MS_MAX(-1,dfXMax),psSrcImage->width);
+      dfYMax = MS_MIN(MS_MAX(-1,dfYMax),psSrcImage->height);
 
       memset( padfPixelSum, 0, sizeof(double)*bandCount );
 
@@ -605,13 +605,13 @@ msAverageRasterResampler( imageObj *psSrcImage, rasterBufferObj *src_rb,
           unsigned char red, green, blue, alpha;
 
           red   = (unsigned char)
-                  MAX(0,MIN(255,padfPixelSum[0]+0.5));
+                  MS_MAX(0,MS_MIN(255,padfPixelSum[0]+0.5));
           green = (unsigned char)
-                  MAX(0,MIN(255,padfPixelSum[1]+0.5));
+                  MS_MAX(0,MS_MIN(255,padfPixelSum[1]+0.5));
           blue  = (unsigned char)
-                  MAX(0,MIN(255,padfPixelSum[2]+0.5));
+                  MS_MAX(0,MS_MIN(255,padfPixelSum[2]+0.5));
           alpha = (unsigned char)
-                  MAX(0,MIN(255,255*dfAlpha01+0.5));
+                  MS_MAX(0,MS_MIN(255,255*dfAlpha01+0.5));
 
           RB_MIX_PIXEL(dst_rb,nDstX,nDstY,
                        red, green, blue, alpha );
@@ -1121,10 +1121,10 @@ static int msTransformMapToSource( int nDstXSize, int nDstYSize,
       psSrcExtent->miny = psSrcExtent->maxy = y_out;
       bOutInit = 1;
     } else {
-      psSrcExtent->minx = MIN(psSrcExtent->minx, x_out);
-      psSrcExtent->maxx = MAX(psSrcExtent->maxx, x_out);
-      psSrcExtent->miny = MIN(psSrcExtent->miny, y_out);
-      psSrcExtent->maxy = MAX(psSrcExtent->maxy, y_out);
+      psSrcExtent->minx = MS_MIN(psSrcExtent->minx, x_out);
+      psSrcExtent->maxx = MS_MAX(psSrcExtent->maxx, x_out);
+      psSrcExtent->miny = MS_MIN(psSrcExtent->miny, y_out);
+      psSrcExtent->maxy = MS_MAX(psSrcExtent->maxy, y_out);
     }
   }
 
@@ -1141,10 +1141,10 @@ static int msTransformMapToSource( int nDstXSize, int nDstYSize,
     int nGrowAmountY = (int)
                        (psSrcExtent->maxy - psSrcExtent->miny)/EDGE_STEPS + 1;
 
-    psSrcExtent->minx = MAX(psSrcExtent->minx - nGrowAmountX,0);
-    psSrcExtent->miny = MAX(psSrcExtent->miny - nGrowAmountY,0);
-    psSrcExtent->maxx = MIN(psSrcExtent->maxx + nGrowAmountX,nSrcXSize);
-    psSrcExtent->maxy = MIN(psSrcExtent->maxy + nGrowAmountY,nSrcYSize);
+    psSrcExtent->minx = MS_MAX(psSrcExtent->minx - nGrowAmountX,0);
+    psSrcExtent->miny = MS_MAX(psSrcExtent->miny - nGrowAmountY,0);
+    psSrcExtent->maxx = MS_MIN(psSrcExtent->maxx + nGrowAmountX,nSrcXSize);
+    psSrcExtent->maxy = MS_MIN(psSrcExtent->maxy + nGrowAmountY,nSrcYSize);
   }
 
   return MS_TRUE;
@@ -1342,10 +1342,10 @@ int msResampleGDALToMap( mapObj *map, layerObj *layer, imageObj *image,
     sSrcExtent.maxy = ceil (sSrcExtent.maxy+1.0);
   }
 
-  sSrcExtent.minx = MAX(0,sSrcExtent.minx);
-  sSrcExtent.maxx = MIN(sSrcExtent.maxx, nSrcXSize );
-  sSrcExtent.miny = MAX(sSrcExtent.miny, 0 );
-  sSrcExtent.maxy = MIN(sSrcExtent.maxy, nSrcYSize );
+  sSrcExtent.minx = MS_MAX(0,sSrcExtent.minx);
+  sSrcExtent.maxx = MS_MIN(sSrcExtent.maxx, nSrcXSize );
+  sSrcExtent.miny = MS_MAX(sSrcExtent.miny, 0 );
+  sSrcExtent.maxy = MS_MIN(sSrcExtent.maxy, nSrcYSize );
 
   if( sSrcExtent.maxx <= sSrcExtent.minx
       || sSrcExtent.maxy <= sSrcExtent.miny ) {
@@ -1383,9 +1383,9 @@ int msResampleGDALToMap( mapObj *map, layerObj *layer, imageObj *image,
   else
     sDummyMap.cellsize = dfNominalCellSize;
 
-  nLoadImgXSize = MAX(1, (int) (sSrcExtent.maxx - sSrcExtent.minx)
+  nLoadImgXSize = MS_MAX(1, (int) (sSrcExtent.maxx - sSrcExtent.minx)
                       * (dfNominalCellSize / sDummyMap.cellsize));
-  nLoadImgYSize = MAX(1, (int) (sSrcExtent.maxy - sSrcExtent.miny)
+  nLoadImgYSize = MS_MAX(1, (int) (sSrcExtent.maxy - sSrcExtent.miny)
                       * (dfNominalCellSize / sDummyMap.cellsize));
 
   /*

--- a/mapstring.c
+++ b/mapstring.c
@@ -135,7 +135,7 @@ char *strrstr(char *string, char *find)
  * Appends src to string dst of size siz (unlike strncat, siz is the
  * full size of dst, not space left).  At most siz-1 characters
  * will be copied.  Always NUL terminates (unless siz <= strlen(dst)).
- * Returns strlen(src) + MIN(siz, strlen(initial dst)).
+ * Returns strlen(src) + MS_MIN(siz, strlen(initial dst)).
  * If retval >= siz, truncation occurred.
  */
 size_t strlcat(char *dst, const char *src, size_t siz)

--- a/mapwcs20.c
+++ b/mapwcs20.c
@@ -4189,8 +4189,8 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage20()", p
             + (orig_bbox.maxx+1) * cm.geotransform[1]
             + (orig_bbox.maxy+1) * cm.geotransform[2];
 
-      subsets.minx = MIN(x_1, x_2);
-      subsets.maxx = MAX(x_1, x_2);
+      subsets.minx = MS_MIN(x_1, x_2);
+      subsets.maxx = MS_MAX(x_1, x_2);
     }
     if(subsets.miny != -DBL_MAX || subsets.maxy != DBL_MAX) {
       y_1 = cm.geotransform[3]
@@ -4201,8 +4201,8 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage20()", p
             + orig_bbox.minx * cm.geotransform[4]
             + orig_bbox.miny * cm.geotransform[5];
 
-      subsets.miny = MIN(y_1, y_2);
-      subsets.maxy = MAX(y_1, y_2);
+      subsets.miny = MS_MIN(y_1, y_2);
+      subsets.maxy = MS_MAX(y_1, y_2);
     }
   } else { /* if crs is not the 'imageCRS' */
     projectionObj subsetProj;
@@ -4241,10 +4241,10 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage20()", p
   }
 
   /* write combined bounding box */
-  bbox.minx = MAX(subsets.minx, map->extent.minx);
-  bbox.miny = MAX(subsets.miny, map->extent.miny);
-  bbox.maxx = MIN(subsets.maxx, map->extent.maxx);
-  bbox.maxy = MIN(subsets.maxy, map->extent.maxy);
+  bbox.minx = MS_MAX(subsets.minx, map->extent.minx);
+  bbox.miny = MS_MAX(subsets.miny, map->extent.miny);
+  bbox.maxx = MS_MIN(subsets.maxx, map->extent.maxx);
+  bbox.maxy = MS_MIN(subsets.maxy, map->extent.maxy);
 
   /* check if we are overspecified  */
   if ((params->width != 0 &&  params->resolutionX != MS_WCS20_UNBOUNDED)
@@ -4620,10 +4620,10 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage20()", p
     tmpCm.xresolution = map->gt.geotransform[1];
     tmpCm.yresolution = map->gt.geotransform[5];
 
-    tmpCm.extent.minx = MIN(map->gt.geotransform[0], map->gt.geotransform[0] + map->width * tmpCm.xresolution);
-    tmpCm.extent.miny = MIN(map->gt.geotransform[3], map->gt.geotransform[3] + map->height * tmpCm.yresolution);
-    tmpCm.extent.maxx = MAX(map->gt.geotransform[0], map->gt.geotransform[0] + map->width * tmpCm.xresolution);
-    tmpCm.extent.maxy = MAX(map->gt.geotransform[3], map->gt.geotransform[3] + map->height * tmpCm.yresolution);
+    tmpCm.extent.minx = MS_MIN(map->gt.geotransform[0], map->gt.geotransform[0] + map->width * tmpCm.xresolution);
+    tmpCm.extent.miny = MS_MIN(map->gt.geotransform[3], map->gt.geotransform[3] + map->height * tmpCm.yresolution);
+    tmpCm.extent.maxx = MS_MAX(map->gt.geotransform[0], map->gt.geotransform[0] + map->width * tmpCm.xresolution);
+    tmpCm.extent.maxy = MS_MAX(map->gt.geotransform[3], map->gt.geotransform[3] + map->height * tmpCm.yresolution);
 
     swapAxes = msWCSSwapAxes20(srs_uri);
     msFree(srs_uri);

--- a/mapwmslayer.c
+++ b/mapwmslayer.c
@@ -698,7 +698,7 @@ msBuildWMSLayerURL(mapObj *map, layerObj *lp, int nRequestType,
       else {
         double cellsize_x = (bbox.maxx-bbox.minx) / bbox_width;
         double cellsize_y = (bbox.maxy-bbox.miny) / bbox_height;
-        double cellsize = MIN(cellsize_x,cellsize_y);
+        double cellsize = MS_MIN(cellsize_x,cellsize_y);
 
         msRectIntersect( &bbox, &layer_rect );
 


### PR DESCRIPTION
As per https://github.com/mapserver/mapserver/pull/5247#issuecomment-186087171 this renames instances of MAX() and MIN() to MS_MAX() and MS_MIN() respectively. Compiling with this patch goes without issue.