### PR TITLE
Change all instances of strdup to msStrdup

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -1909,7 +1909,7 @@ static int loadLabel(labelObj *label)
         if(label->position == MS_BINDING) {
           if(label->bindings[MS_LABEL_BINDING_POSITION].item != NULL)
             msFree(label->bindings[MS_LABEL_BINDING_POSITION].item);
-          label->bindings[MS_LABEL_BINDING_POSITION].item = strdup(msyystring_buffer);
+          label->bindings[MS_LABEL_BINDING_POSITION].item = msStrdup(msyystring_buffer);
           label->numbindings++;
         }
         break;

--- a/mapogcsld.c
+++ b/mapogcsld.c
@@ -199,9 +199,9 @@ int msSLDApplySLD(mapObj *map, char *psSLDXML, int iLayer, char *pszStyleLayerNa
                    map->numlayers);
           if (psTmpLayer->name)
             msFree(psTmpLayer->name);
-          psTmpLayer->name = strdup(tmpId);
+          psTmpLayer->name = msStrdup(tmpId);
           msFree(pasLayers[l].name);
-          pasLayers[l].name = strdup(tmpId);
+          pasLayers[l].name = msStrdup(tmpId);
           msInsertLayer(map, psTmpLayer, -1);
           MS_REFCNT_DECR(psTmpLayer);
         }

--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -3799,7 +3799,7 @@ static int msOGRUpdateStyleParseLabel(mapObj *map, layerObj *layer, classObj *c,
       /* replace spaces with hyphens to allow mapping to a valid hashtable entry*/
       char* pszFontNameEscaped = NULL;
       if (pszFontName != NULL) {
-          pszFontNameEscaped = strdup(pszFontName);
+          pszFontNameEscaped = msStrdup(pszFontName);
           msReplaceChar(pszFontNameEscaped, ' ', '-');
       }
 

--- a/mapoutput.c
+++ b/mapoutput.c
@@ -280,9 +280,9 @@ outputFormatObj *msCreateDefaultOutputFormat( mapObj *map,
   else if( strcasecmp(driver,"KMZ") == 0 ) {
     if(!name) name="kmz";
     format = msAllocOutputFormat( map, name, driver );
-    format->mimetype = strdup("application/vnd.google-earth.kmz");
+    format->mimetype = msStrdup("application/vnd.google-earth.kmz");
     format->imagemode = MS_IMAGEMODE_RGB;
-    format->extension = strdup("kmz");
+    format->extension = msStrdup("kmz");
     format->renderer = MS_RENDER_WITH_KML;
     msSetOutputFormatOption( format, "ATTACHMENT", "mapserver.kmz");
   }

--- a/mapparser.c
+++ b/mapparser.c
@@ -1737,7 +1737,7 @@ yyreduce:
         p->result.intval = MS_FALSE;
       break;
     case(MS_PARSE_TYPE_STRING):
-      p->result.strval = (yyvsp[0].strval); // msStrdup($1);
+      p->result.strval = (yyvsp[(1) - (1)].strval); // msStrdup($1);
       break;
     }
   }

--- a/mapparser.c
+++ b/mapparser.c
@@ -1700,9 +1700,9 @@ yyreduce:
       break;
     case(MS_PARSE_TYPE_STRING):
       if((yyvsp[(1) - (1)].intval)) 
-        p->result.strval = strdup("true");
+        p->result.strval = msStrdup("true");
       else
-        p->result.strval = strdup("false");
+        p->result.strval = msStrdup("false");
       break;
     }
   }
@@ -1737,7 +1737,7 @@ yyreduce:
         p->result.intval = MS_FALSE;
       break;
     case(MS_PARSE_TYPE_STRING):
-      p->result.strval = (yyvsp[(1) - (1)].strval); // strdup($1);
+      p->result.strval = (yyvsp[0].strval); // msStrdup($1);
       break;
     }
   }
@@ -3002,7 +3002,7 @@ int yylex(YYSTYPE *lvalp, parseObj *p)
   case MS_TOKEN_LITERAL_STRING:
     // printf("token value = %s\n", p->expr->curtoken->tokenval.strval); 
     token = STRING;
-    (*lvalp).strval = strdup(p->expr->curtoken->tokenval.strval);    
+    (*lvalp).strval = msStrdup(p->expr->curtoken->tokenval.strval);    
     break;
   case MS_TOKEN_LITERAL_TIME:
     token = TIME;
@@ -3041,7 +3041,7 @@ int yylex(YYSTYPE *lvalp, parseObj *p)
     break;
   case MS_TOKEN_BINDING_STRING:
     token = STRING;
