### PR TITLE
log2vis check if multi-line

### DIFF
--- a/mapstring.c
+++ b/mapstring.c
@@ -1659,7 +1659,13 @@ char *msGetFriBidiEncodedString(const char *string, const char *encoding)
     ltov = NULL;
     vtol = NULL;
     levels = NULL;
-
+    
+    if (strchr(logical, '\n') != NULL) {
+      msSetError(MS_IDENTERR, "Inputted string is a multi-line paragraph.",
+                 "msGetFriBidiEncodedString()");
+      return NULL;
+    }
+    
     /* Create a bidi string. */
     log2vis = fribidi_log2vis (logical, len, &base,
                                /* output */


### PR DESCRIPTION
It seems that log2vis is deprecated because it doesn't support multi-line paragraphs. See: https://lists.freedesktop.org/archives/fribidi/2008-January/000515.html
I added a if statement that would throw an error given a multi-line paragraph.