### PR TITLE
Avoid calling msProjectionsDiffer over and over again

### DIFF
--- a/mapchart.c
+++ b/mapchart.c
@@ -250,10 +250,8 @@ int getNextShape(mapObj *map, layerObj *layer, double *values, int *nvalues, sty
   status = msLayerNextShape(layer, shape);
   if(status == MS_SUCCESS) {
 #ifdef USE_PROJ
-    if(layer->project && msProjectionsDiffer(&(layer->projection), &(map->projection)))
+    if(layer->project)
       msProjectShape(&layer->projection, &map->projection, shape);
-    else
-      layer->project = MS_FALSE;
 #endif
 
     if(msBindLayerToShape(layer, shape, MS_DRAWMODE_FEATURES|MS_DRAWMODE_LABELS) != MS_SUCCESS)
@@ -363,6 +361,9 @@ int msDrawPieChartLayer(mapObj *map, layerObj *layer, imageObj *image)
       return MS_FAILURE;
     }
   }
+#ifdef USE_PROJ
+  layer->project = msProjectionsDiffer(&(layer->projection), &(map->projection));
+#endif
   /* step through the target shapes */
   msInitShape(&shape);
 

--- a/mapgraticule.c
+++ b/mapgraticule.c
@@ -205,10 +205,9 @@ int msGraticuleLayerWhichShapes(layerObj *layer, rectObj rect, int isQuery)
     pInfo->pboundinglines[0].point[1].y = rectMapCoordinates.maxy;
 
 #ifdef USE_PROJ
-    if(layer->project && msProjectionsDiffer(&(layer->projection), &(layer->map->projection)))
+    layer->project = msProjectionsDiffer(&(layer->projection), &(layer->map->projection));
+    if(layer->project)
       msProjectLine(&layer->map->projection, &layer->projection, &pInfo->pboundinglines[0]);
-    else
-      layer->project = MS_FALSE;
 #endif
 
     /*
@@ -222,10 +221,8 @@ int msGraticuleLayerWhichShapes(layerObj *layer, rectObj rect, int isQuery)
     pInfo->pboundinglines[1].point[1].y = rectMapCoordinates.miny;
 
 #ifdef USE_PROJ
-    if(layer->project && msProjectionsDiffer(&(layer->projection), &(layer->map->projection)))
+    if(layer->project)
       msProjectLine(&layer->map->projection, &layer->projection, &pInfo->pboundinglines[1]);
-    else
-      layer->project = MS_FALSE;
 #endif
 
     /*
@@ -239,10 +236,8 @@ int msGraticuleLayerWhichShapes(layerObj *layer, rectObj rect, int isQuery)
     pInfo->pboundinglines[2].point[1].y   = rectMapCoordinates.maxy;
 
 #ifdef USE_PROJ
-    if(layer->project && msProjectionsDiffer(&(layer->projection), &(layer->map->projection)))
+    if(layer->project)
       msProjectLine(&layer->map->projection, &layer->projection, &pInfo->pboundinglines[2]);
-    else
-      layer->project = MS_FALSE;
 #endif
 
     /*
@@ -256,10 +251,8 @@ int msGraticuleLayerWhichShapes(layerObj *layer, rectObj rect, int isQuery)
     pInfo->pboundinglines[3].point[1].y = rectMapCoordinates.maxy;
 
 #ifdef USE_PROJ
-    if(layer->project && msProjectionsDiffer(&(layer->projection), &(layer->map->projection)))
+    if(layer->project)
       msProjectLine(&layer->map->projection, &layer->projection, &pInfo->pboundinglines[3]);
-    else
-      layer->project = MS_FALSE;
 #endif
   }
 
@@ -680,7 +673,7 @@ graticuleIntersectionObj *msGraticuleLayerGetIntersectionPoints(mapObj *map,
     msCopyShape(&shapegrid, &tmpshape);
     /* status = msDrawShape(map, layer, &tmpshape, image, -1); */
 
-    if(layer->project && msProjectionsDiffer(&(layer->projection), &(map->projection)))
+    if(layer->project)
       msProjectShape(&layer->projection, &map->projection, &shapegrid);
 
     msClipPolylineRect(&shapegrid, cliprect);
