### PR TITLE
Min/Max scale values incorrectly formatted (python Mapscript)

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -541,7 +541,7 @@ static void writeNumber(FILE *stream, int indent, const char *name, double defau
 {
   if(number == defaultNumber) return; /* don't output default */
   writeIndent(stream, ++indent);
-  msIO_fprintf(stream, "%s %g\n", name, number);
+  msIO_fprintf(stream, "%s %.15g\n", name, number);
 }
 
 static void writeCharacter(FILE *stream, int indent, const char *name, const char defaultCharacter, char character)


### PR DESCRIPTION
If I set a min or max scale in Mapscript (python) using

```
k.maxscaledenom = 5000000000.0
```

And then generate the mapfile using

```
m.save()
```

The resulting value is formatted as:

```
MAXSCALEDENOM 5e+09
```

Which means the annotation layer isn't rendered until I replace it with:

```
MAXSCALEDENOM 5000000000
```

Is there anyway to control the format of these values when using save()?

Thanks