### PR TITLE
Fix error to support Oracle compound elements for GTYPE 2007

### DIFF
--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -1707,7 +1707,7 @@ static int osGetOrdinates(msOracleSpatialDataHandler *dthand, msOracleSpatialHan
   } /* end of not-null-object if */
 
   if (compound_type){
-    if(gtype == 2003)
+    if (gtype == 2003 || gtype == 2007)
       shape->type = MS_SHAPE_POLYGON;
     msFreeShape(&newshape);
   }


### PR DESCRIPTION
Fix error to support Oracle compound elements for GTYPE 2007 (multipolygon) and not only for GTYPE 2003 (polygon)