### PR TITLE
Line pattern in image mosaic when reprojecting

### DIFF
--- a/mapresample.c
+++ b/mapresample.c
@@ -1383,14 +1383,21 @@ int msResampleGDALToMap( mapObj *map, layerObj *layer, imageObj *image,
   nLoadImgYSize = MS_MAX(1, (int) (sSrcExtent.maxy - sSrcExtent.miny)
                       * (dfNominalCellSize / sDummyMap.cellsize));
 
-  /*
-  ** Because the previous calculation involved some round off, we need
-  ** to fixup the cellsize to ensure the map region represents the whole
-  ** RAW_WINDOW (at least in X).  Re: bug 1715.
-  */
-  sDummyMap.cellsize =
-    ((sSrcExtent.maxx - sSrcExtent.minx) * dfNominalCellSize)
-    / nLoadImgXSize;
+  {
+    /*
+    ** Because the previous calculation involved some round off, we need
+    ** to fixup the cellsize to ensure the map region represents the whole
+    ** RAW_WINDOW (at least in X).  Re: bug 1715.
+    */
+    double tmp_cellsize;
+    tmp_cellsize = ((sSrcExtent.maxy - sSrcExtent.miny) * dfNominalCellSize)
+      / nLoadImgYSize;
+    sDummyMap.cellsize = ((sSrcExtent.maxx - sSrcExtent.minx) * dfNominalCellSize)
+      / nLoadImgXSize;
+    if(tmp_cellsize < sDummyMap.cellsize)
+      sDummyMap.cellsize = tmp_cellsize;
+  }
+
 
   if( layer->debug )
     msDebug( "msResampleGDALToMap in effect: cellsize = %f\n",


### PR DESCRIPTION
**Reporter: ml.dje@geocontent.de**
**Date: 2006/03/15 - 12:58**
**Trac URL:** http://trac.osgeo.org/mapserver/ticket/1715

```
Creating a mosaic from seamless tiled images creates a regular pattern of lines
in the background color along the edges of the images. This only happens if the
image is requested in a projection other than the source projection.

Further:
1. only versions 4.8.x of mapserver are affected (4.6.1 works fine)
2. the pattern is only visible at certain combinations of image resolution, map
extent and map size.

Regarding 1: The gdal version is different (1.2 vs. 1.3). Maybe this is somehow
related.
Regarding 2: It seems that the effect preferably occurs if the images are scaled
down.
```