-    (*lvalp).strval = strdup(p->shape->values[p->expr->curtoken->tokenval.bindval.index]);
+    (*lvalp).strval = msStrdup(p->shape->values[p->expr->curtoken->tokenval.bindval.index]);
     break;
   case MS_TOKEN_BINDING_SHAPE:
     token = SHAPE;

--- a/mapquery.c
+++ b/mapquery.c
@@ -598,7 +598,7 @@ static char *filterTranslateToLogical(expressionObj *filter, char *filteritem) {
   char *string = NULL;
 
   if(filter->type == MS_STRING && filteritem) {
-    string = strdup("'[");
+    string = msStrdup("'[");
     string = msStringConcatenate(string, filteritem);
     string = msStringConcatenate(string, "]'");
     if(filter->flags & MS_EXP_INSENSITIVE)
@@ -608,7 +608,7 @@ static char *filterTranslateToLogical(expressionObj *filter, char *filteritem) {
     string = msStringConcatenate(string, filter->string);
     string = msStringConcatenate(string, "'");
   } else if(filter->type == MS_REGEX && filteritem) {
-    string = strdup("'[");
+    string = msStrdup("'[");
     string = msStringConcatenate(string, filteritem);
     string = msStringConcatenate(string, "]'");
     if(filter->flags & MS_EXP_INSENSITIVE)
@@ -644,7 +644,7 @@ static expressionObj mergeFilters(expressionObj *filter1, char *filteritem1, exp
     return filter; /* should only happen if the filter was a native filter */
   }
 
-  filter.string = strdup(tmpstr1);
+  filter.string = msStrdup(tmpstr1);
   filter.string = msStringConcatenate(filter.string, " AND ");
   filter.string = msStringConcatenate(filter.string, tmpstr2);
 

--- a/maputil.c
+++ b/maputil.c
@@ -423,7 +423,7 @@ int msEvalContext(mapObj *map, layerObj *layer, char *context)
         e.string = msReplaceSubstring(e.string, tag, "0");
     }
 
-    free(tag);
+    msFree(tag);
   }
 
   msTokenizeExpression(&e, NULL, NULL);
@@ -1478,7 +1478,7 @@ char *msTmpPath(mapObj *map, const char *mappath, const char *tmppath)
   }
 
   fullPath = msBuildPath(szPath, mappath, tmpBase);
-  return strdup(fullPath);
+  return msStrdup(fullPath);
 }
 
 /**********************************************************************
@@ -1505,7 +1505,7 @@ char *msTmpFilename(const char *ext)
   snprintf(tmpFname, tmpFnameBufsize, "%s_%x.%s", tmpId, tmpCount++, ext);
   msReleaseLock( TLOCK_TMPFILE );
 
-  fullFname = strdup(tmpFname);
+  fullFname = msStrdup(tmpFname);
   free(tmpFname);
 
   return fullFname;

--- a/mapwcs.c
+++ b/mapwcs.c
@@ -368,7 +368,7 @@ static int msWCSParseRequest(cgiRequestObj *request, wcsParamsObj *params, mapOb
     root = xmlDocGetRootElement(doc);
 
     /* Get service, version and request from root */
-    params->request = strdup((char *) root->name);
+    params->request = msStrdup((char *) root->name);
     if ((tmp = (char *) xmlGetProp(root, BAD_CAST "service")) != NULL)
       params->service = tmp;
     if ((tmp = (char *) xmlGetProp(root, BAD_CAST "version")) != NULL)

--- a/mapwms.c
+++ b/mapwms.c
@@ -1591,9 +1591,9 @@ this request. Check wms/ows_enable_request settings.",
                            map->numlayers);
                   if (psTmpLayer->name)
                     msFree(psTmpLayer->name);
-                  psTmpLayer->name = strdup(tmpId);
+                  psTmpLayer->name = msStrdup(tmpId);
                   msFree(layers[l]);
-                  layers[l] = strdup(tmpId);
+                  layers[l] = msStrdup(tmpId);
                   msInsertLayer(map, psTmpLayer, -1);
                   bLayerInserted =MS_TRUE;
                   /* layer was copied, we need to decrement its refcount */


### PR DESCRIPTION
See issue #5277 - fixes Windows memory issues in conjunction with using `msFree`

I left the following in mapstring.c alone. I presume this shouldn't be called anyway if only `msStrdup` is used?

```
#ifndef HAVE_STRDUP
char  *strdup(char *s)
{
  char  *s1;
  ...
```