### PR TITLE
Legend MapServer 7.0.1 Label OFFSET is not supported anymore

### DIFF
--- a/maplegend.c
+++ b/maplegend.c
@@ -697,11 +697,13 @@ imageObj *msDrawLegend(mapObj *map, int scale_independent, map_hittest *hittest)
     pnt.y += cur->height;
 
     if(cur->ts.annotext) {
-      pnt.y -= cur->ts.textpath->bounds.bbox.maxy;
-      ret = msDrawTextSymbol(map,image,pnt,&cur->ts);
+      pointObj textPnt = pnt;
+      textPnt.y -= cur->ts.textpath->bounds.bbox.maxy;
+      textPnt.y += map->legend.label.offsety;
+      textPnt.x += map->legend.label.offsetx;
+      ret = msDrawTextSymbol(map,image,textPnt,&cur->ts);
       if(UNLIKELY(ret == MS_FAILURE))
         goto cleanup;
-      pnt.y += cur->ts.textpath->bounds.bbox.maxy;
       freeTextSymbol(&cur->ts);
     }
     


### PR DESCRIPTION
After MapServer update from version 6.4 to version 7.0 or 7.01 OFFSET in LEGEND Block does not work anymore.

**MapServer 6.4**
In my mapfile, the LABEL of my LEGEND is adjusted by specifying an OFFSET in the LABEL-block.

LEGEND-block in the Mapfile (Mapserver 6.4.1):

- The OFFSET of 0 -10 centers the LABEL of the LEGEND: legend_mapserv_6_offset.png 
![legend_mapserv_6_offset](https://cloud.githubusercontent.com/assets/996298/14176242/560125a4-f750-11e5-8fd9-e19a36807804.png)

- Without the OFFSET in the LABEL-Block it looks like this (label is a not in the center, but at the bottom:  legend_mapserv_6_without_offset.png
![legend_mapserv_6_without_offset](https://cloud.githubusercontent.com/assets/996298/14176203/2a896cf6-f750-11e5-9ffd-5bf8789e49b7.png)

```
LEGEND
	STATUS ON
	KEYSIZE 30 30
	KEYSPACING 5 3  
	LABEL
		TYPE TRUETYPE
		FONT 'arial' 
		SIZE 10
		COLOR 119 179 0
		OFFSET 0 -10
	END 
END 
```

**MapServer 7.0.1**

- After the update to version 7 the OFFSET in the LEGEND is ignored and the label no longer appears in the center: legend_mapserv_7_offset.png

![legend_mapserv_7_offset](https://cloud.githubusercontent.com/assets/996298/14176248/5bc8f14c-f750-11e5-8240-c8d534d50cd2.png)

```
LEGEND
	STATUS ON
	KEYSIZE 30 30
	KEYSPACING 5 3  
	LABEL
		TYPE TRUETYPE
		FONT 'arial' 
		SIZE 10
		COLOR 119 179 0
		OFFSET 0 -10
	END 
END  

```

I tested this with the MapServer 7.0.1 on the new OSGeo-Live.