### PR TITLE
Change to double quotes for Window's command line parameters

### DIFF
--- a/msautotest/misc/runtime_sub.map
+++ b/msautotest/misc/runtime_sub.map
@@ -2,20 +2,20 @@
 #
 # REQUIRES: INPUT=SHAPEFILE
 # 
-# RUN_PARMS: runtime_sub_test001.txt [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=map&layer=layer1&name1=bdry_counpy2' > [RESULT_DEVERSION] [STRIP:ShapefileOpen]
-# RUN_PARMS: runtime_sub_test002.png [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=map&layer=layer2&name2=bdry_counpy2' > [RESULT_DEMIME]
-# RUN_PARMS: runtime_sub_test003.txt [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=map&layer=layer2&name2=bad+value' > [RESULT_DEVERSION] [STRIP:ShapefileOpen]
-# RUN_PARMS: runtime_sub_test004.png [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=map&layer=layer3&name3=bdry_counpy2' > [RESULT_DEMIME]
-# RUN_PARMS: runtime_sub_test005.txt [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=map&layer=layer3&name3=bad+value' > [RESULT_DEVERSION] [STRIP:ShapefileOpen]
-# RUN_PARMS: runtime_sub_test008.png [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=map&layer=layer5' > [RESULT_DEMIME]
-# RUN_PARMS: runtime_sub_test009.png [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=map&layer=layer6&eppl=40' > [RESULT_DEMIME]
-# RUN_PARMS: runtime_sub_test010.png [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=map&layer=layer7&eppl=40' > [RESULT_DEMIME]
-# RUN_PARMS: runtime_sub_test011.png [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=map&layer=layer8&eppl2=40' > [RESULT_DEMIME]
-# RUN_PARMS: runtime_sub_test012.png [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=map&layer=layer9&mapext=0 0 300 300&mapsize=30 30&resample=average' > [RESULT_DEMIME]
-# RUN_PARMS: runtime_sub_test013.png [ENV resample=nearest] [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=map&layer=layer9&mapext=0 0 300 300&mapsize=30 30&resample=average' > [RESULT_DEMIME]
+# RUN_PARMS: runtime_sub_test001.txt [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer1&name1=bdry_counpy2" > [RESULT_DEVERSION] [STRIP:ShapefileOpen]
+# RUN_PARMS: runtime_sub_test002.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer2&name2=bdry_counpy2" > [RESULT_DEMIME]
+# RUN_PARMS: runtime_sub_test003.txt [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer2&name2=bad+value" > [RESULT_DEVERSION] [STRIP:ShapefileOpen]
+# RUN_PARMS: runtime_sub_test004.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer3&name3=bdry_counpy2" > [RESULT_DEMIME]
+# RUN_PARMS: runtime_sub_test005.txt [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer3&name3=bad+value" > [RESULT_DEVERSION] [STRIP:ShapefileOpen]
+# RUN_PARMS: runtime_sub_test008.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer5" > [RESULT_DEMIME]
+# RUN_PARMS: runtime_sub_test009.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer6&eppl=40" > [RESULT_DEMIME]
+# RUN_PARMS: runtime_sub_test010.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer7&eppl=40" > [RESULT_DEMIME]
+# RUN_PARMS: runtime_sub_test011.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer8&eppl2=40" > [RESULT_DEMIME]
+# RUN_PARMS: runtime_sub_test012.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer9&mapext=0 0 300 300&mapsize=30 30&resample=average" > [RESULT_DEMIME]
+# RUN_PARMS: runtime_sub_test013.png [ENV resample=nearest] [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer9&mapext=0 0 300 300&mapsize=30 30&resample=average" > [RESULT_DEMIME]
 
 #override alloed request types by url. if we do not pass "enable=capabilities" in the url, then "layer2" would not appear in the resulting xml doc
-# RUN_PARMS: runtime_sub_test_caps.xml [MAPSERV] QUERY_STRING='map=[MAPFILE]&service=wms&request=getcapabilities&enable=getcapabilities' > [RESULT_DEVERSION]
+# RUN_PARMS: runtime_sub_test_caps.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&service=wms&request=getcapabilities&enable=getcapabilities" > [RESULT_DEVERSION]
 #
 MAP
   NAME 'runtime_sub'


### PR DESCRIPTION
Otherwise all these tests fail on Windows as the command isn't split properly and results in errors such as:

`'name1' is not recognized as an internal or external command,operable program or batch file.`

The change to double quotes shouldn't affect Linux as I understand it.