### PR TITLE
Proper escaping of Oracle sortby parameters - Enhancement for pull request #5454

### DIFF
--- a/maplayer.c
+++ b/maplayer.c
@@ -1606,18 +1606,7 @@ char* msLayerBuildSQLOrderBy(layerObj *layer)
     int i;
     for(i=0;i<layer->sortBy.nProperties;i++) {
       char* escaped = msLayerEscapePropertyName(layer, layer->sortBy.properties[i].item);
-      //Enclose property name in double quotes (if it isn't yet) to ensure that mixed case property names are supported
-      if (escaped[0] != '"')
-      {
-        size_t propertyLen = strlen(escaped);
-        escaped = msSmallRealloc(escaped, propertyLen + 3);
-        memmove(escaped + 1, escaped, propertyLen);
-        escaped[0] = '\"';
-        escaped[propertyLen+1] = '\"';
-        escaped[propertyLen + 2] = 0;
-
-      }
-      if (i > 0)
+      if( i > 0 )
         strOrderBy = msStringConcatenate(strOrderBy, ", ");
       strOrderBy = msStringConcatenate(strOrderBy, escaped);
       if( layer->sortBy.properties[i].sortOrder == SORT_DESC )

--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -3975,7 +3975,7 @@ PluginInitializeVirtualTable(layerVTableObj* vtable, layerObj *layer)
   vtable->LayerApplyFilterToLayer = msLayerApplyCondSQLFilterToLayer;
   vtable->LayerSetTimeFilter = msLayerMakeBackticsTimeFilter;
   //vtable->LayerSetTimeFilter = msOracleSpatialLayerSetTimeFilter;
-  vtable->LayerEscapePropertyName = msOracleSpatialEscapePropertyName;
+  //vtable->LayerEscapePropertyName = msOracleSpatialEscapePropertyName;
   /* layer->vtable->LayerGetNumFeatures, use default */
   /* layer->vtable->LayerGetAutoProjection = msOracleSpatialLayerGetAutoProjection; Disabled until tested */
   vtable->LayerEnablePaging = msOracleSpatialEnablePaging;
@@ -4009,7 +4009,7 @@ int msOracleSpatialLayerInitializeVirtualTable(layerObj *layer)
   layer->vtable->LayerApplyFilterToLayer = msLayerApplyCondSQLFilterToLayer;
   layer->vtable->LayerSetTimeFilter = msLayerMakeBackticsTimeFilter;
   //layer->vtable->LayerSetTimeFilter = msOracleSpatialLayerSetTimeFilter;
-  layer->vtable->LayerEscapePropertyName = msOracleSpatialEscapePropertyName;
+  //layer->vtable->LayerEscapePropertyName = msOracleSpatialEscapePropertyName;
   /* layer->vtable->LayerCreateItems, use default */
   /* layer->vtable->LayerGetNumFeatures, use default */
   /* layer->vtable->LayerGetAutoProjection = msOracleSpatialLayerGetAutoProjection; Disabled until tested */


### PR DESCRIPTION
This is to clean up some stuff from pull request #5454 - see newest comments there

commented out vtable entries for msOracleSpatialEscapePropertyName.
By that we don't need the additional logic described below anymore

Revert "Enclose the sortby property in double quotes by putting the result of  msLayerEscapePropertyName into double quotes"

This reverts commit d5f89a3353854b0f6a8eda0758d99e74372fdf9f.