### PR TITLE
Allow using double quoted aliases for Oracle column aliases

### DIFF
--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -2019,7 +2019,7 @@ int msOracleSpatialLayerWhichShapes( layerObj *layer, rectObj rect, int isQuery)
   /* define SQL query */
   for( i=0; i < layer->numitems; ++i ) {
       
-      snprintf( query_str + strlen(query_str), sizeof(query_str)-strlen(query_str), "%s, ", layer->items[i] );
+      snprintf( query_str + strlen(query_str), sizeof(query_str)-strlen(query_str), "\"%s\", ", layer->items[i] );
   }
 
   /*we add the uniqueid if it was not part of the current item list*/


### PR DESCRIPTION
Adding double quotes to the columns of the mapserver generated outer
query safely allows using double quoted column aliases in the data
statement
By that we can have mixed capital column names