@@ -1045,7 +1038,7 @@ static int _AdjustLabelPosition( layerObj *pLayer, shapeObj *pShape, msGraticule
   ptPoint = pShape->line->point[0];
 
 #ifdef USE_PROJ
-  if(pLayer->project && msProjectionsDiffer( &pLayer->projection, &pLayer->map->projection ))
+  if(pLayer->project)
     msProjectShape( &pLayer->projection, &pLayer->map->projection, pShape );
 #endif
 
@@ -1087,7 +1080,7 @@ static int _AdjustLabelPosition( layerObj *pLayer, shapeObj *pShape, msGraticule
     msTransformPixelToShape( pShape, pLayer->map->extent, pLayer->map->cellsize );
 
 #ifdef USE_PROJ
-  if(pLayer->project && msProjectionsDiffer( &pLayer->map->projection, &pLayer->projection ))
+  if(pLayer->project)
     msProjectShape( &pLayer->map->projection, &pLayer->projection, pShape );
 #endif
 

--- a/mapogroutput.c
+++ b/mapogroutput.c
@@ -883,7 +883,6 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
     gmlItemListObj *item_list = NULL;
     const char *value;
     char *pszWKT;
-    int  reproject = MS_FALSE;
     int  nFirstOGRFieldIndex = -1;
     const char *pszFeatureid = NULL;
 
@@ -893,11 +892,9 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
     /* -------------------------------------------------------------------- */
     /*      Will we need to reproject?                                      */
     /* -------------------------------------------------------------------- */
-    if(layer->transform == MS_TRUE
-        && layer->project
-        && msProjectionsDiffer(&(layer->projection),
-                               &(layer->map->projection)) )
-      reproject = MS_TRUE;
+    if(layer->transform == MS_TRUE)
+        layer->project = msProjectionsDiffer(&(layer->projection),
+                               &(layer->map->projection));
 
     /* -------------------------------------------------------------------- */
     /*      Establish the geometry type to use for the created layer.       */
@@ -1119,7 +1116,7 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
         }
       }
 
-      if( reproject ) {
+      if( layer->project ) {
         status =
           msProjectShape(&layer->projection, &layer->map->projection,
                          &resultshape);

--- a/mapquery.c
+++ b/mapquery.c
@@ -762,10 +762,9 @@ int msQueryByFilter(mapObj *map)
 
     search_rect = map->query.rect;
 #ifdef USE_PROJ
-    if(lp->project && msProjectionsDiffer(&(lp->projection), &(map->projection))) {
+    lp->project = msProjectionsDiffer(&(lp->projection), &(map->projection));
+    if(lp->project)
       msProjectRect(&(map->projection), &(lp->projection), &search_rect); /* project the searchrect to source coords */
-    } else
-      lp->project = MS_FALSE;
 #endif
 
     status = msLayerWhichShapes(lp, search_rect, MS_TRUE);
@@ -809,10 +808,8 @@ int msQueryByFilter(mapObj *map)
       }
 
 #ifdef USE_PROJ
-      if(lp->project && msProjectionsDiffer(&(lp->projection), &(map->projection)))
+      if(lp->project)
         msProjectShape(&(lp->projection), &(map->projection), &shape);
-      else
-        lp->project = MS_FALSE;
 #endif
 
       /* Should we skip this feature? */
@@ -979,10 +976,9 @@ int msQueryByRect(mapObj *map)
     }
 
 #ifdef USE_PROJ
-    if(lp->project && msProjectionsDiffer(&(lp->projection), &(map->projection)))
+    lp->project = msProjectionsDiffer(&(lp->projection), &(map->projection));
+    if(lp->project)
       msProjectRect(&(map->projection), &(lp->projection), &searchrect); /* project the searchrect to source coords */
-    else
-      lp->project = MS_FALSE;
 #endif
 
     status = msLayerWhichShapes(lp, searchrect, MS_TRUE);
@@ -1031,10 +1027,8 @@ int msQueryByRect(mapObj *map)
       }
 
 #ifdef USE_PROJ
-      if(lp->project && msProjectionsDiffer(&(lp->projection), &(map->projection)))
+      if(lp->project)
         msProjectShape(&(lp->projection), &(map->projection), &shape);
-      else
-        lp->project = MS_FALSE;
 #endif
 
       if(msRectContained(&shape.bounds, &searchrectInMapProj) == MS_TRUE) { /* if the whole shape is in, don't intersect */
@@ -1142,7 +1136,7 @@ int msQueryByFeatures(mapObj *map)
 
   /* conditions may have changed since this layer last drawn, so set
      layer->project true to recheck projection needs (Bug #673) */
-  slp->project = MS_TRUE;
+  slp->project = msProjectionsDiffer(&(slp->projection), &(map->projection));
 
   if(map->query.layer < 0 || map->query.layer >= map->numlayers)
     start = map->numlayers-1;
@@ -1171,7 +1165,7 @@ int msQueryByFeatures(mapObj *map)
 
     /* conditions may have changed since this layer last drawn, so set
        layer->project true to recheck projection needs (Bug #673) */
-    lp->project = MS_TRUE;
+    lp->project = msProjectionsDiffer(&(lp->projection), &(map->projection));
 
     /* free any previous search results, do it now in case one of the next few tests fail */
     if(lp->resultcache) {
@@ -1234,11 +1228,8 @@ int msQueryByFeatures(mapObj *map)
       }
 
 #ifdef USE_PROJ
-      if(slp->project && msProjectionsDiffer(&(slp->projection), &(map->projection))) {
+      if(slp->project)
         msProjectShape(&(slp->projection), &(map->projection), &selectshape);
-        msComputeBounds(&selectshape); /* recompute the bounding box AFTER projection */
-      } else
-        slp->project = MS_FALSE;
 #endif
 
       /* identify target shapes */
@@ -1250,10 +1241,8 @@ int msQueryByFeatures(mapObj *map)
       searchrect.maxy += tolerance;
 
 #ifdef USE_PROJ
-      if(lp->project && msProjectionsDiffer(&(lp->projection), &(map->projection)))
+      if(lp->project)
         msProjectRect(&(map->projection), &(lp->projection), &searchrect); /* project the searchrect to source coords */
-      else
-        lp->project = MS_FALSE;
 #endif
 
       status = msLayerWhichShapes(lp, searchrect, MS_TRUE);
@@ -1309,10 +1298,8 @@ int msQueryByFeatures(mapObj *map)
         }
 
 #ifdef USE_PROJ
