### PR TITLE
Issue #5508 - Revived ANTIALIAS keyword in STYLE section 

### DIFF
--- a/mapagg.cpp
+++ b/mapagg.cpp
@@ -67,11 +67,6 @@
 #include <pixman.h>
 #endif
 
-#ifdef AGG_ALIASED_ENABLED
-#include "renderers/agg/include/agg_renderer_primitives.h"
-#include "renderers/agg/include/agg_rasterizer_outline.h"
-#endif
-
 typedef mapserver::order_bgra band_order;
 
 #define AGG_LINESPACE 1.33
@@ -96,10 +91,6 @@ typedef mapserver::font_cache_manager<font_engine_type> font_manager_type;
 typedef mapserver::conv_curve<font_manager_type::path_adaptor_type> font_curve_type;
 typedef mapserver::glyph_raster_bin<color_type> glyph_gen;
 
-#ifdef AGG_ALIASED_ENABLED
-typedef mapserver::renderer_primitives<renderer_base> renderer_primitives;
-typedef mapserver::rasterizer_outline<renderer_primitives> rasterizer_outline;
-#endif
 static color_type AGG_NO_COLOR = color_type(0, 0, 0, 0);
 
 #define aggColor(c) mapserver::rgba8_pre((c)->red, (c)->green, (c)->blue, (c)->alpha)
@@ -117,11 +108,6 @@ class AGG2Renderer
 public:
 
   AGG2Renderer()
-#ifdef AGG_ALIASED_ENABLED
-    :
-    m_renderer_primitives(m_renderer_base),
-    m_rasterizer_primitives(m_renderer_primitives)
-#endif
   {
     stroke = NULL;
     dash = NULL;
@@ -148,10 +134,6 @@ public:
   compop_renderer_base m_compop_renderer_base;
   renderer_scanline m_renderer_scanline;
   renderer_scanline_aliased m_renderer_scanline_aliased;
-#ifdef AGG_ALIASED_ENABLED
-  renderer_primitives m_renderer_primitives;
-  rasterizer_outline m_rasterizer_primitives;
-#endif
   rasterizer_scanline m_rasterizer_aa;
   rasterizer_scanline m_rasterizer_aa_gamma;
   mapserver::scanline_p8 sl_poly; /*packed scanlines, works faster when the area is larger
@@ -202,14 +184,6 @@ int agg2RenderLine(imageObj *img, shapeObj *p, strokeStyleObj *style)
 
   AGG2Renderer *r = AGG_RENDERER(img);
   line_adaptor lines = line_adaptor(p);
-  
- 
-#ifdef AGG_ALIASED_ENABLED
-  r->m_rasterizer_primitives.reset();
-  r->m_renderer_primitives.line_color(aggColor(style->color));
-  r->m_rasterizer_primitives.add_path(lines);
-  return MS_SUCCESS;
-#endif
 
   r->m_rasterizer_aa.reset();
   r->m_rasterizer_aa.filling_rule(mapserver::fill_non_zero);

--- a/mapcopy.c
+++ b/mapcopy.c
@@ -489,6 +489,7 @@ int msCopyStyle(styleObj *dst, styleObj *src)
   MS_COPYSTELEM(gap);
   MS_COPYSTELEM(linejoin);
   MS_COPYSTELEM(linejoinmaxsize);
+  MS_COPYSTELEM(antialiased);
   MS_COPYSTELEM(linecap);
   MS_COPYSTELEM(symbol);
   MS_COPYSTELEM(size);

--- a/mapfile.c
+++ b/mapfile.c
@@ -2582,6 +2582,7 @@ int initStyle(styleObj *style)
   style->polaroffsetpixel = style->polaroffsetangle = 0; /* no polar offset */
   style->angle = 0;
   style->autoangle= MS_FALSE;
+  style->antialiased = MS_TRUE;
   style->opacity = 100; /* fully opaque */
 
   msInitExpression(&(style->_geomtransform));
@@ -2639,8 +2640,10 @@ int loadStyle(styleObj *style)
           style->autoangle=MS_TRUE;
         }
         break;
-      case(ANTIALIAS): /*ignore*/
-        msyylex();
+      case(ANTIALIAS):
+		if ((symbol = getSymbol(2, MS_TRUE,MS_FALSE)) == -1) return(-1);
+        if (symbol == MS_FALSE)
+        	style->antialiased = MS_FALSE;
         break;
       case(BACKGROUNDCOLOR):
         if(loadColor(&(style->backgroundcolor), NULL) != MS_SUCCESS) return(MS_FAILURE);

