### PR TITLE
Fix format-security errors with swig and java and ruby

### DIFF
--- a/mapscript/mserror.i
+++ b/mapscript/mserror.i
@@ -29,7 +29,7 @@
         char* msg = msGetErrorString(";");
         int ms_errorcode = ms_error->code;
         if (msg) {
-			snprintf(ms_message, MAX_ERROR_LEN, msg);
+			snprintf(ms_message, MAX_ERROR_LEN, "%s", msg);
 			free(msg);
 		}
         else sprintf(ms_message, "Unknown message");

--- a/mapscript/ruby/rbmodule.i
+++ b/mapscript/ruby/rbmodule.i
@@ -81,22 +81,22 @@ static void _raise_ms_exception() {
     
     switch (errcode) {
         case MS_IOERR:
-            rb_raise(rb_eIOError, errmsg);
+            rb_raise(rb_eIOError, errmsg, "%s");
             break;
         case MS_MEMERR:
-            rb_raise(rb_eNoMemError, errmsg);
+            rb_raise(rb_eNoMemError, errmsg, "%s");
             break;
         case MS_TYPEERR:
-            rb_raise(rb_eTypeError, errmsg);
+            rb_raise(rb_eTypeError, errmsg, "%s");
             break;
         case MS_EOFERR:
-            rb_raise(rb_eEOFError, errmsg);
+            rb_raise(rb_eEOFError, errmsg, "%s");
             break;
         case MS_CHILDERR:
-            rb_raise(MSExc_MapServerChildError, errmsg);
+            rb_raise(MSExc_MapServerChildError, errmsg, "%s");
             break;
         default:
-            rb_raise(MSExc_MapServerError, errmsg);
+            rb_raise(MSExc_MapServerError, errmsg, "%s");
             break;
     }
 


### PR DESCRIPTION
Can compile java and ruby mapscript extension with gcc's
`-Werror=format-security` option.