### PR TITLE
Add MapScript support for Python 3.x

### DIFF
--- a/mapscript/python/CMakeLists.txt
+++ b/mapscript/python/CMakeLists.txt
@@ -7,8 +7,8 @@ FIND_PACKAGE(PythonInterp)
 # interpreter that was found beforehand, and defaults to the system
 # python. We first try to find python.h and libpython.so ourselves
 # from the hints given by distutils and sys
-execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_inc; print get_python_inc(True)" OUTPUT_VARIABLE PYTHON_INC OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "import sys; print sys.prefix" OUTPUT_VARIABLE PYTHON_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_inc; print(get_python_inc(True))" OUTPUT_VARIABLE PYTHON_INC OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "import sys; print(sys.prefix)" OUTPUT_VARIABLE PYTHON_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 find_path(PYTHON_INCLUDE_PATH Python.h
   HINTS ${PYTHON_INC}
@@ -37,7 +37,7 @@ set_target_properties(${SWIG_MODULE_pythonmapscript_REAL_NAME} PROPERTIES PREFIX
 set_target_properties(${SWIG_MODULE_pythonmapscript_REAL_NAME} PROPERTIES OUTPUT_NAME _mapscript)
 
 
-execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print get_python_lib(True)" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(True))" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 get_target_property(LOC_MAPSCRIPT_LIB ${SWIG_MODULE_pythonmapscript_REAL_NAME} LOCATION)
 set(mapscript_files ${LOC_MAPSCRIPT_LIB} ${CMAKE_CURRENT_BINARY_DIR}/mapscript.py)

--- a/mapscript/python/pyextend.i
+++ b/mapscript/python/pyextend.i
@@ -49,7 +49,7 @@ def fromstring(data, mappath=None):
         ob.updateFromString(data)
         return ob
     else:
-        raise ValueError, "No map, layer, class, or style found. Can not load from provided string"
+        raise ValueError("No map, layer, class, or style found. Can not load from provided string")
 }
 
 /* ===========================================================================
@@ -88,8 +88,7 @@ def fromstring(data, mappath=None):
             else:
                 return False
         else:
-            raise TypeError, \
-                '__contains__ does not yet handle %s' % (item_type)
+            raise TypeError('__contains__ does not yet handle %s' % (item_type))
         
 }
 
@@ -350,13 +349,6 @@ def fromstring(data, mappath=None):
 
         if (file == Py_None) /* write to stdout */
             retval = msSaveImage(NULL, self, NULL);
-
-        else if (PyFile_Check(file)) /* a Python (C) file */
-        {
-            renderer = self->format->vtable;
-            /* FIXME? as an improvement, pass a map argument instead of the NULL (see #4216) */
-            retval = renderer->saveImage(self, NULL, PyFile_AsFile(file), self->format);
-        }
         else /* presume a Python file-like object */
         {
             imgbuffer = msSaveImageBuffer(self, &imgsize,
@@ -392,7 +384,7 @@ def fromstring(data, mappath=None):
             msSetError(MS_IMGERR, "failed to get image buffer", "saveToString()");
             return NULL;
         }
-        imgstring = PyString_FromStringAndSize((const char*) imgbytes, size); 
+        imgstring = PyBytes_FromStringAndSize((const char*) imgbytes, size); 
         free(imgbytes);
         return imgstring;
     }

--- a/mapscript/python/pymodule.i
+++ b/mapscript/python/pymodule.i
@@ -21,18 +21,9 @@
 /* Translates Python None to C NULL for strings */
 %typemap(in,parse="z") char * "";
 
-/* Translate Python's built-in file object to FILE * */
-%typemap(in) FILE * {
-    if (!PyFile_Check($input)) {
-        PyErr_SetString(PyExc_TypeError, "Input is not file");
-        return NULL;
-    }
-    $1 = PyFile_AsFile($input);
-}
-
 /* To support imageObj::getBytes */
 %typemap(out) gdBuffer {
-    $result = PyString_FromStringAndSize((const char*)$1.data, $1.size); 
+    $result = PyBytes_FromStringAndSize((const char*)$1.data, $1.size); 
     if( $1.owns_data )
        msFree($1.data);
 }

--- a/mapscript/python/setup.py
+++ b/mapscript/python/setup.py
@@ -136,7 +136,7 @@ class ms_ext(build_ext):
     ])
 
     def initialize_options(self):
-        print "LD_RUN_PATH set"
+        print("LD_RUN_PATH set")
         os.environ["LD_RUN_PATH"] = os.getcwd()+"/../../.libs"
         build_ext.initialize_options(self)
         self.gdaldir = None


### PR DESCRIPTION
I haven't had time to test this much, but this allows MapScript to
build and run against Python 3.4. The changes appear to continue to
work with Python 2.7.  I kind of accidentally figured this out while playing
around so it may be incomplete, but I figured I'd share it as it is at least a
good start.

If there are multiple Python versions installed on your machine,
the Python version that is selected is whatever CMake finds first
or the path set with -DPYTHON_EXECUTABLE=

Changes include:
- print ""                     ---> print("")
- raise E, "text"              ---> raise E("text")
- PyString_FromStringAndSize() ---> PyBytes_FromStringAndSize()
- Remove references to PyFile*
