### PR TITLE
php mapscript build error with php 5.6.25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 php:
   - 5.5
-#  - 5.6
+  - 5.6
 
 env:
   global:

--- a/mapscript/php/error.c
+++ b/mapscript/php/error.c
@@ -31,6 +31,7 @@
 
 #include "php_mapscript.h"
 
+#if PHP_VERSION_ID >= 50625
 #undef ZVAL_STRING
 #define ZVAL_STRING(z, s, duplicate) do {       \
     const char *__s=(s);                            \
@@ -39,6 +40,7 @@
     Z_STRVAL_P(__z) = (duplicate?estrndup(__s, Z_STRLEN_P(__z)):(char*)__s);\
     Z_TYPE_P(__z) = IS_STRING;                      \
 } while (0)
+#endif
 
 zend_class_entry *mapscript_ce_error;
 

--- a/mapscript/php/error.c
+++ b/mapscript/php/error.c
@@ -31,6 +31,15 @@
 
 #include "php_mapscript.h"
 
+#undef ZVAL_STRING
+#define ZVAL_STRING(z, s, duplicate) do {       \
+    const char *__s=(s);                            \
+    zval *__z = (z);                                        \
+    Z_STRLEN_P(__z) = strlen(__s);          \
+    Z_STRVAL_P(__z) = (duplicate?estrndup(__s, Z_STRLEN_P(__z)):(char*)__s);\
+    Z_TYPE_P(__z) = IS_STRING;                      \
+} while (0)
+
 zend_class_entry *mapscript_ce_error;
 
 ZEND_BEGIN_ARG_INFO_EX(error___get_args, 0, 0, 1)


### PR DESCRIPTION
5.6.23 builds fine, 5.6.25 fails with:

```
/usr/obj/ports/mapserver-7.0.1/mapserver-7.0.1/mapscript/php/error.c:71: error: called object 'zend_error' is not a function
```

pointing at https://github.com/mapserver/mapserver/blob/branch-7-0/mapscript/php/error.c#L71

this seems caused by this upstream change: http://git.php.net/?p=php-src.git;a=commitdiff;h=791a98eb1c66d2340b4e897ab60e4a6700435b5b

When unrolling the IF_GET_STRING macro, something blows.. tried with gcc 4.2.1 and clang 3.8.1, using libestdc++ 4.2.1 in both cases.
