### PR TITLE
Update test Mapfile encoding to utf-8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: php
 php:
   - 5.5

--- a/mapcopy.c
+++ b/mapcopy.c
@@ -500,6 +500,7 @@ int msCopyStyle(styleObj *dst, styleObj *src)
   MS_COPYSTELEM(offsetx);
   MS_COPYSTELEM(offsety);
   MS_COPYSTELEM(angle);
+  MS_COPYSTELEM(autoangle);
   MS_COPYSTELEM(minvalue);
   MS_COPYSTELEM(maxvalue);
   MS_COPYSTELEM(opacity);

--- a/msautotest/wxs/expected/wms_inspire_scenario1_cap130_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario1_cap130_ger.xml
@@ -48,6 +48,8 @@
       <Format>image/png</Format>
       <Format>image/jpeg</Format>
       <Format>image/png; mode=8bit</Format>
+      <Format>image/vnd.jpeg-png</Format>
+      <Format>image/vnd.jpeg-png8</Format>
       <Format>application/x-pdf</Format>
       <Format>image/svg+xml</Format>
       <Format>image/tiff</Format>

--- a/msautotest/wxs/expected/wms_inspire_scenario1_cap130_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario1_cap130_ger.xml
@@ -48,8 +48,6 @@
       <Format>image/png</Format>
       <Format>image/jpeg</Format>
       <Format>image/png; mode=8bit</Format>
-      <Format>image/vnd.jpeg-png</Format>
-      <Format>image/vnd.jpeg-png8</Format>
       <Format>application/x-pdf</Format>
       <Format>image/svg+xml</Format>
       <Format>image/tiff</Format>

--- a/msautotest/wxs/expected/wms_inspire_scenario1_cap130_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario1_cap130_ger.xml
@@ -48,6 +48,8 @@
       <Format>image/png</Format>
       <Format>image/jpeg</Format>
       <Format>image/png; mode=8bit</Format>
+      <Format>image/vnd.jpeg-png</Format>
+      <Format>image/vnd.jpeg-png8</Format>
       <Format>application/x-pdf</Format>
       <Format>image/svg+xml</Format>
       <Format>image/tiff</Format>
@@ -89,7 +91,7 @@
   </inspire_vs:ExtendedCapabilities>
   <Layer>
     <Name>TN.RoadTransportNetwork.RoadArea</Name>
-    <Title>Verkehrsnetze: Straﬂenfl‰che</Title>
+    <Title>Verkehrsnetze: Stra√üenfl√§che</Title>
     <Abstract>myroadareaabstractger</Abstract>
     <KeywordList>
         <Keyword>myroadareakeyword1</Keyword>
@@ -124,7 +126,7 @@
     </Style>
     <Layer queryable="0" opaque="0" cascaded="0">
         <Name>TN.RoadTransportNetwork.RoadLink</Name>
-        <Title>Verkehrsnetze: Straﬂensegment</Title>
+        <Title>Verkehrsnetze: Stra√üensegment</Title>
         <Abstract>myroadlinklayerabstractger</Abstract>
         <KeywordList>
             <Keyword>myroadlinklayerkeyword1</Keyword>

--- a/msautotest/wxs/expected/wms_inspire_scenario2_cap111_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario2_cap111_ger.xml
@@ -50,6 +50,8 @@
       <Format>image/png</Format>
       <Format>image/jpeg</Format>
       <Format>image/png; mode=8bit</Format>
+      <Format>image/vnd.jpeg-png</Format>
+      <Format>image/vnd.jpeg-png8</Format>
       <Format>application/x-pdf</Format>
       <Format>image/svg+xml</Format>
       <Format>image/tiff</Format>

--- a/msautotest/wxs/expected/wms_inspire_scenario2_cap111_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario2_cap111_ger.xml
@@ -50,6 +50,8 @@
       <Format>image/png</Format>
       <Format>image/jpeg</Format>
       <Format>image/png; mode=8bit</Format>
