### PR TITLE
Filters: add whitespace between and and next part (relates to #5352)

### DIFF
--- a/mapogcfiltercommon.c
+++ b/mapogcfiltercommon.c
@@ -68,7 +68,7 @@ char *FLTGetIsLikeComparisonCommonExpression(FilterEncodingNode *psFilterNode)
   /*      Use operand with regular expressions.                           */
   /* -------------------------------------------------------------------- */
   szBuffer[0] = '\0';
-  sprintf(szTmp, "%s", " (\"[");
+  sprintf(szTmp, "%s", "(\"[");
   szTmp[4] = '\0';
 
   strlcat(szBuffer, szTmp, bufferSize);
@@ -174,9 +174,9 @@ char *FLTGetIsBetweenComparisonCommonExpresssion(FilterEncodingNode *psFilterNod
   /* -------------------------------------------------------------------- */
   /* attribute */
   if (bString)
-    sprintf(szBuffer, "%s", " (\"[");
+    sprintf(szBuffer, "%s", "(\"[");
   else
-    sprintf(szBuffer, "%s", " ([");
+    sprintf(szBuffer, "%s", "([");
   pszExpression = msStringConcatenate(pszExpression, szBuffer);
   
   pszExpression = msStringConcatenate(pszExpression, psFilterNode->psLeftNode->pszValue);
@@ -288,9 +288,9 @@ char *FLTGetBinaryComparisonCommonExpression(FilterEncodingNode *psFilterNode, l
 
   /* attribute */
   if (bString)
-    sprintf(szTmp, "%s", " (\"[");
+    sprintf(szTmp, "%s", "(\"[");
   else
-    sprintf(szTmp,  "%s"," ([");
+    sprintf(szTmp,  "%s","([");
   pszExpression = msStringConcatenate(pszExpression, szTmp);
   pszExpression = msStringConcatenate(pszExpression, psFilterNode->psLeftNode->pszValue);
   
@@ -307,19 +307,20 @@ char *FLTGetBinaryComparisonCommonExpression(FilterEncodingNode *psFilterNode, l
     else
       sprintf(szTmp,  "%s", "=");
   } else if (strcasecmp(psFilterNode->pszValue, "PropertyIsNotEqualTo") == 0)
-    sprintf(szTmp,  "%s", " != ");
+    sprintf(szTmp,  "%s", "!=");
   else if (strcasecmp(psFilterNode->pszValue, "PropertyIsLessThan") == 0)
-    sprintf(szTmp,  "%s", " < ");
+    sprintf(szTmp,  "%s", "<");
   else if (strcasecmp(psFilterNode->pszValue, "PropertyIsGreaterThan") == 0)
-    sprintf(szTmp,  "%s", " > ");
+    sprintf(szTmp,  "%s", ">");
   else if (strcasecmp(psFilterNode->pszValue, "PropertyIsLessThanOrEqualTo") == 0)
-    sprintf(szTmp,  "%s", " <= ");
+    sprintf(szTmp,  "%s", "<=");
   else if (strcasecmp(psFilterNode->pszValue, "PropertyIsGreaterThanOrEqualTo") == 0)
-    sprintf(szTmp,  "%s", " >= ");
+    sprintf(szTmp,  "%s", ">=");
   else if (strcasecmp(psFilterNode->pszValue, "PropertyIsLike") == 0)
-    sprintf(szTmp,  "%s", " ~ ");
+    sprintf(szTmp,  "%s", "~");
 
   pszExpression = msStringConcatenate(pszExpression, szTmp);
+  pszExpression = msStringConcatenate(pszExpression, " ");
 
   /* value */
   if (bString) {
@@ -356,7 +357,6 @@ char *FLTGetLogicalComparisonCommonExpression(FilterEncodingNode *psFilterNode, 
 {
   char *pszExpression = NULL;
   char *pszTmp = NULL;
-  char szBuffer[256];
 
   if (!psFilterNode || !FLTIsLogicalFilterType(psFilterNode->pszValue))
     return NULL;
@@ -369,17 +369,16 @@ char *FLTGetLogicalComparisonCommonExpression(FilterEncodingNode *psFilterNode, 
     if (!pszTmp)
       return NULL;
 
-    sprintf(szBuffer, "%s", " (");
-    pszExpression = msStringConcatenate(pszExpression, szBuffer);
+    pszExpression = msStringConcatenate(pszExpression, "(");
 
     pszExpression = msStringConcatenate(pszExpression, pszTmp);
     msFree(pszTmp);
 
-    sprintf(szBuffer, "%s", " ");
-    pszExpression = msStringConcatenate(pszExpression, szBuffer);
+    pszExpression = msStringConcatenate(pszExpression, " ");
 
     pszExpression = msStringConcatenate(pszExpression, psFilterNode->pszValue);
-    sprintf(szBuffer, "%s", " ");
+
+    pszExpression = msStringConcatenate(pszExpression, " ");
 
     pszTmp = FLTGetCommonExpression(psFilterNode->psRightNode, lp);
     if (!pszTmp) {
@@ -390,8 +389,7 @@ char *FLTGetLogicalComparisonCommonExpression(FilterEncodingNode *psFilterNode, 
     pszExpression = msStringConcatenate(pszExpression, pszTmp);
     msFree(pszTmp);
 
-    sprintf(szBuffer, "%s", ") ");
-    pszExpression = msStringConcatenate(pszExpression, szBuffer);
+    pszExpression = msStringConcatenate(pszExpression, ")");
   }
   /* -------------------------------------------------------------------- */
   /*      NOT                                                             */
@@ -401,14 +399,12 @@ char *FLTGetLogicalComparisonCommonExpression(FilterEncodingNode *psFilterNode, 
     if (!pszTmp)
       return NULL;
 
-    sprintf(szBuffer, "%s", " (NOT ");
-    pszExpression = msStringConcatenate(pszExpression, szBuffer);
+    pszExpression = msStringConcatenate(pszExpression, "(NOT ");
 
     pszExpression = msStringConcatenate(pszExpression, pszTmp);
     msFree(pszTmp);
 
-    sprintf(szBuffer, "%s", ") ");
-    pszExpression = msStringConcatenate(pszExpression, szBuffer);
+    pszExpression = msStringConcatenate(pszExpression, ")");
   }
 
   return pszExpression;

--- a/msautotest/wxs/expected/wfs_filter_false_ogr_property_is_equal_and_bbox.xml
+++ b/msautotest/wxs/expected/wfs_filter_false_ogr_property_is_equal_and_bbox.xml
@@ -1,0 +1,49 @@
+Content-Type: text/xml; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.opengis.net/wfs http://ogc.dmsolutions.ca/wfs/1.0.0/WFS-basic.xsd 
+                       http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=popplace&amp;OUTPUTFORMAT=XMLSCHEMA">
+      <gml:boundedBy>
+      	<gml:Box srsName="EPSG:4326">
+      		<gml:coordinates>-65.816024,44.611049 -65.816024,44.611049</gml:coordinates>
+      	</gml:Box>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:popplace>
+        <gml:boundedBy>
+        	<gml:Box srsName="EPSG:4326">
+        		<gml:coordinates>-65.816024,44.611049 -65.816024,44.611049</gml:coordinates>
+        	</gml:Box>
+        </gml:boundedBy>
+        <ms:msGeometry>
+        <gml:Point srsName="EPSG:4326">
+          <gml:coordinates>-65.816024,44.611049</gml:coordinates>
+        </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0.000</ms:AREA>
+        <ms:PERIMETER>0.000</ms:PERIMETER>
+        <ms:POPPLACE_>118</ms:POPPLACE_>
+        <ms:POPPLACE_I>2</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CAJOA</ms:UNIQUE_KEY>
+        <ms:NAME>Digby</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>021A12</ms:NTS50>
+        <ms:LAT>443700</ms:LAT>
+        <ms:LONG>654600</ms:LONG>
+        <ms:SGC_CODE>1203006</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+      </ms:popplace>
+    </gml:featureMember>
+</wfs:FeatureCollection>
+

--- a/msautotest/wxs/wfs_filter.map
+++ b/msautotest/wxs/wfs_filter.map
@@ -97,12 +97,16 @@
 # Verify 3 AND
 # RUN_PARMS: wfs_filter_3_and.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=popplace&FILTER=<Filter><And><PropertyIsEqualTo><PropertyName>NAME</PropertyName><Literal>Digby</Literal></PropertyIsEqualTo><PropertyIsEqualTo><PropertyName>NTS50</PropertyName><Literal>021A12</Literal></PropertyIsEqualTo><PropertyIsEqualTo><PropertyName>NTS50</PropertyName><Literal>z021A12</Literal></PropertyIsEqualTo></And></Filter>" > [RESULT]
 #
+
 # Verify Not PropertyIsEqualTo
 # RUN_PARMS: wfs_filter_not_isequalto.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=popplace&FILTER=<Filter><Not><PropertyIsEqualTo><PropertyName>POP_RANGE</PropertyName><Literal>4</Literal></PropertyIsEqualTo></Not></Filter>" > [RESULT]
 #
 # Verify BBOX Result:  Digby
 # RUN_PARMS: wfs_filter_bbox.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=popplace&FILTER=<Filter><BBOX><PropertyName>POINT</PropertyName><Box+srsName=%22EPSG:4326%22><coordinates>-65.86,44.56+-65.76,44.68</coordinates></Box></BBOX></Filter>" > [RESULT]
 # RUN_PARMS: wfs_filter_bbox_no_propertyname.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=popplace&FILTER=<Filter><BBOX><Box+srsName=%22EPSG:4326%22><coordinates>-65.86,44.56+-65.76,44.68</coordinates></Box></BBOX></Filter>" > [RESULT]
+
+# RUN_PARMS: wfs_filter_false_ogr_property_is_equal_and_bbox.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=popplace&FILTER=<Filter><Or><PropertyIsEqualTo><PropertyName>NAME</PropertyName><Literal>xxxxxxx</Literal></PropertyIsEqualTo><And><PropertyIsEqualTo><PropertyName>REG_CODE</PropertyName><Literal>12</Literal></PropertyIsEqualTo><BBOX><PropertyName>POINT</PropertyName><Box+srsName=%22EPSG:4326%22><coordinates>-65.86,44.56+-65.76,44.68</coordinates></Box></BBOX></And></Or></Filter>" > [RESULT]
+
 #
 # Verify BBOX Result with epsg in http://www.opengis.net/gml/srs/epsg.xml format:  Digby
 # RUN_PARMS: wfs_filter_bbox_urlepsg.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.1.0&REQUEST=GetFeature&TYPENAME=popplace&FILTER=<Filter><BBOX><PropertyName>POINT</PropertyName><Box+srsName=%22http://www.opengis.net/gml/srs/epsg.xml#26920%22><coordinates>272868.16,4938053.09+281261.3,4951109.39</coordinates></Box></BBOX></Filter>" > [RESULT]


### PR DESCRIPTION
A <Filter><And>....<BBOX></BBOX></And></Filter> results in
a ( ..... ANDintersects(....)) mapserver expression. The expression lexer seems
to make sense of it though, but this is ugly.