### PR TITLE
Heap errors with msEvalTextExpressionJSonEscape in maputfgrid.cpp

### DIFF
--- a/maputfgrid.cpp
+++ b/maputfgrid.cpp
@@ -285,7 +285,7 @@ band_type addToTable(UTFGridRenderer *r, shapeObj *p)
   utfvalue = encodeForRendering(utfvalue);
 
   /* Data added to the table */
-  r->data->table[r->data->counter].datavalues = msEvalTextExpressionJSonEscape(&r->utflayer->utfdata, p);
+  r->data->table[r->data->counter].datavalues = msStrdup(msEvalTextExpressionJSonEscape(&r->utflayer->utfdata, p));
 
   /* If UTFITEM is set in the mapfile we add its value to the table */
   if(r->useutfitem)

--- a/maputfgrid.cpp
+++ b/maputfgrid.cpp
@@ -284,10 +284,10 @@ band_type addToTable(UTFGridRenderer *r, shapeObj *p)
   /* Simple operation so we don't have unavailable char in the JSON */
   utfvalue = encodeForRendering(utfvalue);
 
-  /* Datas are added to the table */
+  /* Data added to the table */
   r->data->table[r->data->counter].datavalues = msEvalTextExpressionJSonEscape(&r->utflayer->utfdata, p);
 
-  /* If UTFITEM is set in the mapfiles we add its value to the table */
+  /* If UTFITEM is set in the mapfile we add its value to the table */
   if(r->useutfitem)
     r->data->table[r->data->counter].itemvalue =  msStrdup(p->values[r->utflayer->utfitemindex]);
 
@@ -463,7 +463,7 @@ int utfgridCleanData(imageObj *img)
 }
 
 /*
- * Print the renderer datas as a JSON.
+ * Print the renderer data as JSON.
  */
 int utfgridSaveImage(imageObj *img, mapObj *map, FILE *fp, outputFormatObj *format)
 {
@@ -483,25 +483,25 @@ int utfgridSaveImage(imageObj *img, mapObj *map, FILE *fp, outputFormatObj *form
 
   msIO_fprintf(fp,"{\"grid\":[");
 
-  /* Print the buffer, also */
+  /* Print the buffer */
   for(row=0; row<imgheight; row++) {
 
     wchar_t *string = (wchar_t*) msSmallMalloc ((imgwidth + 1) * sizeof(wchar_t));
     wchar_t *stringptr;
     stringptr = string;
-    /* Needs comma between each lines but JSON must not start with a comma. */
+    /* Need a comma between each line but JSON must not start with a comma. */
     if(row!=0)
       msIO_fprintf(fp,",");
     msIO_fprintf(fp,"\"");
     for(col=0; col<img->width/renderer->utfresolution; col++) {
-      /* Get the datas from buffer. */
+      /* Get the data from buffer. */
       pixelid = renderer->buffer[(row*imgwidth)+col];
 
       *stringptr = pixelid;
       stringptr++;
     }
 
-    /* Convertion to UTF-8 encoding */
+    /* Conversion to UTF-8 encoding */
     *stringptr = '\0';
     char * utf8;
     utf8 = msConvertWideStringToUTF8 (string, "UCS-4LE");
@@ -513,7 +513,7 @@ int utfgridSaveImage(imageObj *img, mapObj *map, FILE *fp, outputFormatObj *form
 
   msIO_fprintf(fp,"],\"keys\":[\"\"");
 
-  /* Prints the key specified */
+  /* Print the specified key */
   for(i=0;i<renderer->data->counter;i++) {
       msIO_fprintf(fp,",");
 
@@ -530,7 +530,7 @@ int utfgridSaveImage(imageObj *img, mapObj *map, FILE *fp, outputFormatObj *form
 
   msIO_fprintf(fp,"],\"data\":{");
 
-  /* Print the datas */
+  /* Print the data */
   if(renderer->useutfdata) {
     for(i=0;i<renderer->data->counter;i++) {
       if(i!=0)
@@ -606,7 +606,7 @@ int utfgridEndLayer(imageObj *img, mapObj *map, layerObj *layer)
 }
 
 /*
- * Do the table operations on the shapes. Allow multiple type of data to be rendered.
+ * Do the table operations on the shapes. Allow multiple types of data to be rendered.
  */
 int utfgridStartShape(imageObj *img, shapeObj *shape)
 {
@@ -633,7 +633,7 @@ int utfgridEndShape(imageObj *img, shapeObj *shape)
 }
 
 /*
- * Function that render polygons into UTFGrid.
+ * Function that renders polygons into UTFGrid.
  */
 int utfgridRenderPolygon(imageObj *img, shapeObj *polygonshape, colorObj *color)
 {
@@ -652,8 +652,8 @@ int utfgridRenderPolygon(imageObj *img, shapeObj *polygonshape, colorObj *color)
 }
 
 /*
- * Function that render lines into UTFGrid. Starts by looking if the line is a polygon
- * outline. Then draw it if it's not.
+ * Function that renders lines into UTFGrid. Starts by looking if the line is a polygon
+ * outline, draw it if it's not.
  */
 int utfgridRenderLine(imageObj *img, shapeObj *lineshape, strokeStyleObj *linestyle)
 {
@@ -710,7 +710,7 @@ int utfgridRenderVectorSymbol(imageObj *img, double x, double y, symbolObj *symb
 }
 
 /*
- * Function that render Pixmap type symbols into UTFGrid.
+ * Function that renders Pixmap type symbols into UTFGrid.
  */
 int utfgridRenderPixmapSymbol(imageObj *img, double x, double y, symbolObj *symbol, symbolStyleObj * style)
 {


### PR DESCRIPTION
When debugging I get invalid heap errors at the following line:

`msFree(r->data->table[i].datavalues);`

This is caused by the following line, which assigns a string on the stack rather than heap - hence the error when calling free()

`r->data->table[r->data->counter].datavalues = msEvalTextExpressionJSonEscape(&r->utflayer->utfdata, p);`

This pull request stops the error, but may not be the cleanest solution. 

Pull request also includes comment updates. 