### PR TITLE
postgis - implements the "ilike" / IEQ operator

### DIFF
--- a/maplayer.c
+++ b/maplayer.c
@@ -623,7 +623,7 @@ const char *msExpressionTokenToString(int token) {
     case MS_TOKEN_COMPARISON_GE: return " >= ";
     case MS_TOKEN_COMPARISON_LT: return " < ";
     case MS_TOKEN_COMPARISON_LE: return " <= ";
-    case MS_TOKEN_COMPARISON_IEQ: return "";
+    case MS_TOKEN_COMPARISON_IEQ: return " ilike ";
     case MS_TOKEN_COMPARISON_RE: return " ~ ";
     case MS_TOKEN_COMPARISON_IRE: return " ~* ";
     case MS_TOKEN_COMPARISON_IN: return " in ";

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -3990,7 +3990,6 @@ int msPostGISLayerTranslateFilter(layerObj *layer, expressionObj *filter, char *
           break;
 
 	/* unsupported tokens */ 
-	case MS_TOKEN_COMPARISON_IEQ:
         case MS_TOKEN_COMPARISON_BEYOND:
 	case MS_TOKEN_FUNCTION_TOSTRING:
 	case MS_TOKEN_FUNCTION_ROUND:


### PR DESCRIPTION
This PR is a fix proposal for issue #5499 ; when a OGC filter is posted with a case-insensitive search, the postgis code is unable to translate the filter into a query, raising the following error:

```
msPostGISLayerTranslateFilter(): General error message. Translation to native SQL failed.
```

The fix was simply implemented by removing the `MS_TOKEN_COMPARISON_IEQ` from the "unsupported operator" list in mappostgis.c then adding a "ilike" expression instead of an empty string in the method responsible of transforming the token to SQL.

Tests: directly by faking onto our dev server the libmaserver.so with a custom `LD_LIBRARY_PATH`, ensuring the previous postgis function was actually able to generated a SQL query (which can be then retrieved in our postgresql logs with no error).

Concerns / critics: relying on the postgresql doc, it actually seems that the ILIKE operator is not in the SQL standard but a postgresql extension, and maplayer.c seems to be db-agnostic.

