### PR TITLE
Fix bug in Oracle TranslateFilter method 

### DIFF
--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -3956,7 +3956,7 @@ PluginInitializeVirtualTable(layerVTableObj* vtable, layerObj *layer)
   assert(layer != NULL);
   assert(vtable != NULL);
 
-  layer->vtable->LayerTranslateFilter = msOracleSpatialLayerTranslateFilter;
+  vtable->LayerTranslateFilter = msOracleSpatialLayerTranslateFilter;
 
 
   vtable->LayerInitItemInfo = msOracleSpatialLayerInitItemInfo;


### PR DESCRIPTION
Removed bug that caused MapServer only to use the Oracle TranslateFilter method at the first call e.g. in an FCGI environment

unlike all other vtable assignments the msOracleSpatialLayerTranslateFilter was set to layer->vtable and not to vtable

The effect was that e.g a WFS filter was only translated to the SQL statement in the first call, in all subsequent calls the original SQL statement was used and the filtering was done by MapServer after the fetch - for large datasets that caused significant overhead

