### PR TITLE
Enabled WFS sortby for Oracle plugin

### DIFF
--- a/maplayer.c
+++ b/maplayer.c
@@ -1604,9 +1604,19 @@ char* msLayerBuildSQLOrderBy(layerObj *layer)
   if( layer->sortBy.nProperties > 0 ) {
     int i;
     for(i=0;i<layer->sortBy.nProperties;i++) {
-      char* escaped = msSmallMalloc(strlen(layer->sortBy.properties[i].item) + 3);
-      sprintf(escaped, "\"%s\"", layer->sortBy.properties[i].item);
-      if( i > 0 )
+      char* escaped = msLayerEscapePropertyName(layer, layer->sortBy.properties[i].item);
+      //Enclose property name in double quotes (if it isn't yet) to ensure that mixed case property names are supported
+      if (escaped[0] != '"')
+      {
+        size_t propertyLen = strlen(escaped);
+        escaped = msSmallRealloc(escaped, propertyLen + 3);
+        memmove(escaped + 1, escaped, propertyLen);
+        escaped[0] = '\"';
+        escaped[propertyLen+1] = '\"';
+        escaped[propertyLen + 2] = 0;
+
+      }
+      if (i > 0)
         strOrderBy = msStringConcatenate(strOrderBy, ", ");
       strOrderBy = msStringConcatenate(strOrderBy, escaped);
       if( layer->sortBy.properties[i].sortOrder == SORT_DESC )

--- a/maplayer.c
+++ b/maplayer.c
@@ -1564,7 +1564,7 @@ int msLayerApplyPlainFilterToLayer(FilterEncodingNode *psNode, mapObj *map, int 
 int msLayerSupportsSorting(layerObj *layer)
 {
   if (layer && (
-         (layer->connectiontype == MS_OGR) || (layer->connectiontype == MS_POSTGIS) || (layer->connectiontype == MS_ORACLESPATIAL)
+    (layer->connectiontype == MS_OGR) || (layer->connectiontype == MS_POSTGIS) || (layer->connectiontype == MS_ORACLESPATIAL) || ((layer->connectiontype == MS_PLUGIN) && (strstr(layer->plugin_library,"msplugin_oracle") != NULL))
                )
      )
     return MS_TRUE;
@@ -1604,7 +1604,8 @@ char* msLayerBuildSQLOrderBy(layerObj *layer)
   if( layer->sortBy.nProperties > 0 ) {
     int i;
     for(i=0;i<layer->sortBy.nProperties;i++) {
-      char* escaped = msLayerEscapePropertyName(layer, layer->sortBy.properties[i].item);
+      char* escaped = msSmallMalloc(strlen(layer->sortBy.properties[i].item) + 3);
+      sprintf(escaped, "\"%s\"", layer->sortBy.properties[i].item);
       if( i > 0 )
         strOrderBy = msStringConcatenate(strOrderBy, ", ");
       strOrderBy = msStringConcatenate(strOrderBy, escaped);


### PR DESCRIPTION
Enabled WFS sortby for Oracle plugin, Previously that was only available if Oracle support was statically linked to mapserver.

additionally we now support a quoted sortby parameter to enable sorting by non-capitalized column names