+      <Format>image/vnd.jpeg-png</Format>
+      <Format>image/vnd.jpeg-png8</Format>
       <Format>application/x-pdf</Format>
       <Format>image/svg+xml</Format>
       <Format>image/tiff</Format>
@@ -112,7 +114,7 @@
   </VendorSpecificCapabilities>
   <Layer>
     <Name>TN.RoadTransportNetwork.RoadArea</Name>
-    <Title>Verkehrsnetze: Straﬂenfl‰che</Title>
+    <Title>Verkehrsnetze: Stra√üenfl√§che</Title>
     <Abstract>myroadareaabstractger</Abstract>
     <KeywordList>
         <Keyword>myroadareakeyword1</Keyword>
@@ -138,7 +140,7 @@
     </Style>
     <Layer queryable="0" opaque="0" cascaded="0">
         <Name>TN.RoadTransportNetwork.RoadLink</Name>
-        <Title>Verkehrsnetze: Straﬂensegment</Title>
+        <Title>Verkehrsnetze: Stra√üensegment</Title>
         <Abstract>myroadlinklayerabstractger</Abstract>
         <KeywordList>
             <Keyword>myroadlinklayerkeyword1</Keyword>

--- a/msautotest/wxs/expected/wms_inspire_scenario2_cap111_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario2_cap111_ger.xml
@@ -50,8 +50,6 @@
       <Format>image/png</Format>
       <Format>image/jpeg</Format>
       <Format>image/png; mode=8bit</Format>
-      <Format>image/vnd.jpeg-png</Format>
-      <Format>image/vnd.jpeg-png8</Format>
       <Format>application/x-pdf</Format>
       <Format>image/svg+xml</Format>
       <Format>image/tiff</Format>

--- a/msautotest/wxs/expected/wms_inspire_scenario2_cap130_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario2_cap130_ger.xml
@@ -48,6 +48,8 @@
       <Format>image/png</Format>
       <Format>image/jpeg</Format>
       <Format>image/png; mode=8bit</Format>
+      <Format>image/vnd.jpeg-png</Format>
+      <Format>image/vnd.jpeg-png8</Format>
       <Format>application/x-pdf</Format>
       <Format>image/svg+xml</Format>
       <Format>image/tiff</Format>

--- a/msautotest/wxs/expected/wms_inspire_scenario2_cap130_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario2_cap130_ger.xml
@@ -48,8 +48,6 @@
       <Format>image/png</Format>
       <Format>image/jpeg</Format>
       <Format>image/png; mode=8bit</Format>
-      <Format>image/vnd.jpeg-png</Format>
-      <Format>image/vnd.jpeg-png8</Format>
       <Format>application/x-pdf</Format>
       <Format>image/svg+xml</Format>
       <Format>image/tiff</Format>

--- a/msautotest/wxs/expected/wms_inspire_scenario2_cap130_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario2_cap130_ger.xml
@@ -48,6 +48,8 @@
       <Format>image/png</Format>
       <Format>image/jpeg</Format>
       <Format>image/png; mode=8bit</Format>
+      <Format>image/vnd.jpeg-png</Format>
+      <Format>image/vnd.jpeg-png8</Format>
       <Format>application/x-pdf</Format>
       <Format>image/svg+xml</Format>
       <Format>image/tiff</Format>
@@ -108,7 +110,7 @@
   </inspire_vs:ExtendedCapabilities>
   <Layer>
     <Name>TN.RoadTransportNetwork.RoadArea</Name>
-    <Title>Verkehrsnetze: Straﬂenfl‰che</Title>
+    <Title>Verkehrsnetze: Stra√üenfl√§che</Title>
     <Abstract>myroadareaabstractger</Abstract>
     <KeywordList>
         <Keyword>myroadareakeyword1</Keyword>
@@ -139,7 +141,7 @@
     </Style>
     <Layer queryable="0" opaque="0" cascaded="0">
         <Name>TN.RoadTransportNetwork.RoadLink</Name>
-        <Title>Verkehrsnetze: Straﬂensegment</Title>
+        <Title>Verkehrsnetze: Stra√üensegment</Title>
         <Abstract>myroadlinklayerabstractger</Abstract>
         <KeywordList>
             <Keyword>myroadlinklayerkeyword1</Keyword>

