### PR TITLE
Fix enable out of source build path with spaces

### DIFF
--- a/mapscript/csharp/CMakeLists.txt
+++ b/mapscript/csharp/CMakeLists.txt
@@ -44,8 +44,10 @@ SWIG_LINK_LIBRARIES(csharpmapscript ${MAPSERVER_LIBMAPSERVER})
 ADD_CUSTOM_COMMAND(TARGET csharpmapscript
                       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                       POST_BUILD
-					  COMMAND copy /Y ..\\..\\..\\mapscript\\csharp\\mapscript.snk
-                      COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /t:library /out:mapscript_csharp.dll ${KEYFILE_SPEC} *.cs ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\config\\AssemblyInfo.cs
+					  COMMAND set MAPSCRIPT_SNK=${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\mapscript.snk          
+					  COMMAND set MAPSCRIPT_SNK=%MAPSCRIPT_SNK:/=\\%          
+					  COMMAND copy /Y %MAPSCRIPT_SNK%
+					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /t:library /out:mapscript_csharp.dll ${KEYFILE_SPEC} *.cs ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\config\\AssemblyInfo.cs
 					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:shpdump.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\shpdump.cs
 					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:drawmap.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmap.cs
 					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:shapeinfo.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\shapeinfo.cs

--- a/mapscript/csharp/CMakeLists.txt
+++ b/mapscript/csharp/CMakeLists.txt
@@ -46,7 +46,7 @@ ADD_CUSTOM_COMMAND(TARGET csharpmapscript
                       POST_BUILD
 					  COMMAND set MAPSCRIPT_SNK=${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\mapscript.snk          
 					  COMMAND set MAPSCRIPT_SNK=%MAPSCRIPT_SNK:/=\\%          
-					  COMMAND copy /Y %MAPSCRIPT_SNK%
+					  COMMAND copy /Y \"%MAPSCRIPT_SNK%\"
 					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /t:library /out:mapscript_csharp.dll ${KEYFILE_SPEC} *.cs ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\config\\AssemblyInfo.cs
 					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:shpdump.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\shpdump.cs
 					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:drawmap.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmap.cs


### PR DESCRIPTION
this fix allows to have an out-of-source build on any location - previously it was assumed that the mapscript csharp sources had a fixed path relative to the build
In addition we can now have build path names with spaces