### PR TITLE
Label frame offset with leader line

### DIFF
--- a/mapdraw.c
+++ b/mapdraw.c
@@ -2269,7 +2269,7 @@ void offsetAndTest(mapObj *map, labelCacheMemberObj *cachePtr, double ox, double
       }
     }
     for(j=0; j<ts->label->numstyles; j++) {
-      if(ts->label->styles[i]->_geomtransform.type == MS_GEOMTRANSFORM_LABELPOINT) {
+      if(ts->label->styles[j]->_geomtransform.type == MS_GEOMTRANSFORM_LABELPOINT) {
         scratch->poly = scratch_line;
         offset_label_bounds(ts->style_bounds[j], scratch, ox, oy);
         status = msTestLabelCacheCollisions(map, cachePtr, scratch, priority, label_idx);
@@ -2313,8 +2313,8 @@ void offsetAndTest(mapObj *map, labelCacheMemberObj *cachePtr, double ox, double
     }
     if(ts->style_bounds) {
       for(j=0; j<ts->label->numstyles; j++) {
-        if(ts->label->styles[i]->_geomtransform.type == MS_GEOMTRANSFORM_LABELPOINT ||
-            ts->label->styles[i]->_geomtransform.type == MS_GEOMTRANSFORM_LABELPOLY) {
+        if(ts->label->styles[j]->_geomtransform.type == MS_GEOMTRANSFORM_LABELPOINT ||
+            ts->label->styles[j]->_geomtransform.type == MS_GEOMTRANSFORM_LABELPOLY) {
           offset_label_bounds(ts->style_bounds[j], ts->style_bounds[j], ox, oy);
         }
       }

--- a/mapdraw.c
+++ b/mapdraw.c
@@ -2511,7 +2511,7 @@ int msDrawOffsettedLabels(imageObj *image, mapObj *map, int priority)
             /* here's where we draw the label styles */
             for(i=0; i<ts->label->numstyles; i++) {
               if(ts->label->styles[i]->_geomtransform.type == MS_GEOMTRANSFORM_LABELPOINT) {
-                retval = msDrawMarkerSymbol(map, image, &(cachePtr->point), ts->label->styles[i], layerPtr->scalefactor);
+                retval = msDrawMarkerSymbol(map, image, &(labelLeader.line->point[1]), ts->label->styles[i], layerPtr->scalefactor);
                 if(UNLIKELY(retval == MS_FAILURE)) {
                   goto offset_cleanup;
                 }

--- a/mapdraw.c
+++ b/mapdraw.c
@@ -2386,8 +2386,8 @@ int msDrawOffsettedLabels(imageObj *image, mapObj *map, int priority)
 
 #define otest(ox,oy) if((x0+(ox)) >= labelcache->gutter &&\
                 (y0+(oy)) >= labelcache->gutter &&\
-                (x0+(ox)) < image->width + labelcache->gutter &&\
-                (y0+(oy)) < image->height + labelcache->gutter) {\
+                (x0+(ox)) < image->width - labelcache->gutter &&\
+                (y0+(oy)) < image->height - labelcache->gutter) {\
                    scratch_line.point = scratch_points;\
                    scratch.poly = &scratch_line; \
                    offsetAndTest(map,cachePtr,(ox),(oy),priority,l,&scratch); \
@@ -2952,7 +2952,7 @@ int msDrawLabelCache(mapObj *map, imageObj *image)
                                                            textSymbolPtr->rotation, textSymbolPtr->label->buffer * textSymbolPtr->scalefactor,
                                                            &metrics_bounds);
                     if(need_labelpoly) get_metrics(&(cachePtr->point), MS_CC, textSymbolPtr->textpath,
-                                                              marker_offset_x + label_offset_x, marker_offset_y + label_offset_y,
+                                                              label_offset_x, label_offset_y,
                                                               textSymbolPtr->rotation, 1, &labelpoly_bounds);
                   }
                 } else { /* explicit position */
@@ -2960,7 +2960,7 @@ int msDrawLabelCache(mapObj *map, imageObj *image)
                     metrics_bounds.poly = &metrics_line;
                     textSymbolPtr->annopoint = get_metrics(&(cachePtr->point), MS_CC, textSymbolPtr->textpath, label_offset_x, label_offset_y,
                             textSymbolPtr->rotation, textSymbolPtr->label->buffer * textSymbolPtr->scalefactor, &metrics_bounds);
-                    if(need_labelpoly) get_metrics(&(cachePtr->point), textSymbolPtr->label->position, textSymbolPtr->textpath,
+                    if(need_labelpoly) get_metrics(&(cachePtr->point), MS_CC, textSymbolPtr->textpath,
                                                               label_offset_x, label_offset_y, textSymbolPtr->rotation, 1, &labelpoly_bounds);
                   } else {
                     metrics_bounds.poly = &metrics_line;


### PR DESCRIPTION
When using the LEADER for point labels, the GEOMTRANSFORM 'labelpoly' frame around the label gets an offset both vertically and horizontally. See the image below where the bottom-left label has a leader, but the green frame is moved a few pixels down and to the right. The label which rendered without a LEADER has the correct frame around it.

![labeloffset](https://cloud.githubusercontent.com/assets/22219873/18554971/593c65ae-7b66-11e6-9e9c-c178836fd8aa.png)

Here is a section of my mapfile for the relevant layer:

    LABEL 
        WRAP "!"
        ALIGN center
        TEXT ('[name]' + "!D116.7 " + '[ident]')
        MAXSCALEDENOM 2600064
        POSITION auto
        PARTIALS false
        SIZE 8 
        COLOR 100 150 100
        TYPE truetype 
        FONT vera
        FORCE false 
        STYLE
                GEOMTRANSFORM 'labelpoly'
                OFFSET 2 2
                COLOR 150 200 150
                OUTLINECOLOR 150 200 150
                WIDTH 1
                OPACITY 100
        END
        STYLE
                GEOMTRANSFORM 'labelpoly'
                COLOR 255 255 255
                OUTLINECOLOR 150 200 150
                WIDTH 1
                OPACITY 95
        END
    END
    LEADER
        GRIDSTEP 40
        MAXDISTANCE 1000
        STYLE
                COLOR 150 200 150
                WIDTH 2
        END
    END


Thanks,
Stephen
