### PR TITLE
Legend MapServer 7.0.1 Label SIZE is ignored when using SIZEUNITS meters

### DIFF
--- a/maplegend.c
+++ b/maplegend.c
@@ -523,7 +523,7 @@ int msLegendCalcSize(mapObj *map, int scale_independent, int *size_x, int *size_
 
       if(*text) {
         initTextSymbol(&ts);
-        msPopulateTextSymbolForLabelAndString(&ts,&map->legend.label,msStrdup(text),lp->scalefactor*resolutionfactor,resolutionfactor, 0);
+        msPopulateTextSymbolForLabelAndString(&ts,&map->legend.label,msStrdup(text),resolutionfactor,resolutionfactor, 0);
         if(UNLIKELY(MS_FAILURE == msGetTextSymbolSize(map,&ts,&rect))) {
           freeTextSymbol(&ts);
           return MS_FAILURE;
@@ -638,7 +638,7 @@ imageObj *msDrawLegend(mapObj *map, int scale_independent, map_hittest *hittest)
       cur = (legendlabel*) msSmallMalloc(sizeof(legendlabel));
       initTextSymbol(&cur->ts);
       if(*text) {
-        msPopulateTextSymbolForLabelAndString(&cur->ts,&map->legend.label,msStrdup(text),lp->scalefactor*map->resolution/map->defresolution,map->resolution/map->defresolution, 0);
+        msPopulateTextSymbolForLabelAndString(&cur->ts,&map->legend.label,msStrdup(text),map->resolution/map->defresolution,map->resolution/map->defresolution, 0);
         if(UNLIKELY(MS_FAILURE == msComputeTextPath(map,&cur->ts))) {
           ret = MS_FAILURE;
           goto cleanup;


### PR DESCRIPTION
When you use SIZEUNITS meters instead of pixel in your LAYER the SIZE of your LEGEND is very small as long as you define only size. When you define MINSIZE and MAXSIZE the size is ok.

```
LEGEND
	STATUS ON
	KEYSIZE 30 30
	KEYSPACING 5 3  
	LABEL
		TYPE TRUETYPE
		FONT 'arial' 
		SIZE 10
		COLOR 119 179 0
	END 
END
```

* example using SIZE 10
![legend_mapserv7_size10](https://cloud.githubusercontent.com/assets/996298/14176383/fece3834-f750-11e5-8a8e-5649152fc2a3.png)

* Example using SIZE 100 (legend comes back with a big white extra area at the left and bottom)
![legend_mapserv7_size100](https://cloud.githubusercontent.com/assets/996298/14176387/02f59358-f751-11e5-8820-911673173309.png)

* when you add MINSIZE and MAXSIZE the Legend SIZE is ok

```
LEGEND
	STATUS ON
	KEYSIZE 30 30
	KEYSPACING 5 3  
	LABEL
		TYPE TRUETYPE
		FONT 'arial' 
		SIZE 10
                MINSIZE 10
                MAXSIZE 10
		COLOR 119 179 0
	END 
END
```

![legend_mapserv_7_size_minsize_maxsize](https://cloud.githubusercontent.com/assets/996298/14176513/a6b44e4e-f751-11e5-9637-2290d6f32404.png)