### PR TITLE
UTF-Grid not working in .fcgi-mode

### DIFF
--- a/maputfgrid.cpp
+++ b/maputfgrid.cpp
@@ -481,7 +481,7 @@ int utfgridSaveImage(imageObj *img, mapObj *map, FILE *fp, outputFormatObj *form
   imgheight = img->height/renderer->utfresolution;
   imgwidth = img->width/renderer->utfresolution;
 
-  fprintf(fp,"{\"grid\":[");
+  msIO_fprintf(fp,"{\"grid\":[");
 
   /* Print the buffer, also */
   for(row=0; row<imgheight; row++) {
@@ -491,8 +491,8 @@ int utfgridSaveImage(imageObj *img, mapObj *map, FILE *fp, outputFormatObj *form
     stringptr = string;
     /* Needs comma between each lines but JSON must not start with a comma. */
     if(row!=0)
-      fprintf(fp,",");
-    fprintf(fp,"\"");
+      msIO_fprintf(fp,",");
+    msIO_fprintf(fp,"\"");
     for(col=0; col<img->width/renderer->utfresolution; col++) {
       /* Get the datas from buffer. */
       pixelid = renderer->buffer[(row*imgwidth)+col];
@@ -505,51 +505,51 @@ int utfgridSaveImage(imageObj *img, mapObj *map, FILE *fp, outputFormatObj *form
     *stringptr = '\0';
     char * utf8;
     utf8 = msConvertWideStringToUTF8 (string, "UCS-4LE");
-    fprintf(fp,"%s", utf8);
+    msIO_fprintf(fp,"%s", utf8);
     msFree(utf8);
     msFree(string);
-    fprintf(fp,"\"");
+    msIO_fprintf(fp,"\"");
   }
 
-  fprintf(fp,"],\"keys\":[\"\"");
+  msIO_fprintf(fp,"],\"keys\":[\"\"");
 
   /* Prints the key specified */
   for(i=0;i<renderer->data->counter;i++) {
-      fprintf(fp,",");
+      msIO_fprintf(fp,",");
 
     if(renderer->useutfitem)
     {
       pszEscaped = msEscapeJSonString(renderer->data->table[i].itemvalue);
-      fprintf(fp,"\"%s\"", pszEscaped);
+      msIO_fprintf(fp,"\"%s\"", pszEscaped);
       msFree(pszEscaped);
     }
     /* If no UTFITEM specified use the serial ID as the key */
     else
-      fprintf(fp,"\"%i\"", renderer->data->table[i].serialid);
+      msIO_fprintf(fp,"\"%i\"", renderer->data->table[i].serialid);
   }
 
-  fprintf(fp,"],\"data\":{");
+  msIO_fprintf(fp,"],\"data\":{");
 
   /* Print the datas */
   if(renderer->useutfdata) {
     for(i=0;i<renderer->data->counter;i++) {
       if(i!=0)
-        fprintf(fp,",");
+        msIO_fprintf(fp,",");
 
       if(renderer->useutfitem)
       {
         pszEscaped = msEscapeJSonString(renderer->data->table[i].itemvalue);
-        fprintf(fp,"\"%s\":", pszEscaped);
+        msIO_fprintf(fp,"\"%s\":", pszEscaped);
         msFree(pszEscaped);
       }
       /* If no UTFITEM specified use the serial ID as the key */
       else
-        fprintf(fp,"\"%i\":", renderer->data->table[i].serialid);
+        msIO_fprintf(fp,"\"%i\":", renderer->data->table[i].serialid);
 
-      fprintf(fp,"%s", renderer->data->table[i].datavalues);
+      msIO_fprintf(fp,"%s", renderer->data->table[i].datavalues);
     }
   }
-  fprintf(fp,"}}");
+  msIO_fprintf(fp,"}}");
 
   return MS_SUCCESS;
 }


### PR DESCRIPTION
I use Mapserver 7.0.1 (and also tried the latest master) and wasn’t able to get any output from the web-Service as WMS-Request with format “application/json”.
The application/json-response has a filesize of 0Bytes, other formats (jpeg/png) work well – with exactly the same request, except the format.

UTF-Grid also seems to be produced well with a simulated request against mapserver on the commandline-interface
(“/usr/local/bin/mapserv QUERY_STRING="SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&BBOX=339444,5697190,347678,5702286&CRS=EPSG:25832&WIDTH=1556&HEIGHT=963&LAYERS=poi &STYLES=&FORMAT=application/json&TRANSPARENT=TRUE&map=PATH_TO_MAPFILE" > OUTPUT”)

Mapserver LOG (DEBUG 5) with above request wms request thru Apache webserver (**fcgi**-mode):
[Thu Mar  3 17:01:37 2016].53153 CGI Request 3 on process 2029
[Thu Mar  3 17:01:37 2016].53270 msDrawMap(): rendering using outputformat named json (UTFGrid).
[Thu Mar  3 17:01:37 2016].53278 msDrawMap(): WMS/WFS set-up and query, 0.000s
[Thu Mar  3 17:01:37 2016].60122 msDrawMap(): Layer 0 (poi_bildung), 0.007s
[Thu Mar  3 17:01:37 2016].60131 msDrawMap(): Drawing Label Cache, 0.000s
[Thu Mar  3 17:01:37 2016].60134 msDrawMap() total time: 0.007s
[Thu Mar  3 17:01:37 2016].63945 msSaveImage(stdout) total time: 0.004s
[Thu Mar  3 17:01:37 2016].63963 mapserv request processing time (msLoadMap not incl.): 0.011s
[Thu Mar  3 17:01:37 2016].63966 msFreeMap(): freeing map at 0x2ddcfe0.

Mapserver LOG (DEBUG 5) with above wms request (**cgi**-mode):
[Thu Mar  3 17:02:11 2016].882422 CGI Request 1 on process 2049
[Thu Mar  3 17:02:11 2016].882667 msDrawMap(): rendering using outputformat named json (UTFGrid).
[Thu Mar  3 17:02:11 2016].882677 msDrawMap(): WMS/WFS set-up and query, 0.000s
[Thu Mar  3 17:02:11 2016].915105 msDrawMap(): Layer 0 (poi_bildung), 0.032s
[Thu Mar  3 17:02:11 2016].915136 msDrawMap(): Drawing Label Cache, 0.000s
[Thu Mar  3 17:02:11 2016].915146 msDrawMap() total time: 0.033s
[Thu Mar  3 17:02:11 2016].926682 msSaveImage(stdout) total time: 0.011s
[Thu Mar  3 17:02:11 2016].926787 mapserv request processing time (msLoadMap not incl.): 0.044s
[Thu Mar  3 17:02:11 2016].926802 msFreeMap(): freeing map at 0xaf0300.

both look good, but no response on the client-side in fcgi-mode! cgi-mode works well!

Some further investigation showed me, that the correct output in fcgi-mode is written to the apache error.log!!!

it seems, that the mapserver output for format “application/json” in fcgi-mode goes to “STDERR” (apache error.log) and not to “STDOUT” (client)

I'm using a fully patched debian 7.

Please have a look at this.

THX