### PR TITLE
Bug fix: Included mapows.h to have correct prototype for msOWSLookupMetadata

### DIFF
--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -38,6 +38,7 @@
 
 #include "mapserver.h"
 #include "maptime.h" 
+#include "mapows.h"
 #include <assert.h>
 
 


### PR DESCRIPTION
mapserver crashed on windows with an Oracle layer (using Oracle plugin)
and "gml_types" "auto"
This was caused by using msOWSLookupMetadata without a prototype
Missing prototype gave following warning during a windows build:
Warning 13 warning C4013: 'msOWSLookupMetadata' undefined; assuming
extern returning int
C:\dev\mapserver-bentley\mapserver\maporaclespatial.c 2949 1
msplugin_oracle