-        if(lp->project && msProjectionsDiffer(&(lp->projection), &(map->projection)))
+        if(lp->project)
           msProjectShape(&(lp->projection), &(map->projection), &shape);
-        else
-          lp->project = MS_FALSE;
 #endif
 
         switch(selectshape.type) { /* may eventually support types other than polygon on line */
@@ -1545,10 +1532,9 @@ int msQueryByPoint(mapObj *map)
     /* identify target shapes */
     searchrect = rect;
 #ifdef USE_PROJ
-    if(lp->project && msProjectionsDiffer(&(lp->projection), &(map->projection)))
+    lp->project = msProjectionsDiffer(&(lp->projection), &(map->projection));
+    if(lp->project)
       msProjectRect(&(map->projection), &(lp->projection), &searchrect); /* project the searchrect to source coords */
-    else
-      lp->project = MS_FALSE;
 #endif
     status = msLayerWhichShapes(lp, searchrect, MS_TRUE);
     if(status == MS_DONE) { /* no overlap */
@@ -1595,10 +1581,8 @@ int msQueryByPoint(mapObj *map)
       }
 
 #ifdef USE_PROJ
-      if(lp->project && msProjectionsDiffer(&(lp->projection), &(map->projection)))
+      if(lp->project)
         msProjectShape(&(lp->projection), &(map->projection), &shape);
-      else
-        lp->project = MS_FALSE;
 #endif
 
       d = msDistancePointToShape(&(map->query.point), &shape);
@@ -1767,10 +1751,9 @@ int msQueryByShape(mapObj *map)
     searchrect.maxy += tolerance;
 
 #ifdef USE_PROJ
-    if(lp->project && msProjectionsDiffer(&(lp->projection), &(map->projection)))
+    lp->project = msProjectionsDiffer(&(lp->projection), &(map->projection));
+    if(lp->project)
       msProjectRect(&(map->projection), &(lp->projection), &searchrect); /* project the searchrect to source coords */
-    else
-      lp->project = MS_FALSE;
 #endif
 
     status = msLayerWhichShapes(lp, searchrect, MS_TRUE);
@@ -1817,10 +1800,8 @@ int msQueryByShape(mapObj *map)
       }
 
 #ifdef USE_PROJ
-      if(lp->project && msProjectionsDiffer(&(lp->projection), &(map->projection)))
+      if(lp->project)
         msProjectShape(&(lp->projection), &(map->projection), &shape);
-      else
-        lp->project = MS_FALSE;
 #endif
 
       switch(qshape->type) { /* may eventually support types other than polygon or line */

--- a/maprasterquery.c
+++ b/maprasterquery.c
@@ -416,7 +416,6 @@ msRasterQueryByRectLow(mapObj *map, layerObj *layer, GDALDatasetH hDS,
   CPLErr      eErr;
   rasterLayerInfo *rlinfo;
   rectObj     searchrect;
-  int         needReproject = MS_FALSE;
 
   rlinfo = (rasterLayerInfo *) layer->layerinfo;
 
@@ -426,12 +425,9 @@ msRasterQueryByRectLow(mapObj *map, layerObj *layer, GDALDatasetH hDS,
   /* -------------------------------------------------------------------- */
   searchrect = queryRect;
 #ifdef USE_PROJ
-  if(layer->project
-      && msProjectionsDiffer(&(layer->projection), &(map->projection))) {
+  layer->project = msProjectionsDiffer(&(layer->projection), &(map->projection));
+  if(layer->project)
     msProjectRect(&(map->projection), &(layer->projection), &searchrect);
-    needReproject = MS_TRUE;
-  } else
-    layer->project = MS_FALSE;
 #endif
 
   /* -------------------------------------------------------------------- */
@@ -582,7 +578,7 @@ msRasterQueryByRectLow(mapObj *map, layerObj *layer, GDALDatasetH hDS,
       /* in sPixelLocationInLayerSRS, so that we can return those */
       /* coordinates if we have a hit */
       sReprojectedPixelLocation = sPixelLocation;
-      if( needReproject )
+      if( layer->project )
         msProjectPoint( &(layer->projection), &(map->projection),
                         &sReprojectedPixelLocation);
 


### PR DESCRIPTION
As reported on the mailing list in http://osgeo-org.1560.x6.nabble.com/Performance-issue-with-MS-7-x-td5253419.html , there is a performance issue that became visible once the code to ```msProjectionsDiffer``` became more complicated with eeb1e786. This PR aims to set ```layer->project``` when necessary and then avoid calling ```msProjectionsDiffer``` over and over (for each feature)
cc @pmauduit @yjacolin 
