### PR TITLE
Fix generated C# module

### DIFF
--- a/mapscript/csharp/CMakeLists.txt
+++ b/mapscript/csharp/CMakeLists.txt
@@ -34,14 +34,14 @@ include_directories(${PROJECT_SOURCE_DIR}/mapscript/)
 include_directories(${PROJECT_SOURCE_DIR}/mapscript/csharp)
 SET (CMAKE_SWIG_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}")
 SET( CMAKE_SWIG_FLAGS -namespace OSGeo.MapServer ${MAPSERVER_COMPILE_DEFINITIONS} -DWIN32)
-SWIG_ADD_MODULE(csharpmapscript csharp ../mapscript.i)
+SWIG_ADD_MODULE(mapscript csharp ../mapscript.i)
 
-set_target_properties(csharpmapscript PROPERTIES OUTPUT_NAME "mapscript")
+set_target_properties(mapscript PROPERTIES OUTPUT_NAME "mapscript")
 
-SWIG_LINK_LIBRARIES(csharpmapscript ${MAPSERVER_LIBMAPSERVER})
+SWIG_LINK_LIBRARIES(mapscript ${MAPSERVER_LIBMAPSERVER})
 
 
-ADD_CUSTOM_COMMAND(TARGET csharpmapscript
+ADD_CUSTOM_COMMAND(TARGET mapscript
                       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                       POST_BUILD
 					  COMMAND copy /Y ..\\..\\..\\mapscript\\csharp\\mapscript.snk


### PR DESCRIPTION
Fixes the name of the C# module.  Should be `mapscript.dll` however the generated code currently looks for `csharpmapscript.dll` so will throw an error when loaded.

Seems it's only the cmake file that has this result.

@szekerest thoughts?