### PR TITLE
oracle - fixing memory handling error

### DIFF
--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -399,8 +399,10 @@ static int msSplitData( char *data, char **geometry_column_name, char **table_na
       break; /* stop on spaces */
     /* double the size of the table_name array if necessary */
     if (i == table_name_size) {
+      size_t tgt_offset = tgt - *table_name;
       table_name_size *= 2;
       *table_name = (char *) realloc(*table_name,sizeof(char *) * table_name_size);
+      tgt = *table_name + tgt_offset;
     }
     *tgt = *src;
   }


### PR DESCRIPTION
If the memory area pointed by `table_name` is too small, it is resized multiplying its size by 2. But if this occurs, the `tgt` variable used in the "for" loop continues to point on a memory area which might have become invalid (because the realloc could have moved the memory somewhere else, depending on how the OS manages the memory).

To fix this, in my understanding, the `tgt` pointer should be readjusted after the realloc call to the new location pointed by `table_name`.

Running valgrind without my patch (sources based on the 7.0.1 version, but the maporaclespatial.c is identical to master):

```
==1908== Invalid write of size 1
==1908==    at 0x4E81FEF: msSplitData (in /usr/lib/x86_64-linux-gnu/libmapserver.so.7.0.1)
```
Running in gdb gives the following error:

```
*** Error in `/usr/lib/cgi-bin/mapserv': realloc(): invalid next size: 0x0000000000786c90 ***
```

Tests: runtime tested in a docker composition, after patching, I don't have the error in gdb anymore.

Note: valgrinds continues to indicate some errors related to this msSplitData() method:

```
==1945== 32,000 bytes in 1 blocks are definitely lost in loss record 264
of 268
==1945==    at 0x4C2AF2E: realloc (vg_replace_malloc.c:692)
==1945==    by 0x4EBDF4B: msSplitData (maporaclespatial.c:404)
==1945==    by 0x4EC90E0: msOracleSpatialLayerTranslateFilter (maporaclespatial.c:3499)
```

I wonder if in the context of `msOracleSpatialLayerTranslateFilter()`, the pointers are still valid when they are actually freed at the end of the method.