### PR TITLE
Fix filter of MS_TOKEN_LITERAL_TIME in PostGIS (#5265)

### DIFF
--- a/mappostgis.c
+++ b/mappostgis.c
@@ -3785,6 +3785,7 @@ int msPostGISLayerTranslateFilter(layerObj *layer, expressionObj *filter, char *
         default:
           /* by default accept the general token to string conversion */
 
+          if(node->token == MS_TOKEN_COMPARISON_EQ && node->next != NULL && node->next->token == MS_TOKEN_LITERAL_TIME) break; /* skip, handled with the next token */
           if(bindingToken == MS_TOKEN_BINDING_TIME && (node->token == MS_TOKEN_COMPARISON_EQ || node->token == MS_TOKEN_COMPARISON_NE)) break; /* skip, handled elsewhere */
 
           native_string = msStringConcatenate(native_string, msExpressionTokenToString(node->token));


### PR DESCRIPTION
In PostGIS filter, a MS_TOKEN_COMPARISON_EQ followed by a MS_TOKEN_LITERAL_TIME is ignored, because the operator if set with the MS_TOKEN_LITERAL_TIME.

Fix #5265 