### PR TITLE
Add dll version stamp in Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,16 @@ mappostgis.h mapprimitive.h mapproject.h mapraster.h mapregex.h mapresample.h
 mapserver-api.h mapserver.h mapserv.h mapshape.h mapsymbol.h maptemplate.h
 mapthread.h maptile.h maptime.h maptree.h maputfgrid.h mapwcs.h uthash.h)
 
+if(WIN32)
+	configure_file(
+	  ${CMAKE_CURRENT_SOURCE_DIR}/version.rc.in
+	  ${CMAKE_CURRENT_BINARY_DIR}/version.rc
+	  @ONLY)
+	set(mapserver_SOURCES ${mapserver_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
+endif(WIN32)
+
+
+
 if(BUILD_DYNAMIC)
   add_library(mapserver SHARED ${mapserver_SOURCES} ${agg_SOURCES} ${v8_SOURCES})
   set_target_properties( mapserver  PROPERTIES

--- a/version.rc.in
+++ b/version.rc.in
@@ -1,0 +1,53 @@
+#include "winres.h"
+
+#define VER_FILEVERSION             @MapServer_VERSION_MAJOR@,@MapServer_VERSION_MINOR@,@MapServer_VERSION_REVISION@,0
+#define VER_FILEVERSION_STR         "@MapServer_VERSION_STRING@\0"
+
+#define VER_PRODUCTVERSION             @MapServer_VERSION_MAJOR@,@MapServer_VERSION_MINOR@,@MapServer_VERSION_REVISION@,0
+#define VER_PRODUCTVERSION_STR         "@MapServer_VERSION_STRING@\0"
+
+#ifndef DEBUG
+#define VER_DEBUG                   0
+#else
+#define VER_DEBUG                   VS_FF_DEBUG
+#endif
+
+VS_VERSION_INFO VERSIONINFO
+	FILEVERSION    	VER_FILEVERSION
+	PRODUCTVERSION 	VER_PRODUCTVERSION
+    FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+	FILEFLAGS      	VER_DEBUG
+    FILEOS VOS__WINDOWS32
+    FILETYPE VFT_DLL
+    FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4"
+        BEGIN
+            VALUE "CompanyName",      "MapServer"
+            VALUE "FileDescription",  "MapServer"
+            VALUE "FileVersion",      VER_FILEVERSION_STR
+            VALUE "InternalName",     ""
+            VALUE "LegalCopyright",   "Copyright (c) 2017 MapServer"
+            VALUE "LegalTrademarks1", ""
+            VALUE "LegalTrademarks2", ""
+            VALUE "OriginalFilename", ""
+            VALUE "ProductName",      "MapServer"
+            VALUE "ProductVersion",   VER_PRODUCTVERSION_STR
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        /* The following line should only be modified for localized versions.     */
+        /* It consists of any number of WORD,WORD pairs, with each pair           */
+        /* describing a language,codepage combination supported by the file.      */
+        /*                                                                        */
+        /* For example, a file might have values "0x409,1252" indicating that it  */
+        /* supports English language (0x409) in the Windows ANSI codepage (1252). */
+
+        VALUE "Translation", 0x409, 1252
+
+    END
+END


### PR DESCRIPTION
This commits adds a version stamp to the mapserver.dll on Windows like the following: Just a nice touch more than anything else.

![image](https://cloud.githubusercontent.com/assets/381660/23936873/21751e5e-09a0-11e7-840b-55449774c2cc.png)
