### PR TITLE
Change text encoding in UTFGrid driver to work with Windows

### DIFF
--- a/maputfgrid.cpp
+++ b/maputfgrid.cpp
@@ -504,7 +504,13 @@ int utfgridSaveImage(imageObj *img, mapObj *map, FILE *fp, outputFormatObj *form
     /* Conversion to UTF-8 encoding */
     *stringptr = '\0';
     char * utf8;
-    utf8 = msConvertWideStringToUTF8 (string, "WCHAR_T");
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	const char* encoding = "UCS-2LE";
+#else
+	const char* encoding = "UCS-4LE";
+#endif
+
+	  utf8 = msConvertWideStringToUTF8(string, encoding);
     msIO_fprintf(fp,"%s", utf8);
     msFree(utf8);
     msFree(string);

--- a/maputfgrid.cpp
+++ b/maputfgrid.cpp
@@ -504,7 +504,7 @@ int utfgridSaveImage(imageObj *img, mapObj *map, FILE *fp, outputFormatObj *form
     /* Conversion to UTF-8 encoding */
     *stringptr = '\0';
     char * utf8;
-    utf8 = msConvertWideStringToUTF8 (string, "UCS-4LE");
+    utf8 = msConvertWideStringToUTF8 (string, "UCS-2LE");
     msIO_fprintf(fp,"%s", utf8);
     msFree(utf8);
     msFree(string);

--- a/maputfgrid.cpp
+++ b/maputfgrid.cpp
@@ -504,7 +504,7 @@ int utfgridSaveImage(imageObj *img, mapObj *map, FILE *fp, outputFormatObj *form
     /* Conversion to UTF-8 encoding */
     *stringptr = '\0';
     char * utf8;
-    utf8 = msConvertWideStringToUTF8 (string, "UCS-2LE");
+    utf8 = msConvertWideStringToUTF8 (string, "WCHAR_T");
     msIO_fprintf(fp,"%s", utf8);
     msFree(utf8);
     msFree(string);


### PR DESCRIPTION
The use of the ICONV encoding "UCS-4LE" in the maputfgrid.cpp encoding causes junk output on Windows. 

`utf8 = msConvertWideStringToUTF8 (string, "UCS-4LE");`

Changing this to "UCS-2LE" produces the correct output on Windows. I'm not sure if this also works
without issues on Linux. Hopefully there can be one encoding that works on both. 

The only other place the encoding is specified is in the Windows-only MS SQL driver which uses "UCS-2LE"
https://github.com/mapserver/mapserver/blob/branch-7-0/mapmssql2008.c#L1741

I'm not sure of the exact difference between the two encodings. The most detailed descriptions I could find were:

"UCS2LE is a direct byte encoding of the first plane in which the low byte comes first"
http://interscript.sourceforge.net/interscript/doc/en_iscr_0279.html

"UCS4LE is a four byte direct encodings of of ISO-10646. UCS4LE puts the low byte first. "
http://interscript.sourceforge.net/interscript/doc/en_iscr_0281.html