--- a/maprendering.c
+++ b/maprendering.c
@@ -597,6 +597,7 @@ int msDrawLineSymbol(mapObj *map, imageObj *image, shapeObj *p,
         s.linecap = style->linecap;
         s.linejoin = style->linejoin;
         s.linejoinmaxsize = style->linejoinmaxsize;
+        s.antialiased = style->antialiased;
         s.width = width;
         s.patternlength = style->patternlength;
         for(i=0; i<s.patternlength; i++)

--- a/mapserver.h
+++ b/mapserver.h
@@ -970,6 +970,9 @@ extern "C" {
     /*should an angle be automatically computed*/
     int autoangle;
 
+    /* should lines be drawn with antialiasing (default)? */
+    int antialiased;
+
     colorObj color;
     colorObj backgroundcolor;
     colorObj outlinecolor;
@@ -2971,9 +2974,10 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
     int linecap; /* MS_CJC_TRIANGLE, MS_CJC_SQUARE, MS_CJC_ROUND, MS_CJC_BUTT */
     int linejoin; /* MS_CJC_BEVEL MS_CJC_ROUND MS_CJC_MITER */
     double linejoinmaxsize;
+    int antialiased;
   } strokeStyleObj;
 
-#define INIT_STROKE_STYLE(s) { (s).width=0; (s).patternlength=0; (s).color=NULL; (s).linecap=MS_CJC_ROUND; (s).linejoin=MS_CJC_ROUND; (s).linejoinmaxsize=0;}
+#define INIT_STROKE_STYLE(s) { (s).width=0; (s).patternlength=0; (s).color=NULL; (s).linecap=MS_CJC_ROUND; (s).linejoin=MS_CJC_ROUND; (s).linejoinmaxsize=0; (s).antialiased=MS_TRUE; }
 
 
   /*

--- a/msautotest/renderers/line_aliased.map
+++ b/msautotest/renderers/line_aliased.map
@@ -1,0 +1,35 @@
+# RUN_PARMS: line_aliased.png [SHP2IMG] -m [MAPFILE] -i png -o [RESULT]
+#
+map
+
+imagetype png
+size 400 300
+extent -166.245673 -55.551347 174.019748 53.883753
+shapepath "../misc/data"
+fontset "../misc/fonts.lst"
+symbolset "symbolset"
+
+OUTPUTFORMAT
+      NAME "png"
+	  DRIVER AGG/PNG
+	  MIMETYPE "image/png"
+	  IMAGEMODE RGBA
+	  EXTENSION "png"
+	  FORMATOPTION "GAMMA=1.0"
+END
+
+layer
+    type line
+    data "testlines"
+    status default
+    name "lines"
+    class
+        style
+            color 128 128 128
+            width 5
+            ANTIALIAS FALSE            
+        end
+    end
+end
+
+end

--- a/msautotest/renderers/line_antialiased.map
+++ b/msautotest/renderers/line_antialiased.map
@@ -1,0 +1,35 @@
+# RUN_PARMS: line_anti_aliased.png [SHP2IMG] -m [MAPFILE] -i png -o [RESULT]
+#
+map
+
+imagetype png
+size 400 300
+extent -166.245673 -55.551347 174.019748 53.883753
+shapepath "../misc/data"
+fontset "../misc/fonts.lst"
+symbolset "symbolset"
+
+OUTPUTFORMAT
+      NAME "png"
+	  DRIVER AGG/PNG
+	  MIMETYPE "image/png"
+	  IMAGEMODE RGBA
+	  EXTENSION "png"
+	  FORMATOPTION "GAMMA=1.0"
+END
+
+layer
+    type line
+    data "testlines"
+    status default
+    name "lines"
+    class
+        style
+            color 128 128 128
+            width 5
+            ANTIALIAS TRUE            
+        end
+    end
+end
+
+end


### PR DESCRIPTION
 Revived ANTIALIAS keyword in STYLE section (only for line rendering). 

The parser in the current code still recognizes this keyword, but the loadStyle() method simply ignores it. I'm now setting a flag in styleObj if the symbol is MS_FALSE, then copy that flag to strokeStyleObj, and in agg2RenderLine (mapagg.cpp) I pick renderer_scanline_bin_solid if the flag is MS_FALSE.