### PR TITLE
Wrong rotation of characters if label is first rendered with cairo and then by agg (fastcgi, fontcache, cairo)

### DIFF
--- a/fontcache.c
+++ b/fontcache.c
@@ -273,11 +273,17 @@ outline_element* msGetGlyphOutline(face_element *face, glyph_element *glyph) {
   key.glyph = glyph;
   UT_HASH_FIND(hh,face->outline_cache,&key, sizeof(outline_element_key),oc);
   if(!oc) {
+    FT_Matrix matrix;
+    FT_Vector pen;
     FT_Error error;
     oc = msSmallMalloc(sizeof(outline_element));
     if(MS_NINT(glyph->key.size * 96.0/72.0) != face->face->size->metrics.x_ppem) {
       FT_Set_Pixel_Sizes(face->face,0,MS_NINT(glyph->key.size * 96/72.0));
     }
+    matrix.xx = matrix.yy = 0x10000L;
+    matrix.xy = matrix.yx = 0x00000L;
+    pen.x = pen.y = 0;
+    FT_Set_Transform(face->face, &matrix, &pen);
     error = FT_Load_Glyph(face->face,glyph->key.codepoint,FT_LOAD_DEFAULT/*|FT_LOAD_IGNORE_TRANSFORM*/|FT_LOAD_NO_HINTING|FT_LOAD_IGNORE_GLOBAL_ADVANCE_WIDTH);
     if(error) {
       msSetError(MS_MISCERR, "unable to load glyph %ud for font \"%s\"", "msGetGlyphByIndex()",glyph->key.codepoint, face->font);


### PR DESCRIPTION
Issue: Characters in labels are rotated incorrecly
Environment: Mapserver: 7.x built from source in FastCGI-mode

How to reproduce:
1) Start a fresh mapserver process
2) Request a map with labels and where labels are using the "ANGLE"-keyword with driver CARIO/PDF
3) Request the same map from the same fastcgi-process using the driver AGG/PNG

Example:
1) Create the following mapfile. Update FONT/FONTSET to a valid truetype font

```
MAP
  NAME "WMS"
  EXTENT 0 0 200 200 

  OUTPUTFORMAT
    NAME pdf
    DRIVER "CAIRO/PDF"
    MIMETYPE "application/x-pdf"
    IMAGEMODE RGB
    EXTENSION "pdf"
    FORMATOPTION "GEO_ENCODING=ISO32000"
  END

  OUTPUTFORMAT
    NAME png
    DRIVER "AGG/PNG"
    MIMETYPE "image/png"
    IMAGEMODE RGBA
    EXTENSION "png" 
  END

  RESOLUTION 300
  FONTSET "fonts/fonts.list"
  PROJECTION
    "init=epsg:3006"
  END
  WEB
    METADATA  
      "wms_enable_request" "*"
      "wms_srs" "epsg:3006"
    END
  END

LAYER
  NAME "lname"
  EXTENT 0 0 200 200 
  TYPE POINT
        FEATURE
                POINTS
                        100 100
                END
                TEXT "Gavle"
        END
  STATUS ON
  SIZEUNITS pixels

  CLASS
    NAME "name"
    LABEL
      FONT "arial"
      TYPE truetype
      SIZE 12
      ANGLE 60  
        POSITION ul
    END
  END
END
END
```

2) Restart apache (to get a clean mapserver fastcgi process)
3) Request WMS map using caiiro:

```
GET /mapserv?map=../maps/simple.map&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&BBOX=0,0,200,200&SRS=EPSG:3006&WIDTH=400&HEIGHT=400&LAYERS=lname&FORMAT=application/x-pdf
```

![image](https://cloud.githubusercontent.com/assets/6604809/19436988/91a3eaea-9473-11e6-8baa-65a6628f477a.png)

4) Request WMS map using agg

```
GET /mapserv?map=../maps/simple.map&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&BBOX=0,0,200,200&SRS=EPSG:3006&WIDTH=400&HEIGHT=400&LAYERS=lname&FORMAT=image/png
```

![image](https://cloud.githubusercontent.com/assets/6604809/19436789/701bd50a-9472-11e6-8966-1cc36e91327a.png)

Notice the rotated characters.  
The opposite, by first using agg-driver followed by cario does not seem to have any issues.