--- a/msautotest/wxs/wms_inspire_scenario1.map
+++ b/msautotest/wxs/wms_inspire_scenario1.map
@@ -101,7 +101,7 @@ WEB
   "wms_contactorganization" "MapServer"                                         #responsible organisation
   "wms_contactposition" "owner"                                                 #responsible organisation, value according "INSPIRE Metadata Regulation" (part D6)
   "wms_rootlayer_title.eng" "Transport networks: Road Area"
-  "wms_rootlayer_title.ger" "Verkehrsnetze: Straﬂenfl‰che"
+  "wms_rootlayer_title.ger" "Verkehrsnetze: Stra√üenfl√§che"
   "wms_rootlayer_abstract" "myroadarealayerabstract"                            #to test fallback
   "wms_rootlayer_abstract.ger" "myroadareaabstractger"
   "wms_rootlayer_keywordlist" "myroadareakeyword1,myroadareakeyword2"
@@ -133,7 +133,7 @@ LAYER
  DATA "road_%language%"
  METADATA
   "wms_title.eng" "Transport networks: Road Link"
-  "wms_title.ger" "Verkehrsnetze: Straﬂensegment"
+  "wms_title.ger" "Verkehrsnetze: Stra√üensegment"
   "wms_abstract" "myroadlinklayerabstract"                                      #to test fallback
   "wms_abstract.ger" "myroadlinklayerabstractger"
   "wms_keywordlist" "myroadlinklayerkeyword1,myroadlinklayerkeyword2"

--- a/msautotest/wxs/wms_inspire_scenario2.map
+++ b/msautotest/wxs/wms_inspire_scenario2.map
@@ -112,7 +112,7 @@ WEB
   "wms_contactorganization" "MapServer"                                         #responsible organisation
   "wms_contactposition" "owner"                                                 #responsible organisation, value according "INSPIRE Metadata Regulation" (part D6)
   "wms_rootlayer_title.eng" "Transport networks: Road Area"
-  "wms_rootlayer_title.ger" "Verkehrsnetze: Straﬂenfl‰che"
+  "wms_rootlayer_title.ger" "Verkehrsnetze: Stra√üenfl√§che"
   "wms_rootlayer_abstract" "myroadarealayerabstract"                            #to test fallback
   "wms_rootlayer_abstract.ger" "myroadareaabstractger"
   "wms_rootlayer_keywordlist" "myroadareakeyword1,myroadareakeyword2"
@@ -140,7 +140,7 @@ LAYER
  DATA "road_%language%"
  METADATA
   "wms_title.eng" "Transport networks: Road Link"
-  "wms_title.ger" "Verkehrsnetze: Straﬂensegment"
+  "wms_title.ger" "Verkehrsnetze: Stra√üensegment"
   "wms_abstract" "myroadlinklayerabstract"                                      #to test fallback
   "wms_abstract.ger" "myroadlinklayerabstractger"
   "wms_keywordlist" "myroadlinklayerkeyword1,myroadlinklayerkeyword2"


### PR DESCRIPTION
This replaces #5460 as it was not created in a feature branch..apologies. 

These files were in iso-8859-1 (for the German accents in Straßenfläche). All Mapfiles should be in utf-8 according to the docs.

Sample Python code used to convert below for reference (all line breaks etc. preserved). 

```
def change_encoding():
    sourceEncoding = "iso-8859-1"
    targetEncoding = "utf-8"
    files = ["wms_inspire_scenario2_cap130_ger.xml","wms_inspire_scenario2_cap111_ger.xml","wms_inspire_scenario1_cap130_ger.xml"]

    for f in files:
        source = open(os.path.join(r"D:\GitHub\mapserver\msautotest\wxs\expected", f))
        target = open(os.path.join(r"D:\GitHub\mapserver\msautotest\wxs\expected", f + ".utf.xml"), "wb")
        target.write(unicode(source.read(), sourceEncoding).encode(targetEncoding))
```