### PR TITLE
Throw exception if wms layer is essential

### DIFF
--- a/mapwmslayer.c
+++ b/mapwmslayer.c
@@ -1255,7 +1255,7 @@ int msDrawWMSLayerLow(int nLayerId, httpRequestObj *pasReqInfo,
   if ( !MS_HTTP_SUCCESS( pasReqInfo[iReq].nStatus ) ) {
     /* ====================================================================
           Failed downloading layer... we log an error but we still return
-          SUCCESS here so that the layer is only skipped intead of aborting
+          SUCCESS here so that the layer is only skipped instead of aborting
           the whole draw map.
           If the layer is essential the map is not to be drawn.
      ==================================================================== */
@@ -1275,7 +1275,7 @@ int msDrawWMSLayerLow(int nLayerId, httpRequestObj *pasReqInfo,
    * Check the Content-Type of the response to see if we got an exception,
    * if yes then try to parse it and pass the info to msSetError().
    * We log an error but we still return SUCCESS here so that the layer
-   * is only skipped intead of aborting the whole draw map.
+   * is only skipped instead of aborting the whole draw map.
    * If the layer is essential the map is not to be drawn.
    * ------------------------------------------------------------------ */
   if (pasReqInfo[iReq].pszContentType &&


### PR DESCRIPTION
Normally, when a layer request to another WMS server fails, this layer is skipped and the map is rendered without this layer. This behaviour is absolutely OK in most cases, but sometimes it could be necessary that the complete map fails if the requested layer is essential for this map.
This patch looks whether "wms_essential" is set. If not, MapServer behaves like before, otherwise an exception is thrown.