### PR TITLE
Allow paging in msQueryByFilter().

### DIFF
--- a/mapquery.c
+++ b/mapquery.c
@@ -672,6 +672,7 @@ int msQueryByFilter(mapObj *map)
   rectObj search_rect;
 
   shapeObj shape;
+  int paging;
 
   int nclasses = 0;
   int *classgroup = NULL;
@@ -731,12 +732,14 @@ int msQueryByFilter(mapObj *map)
       if((lp->mingeowidth > 0) && ((map->extent.maxx - map->extent.minx) < lp->mingeowidth)) continue;
     }
 
+    paging = msLayerGetPaging(lp);
     msLayerClose(lp); /* reset */
     status = msLayerOpen(lp);
     if(status != MS_SUCCESS) goto query_error;
+    msLayerEnablePaging(lp, paging);
 
     /* disable driver paging */
-    msLayerEnablePaging(lp, MS_FALSE);
+    // msLayerEnablePaging(lp, MS_FALSE);
         
     old_filteritem = lp->filteritem; /* cache the existing filter/filteritem */
     msInitExpression(&old_filter);
@@ -816,7 +819,7 @@ int msQueryByFilter(mapObj *map)
 #endif
 
       /* Should we skip this feature? */
-      if (!msLayerGetPaging(lp) && map->query.startindex > 1) {
+      if (!paging && map->query.startindex > 1) {
         --map->query.startindex;
         msFreeShape(&shape);
         continue;


### PR DESCRIPTION
The msQueryByFilter() function disabled paging (and also max features) by default which could cause serious performance issues when you only want a feature or two from a large result set.

Steve