### PR TITLE
Empty response is returned for GeoJSON when no features

### DIFF
--- a/mapogroutput.c
+++ b/mapogroutput.c
@@ -869,7 +869,7 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
     int  reproject = MS_FALSE;
     int  nFirstOGRFieldIndex = -1;
 
-    if( !layer->resultcache || layer->resultcache->numresults == 0 )
+    if( !layer->resultcache )
       continue;
 
     /* -------------------------------------------------------------------- */


### PR DESCRIPTION
When using GeoJSON as output format with the OGR GeoJSON driver, an empty response (`Content-Length: 0`) is returned when no features match a query.

For GML an empty feature collection is returned, I would expect the same for GeoJSON. GeoServer does it this way and OpenLayers 3 also expects an empty feature collection.