### PR TITLE
Fix segfault with polyline labels for empty (multi)linestrings

### DIFF
--- a/mapprimitive.c
+++ b/mapprimitive.c
@@ -1552,7 +1552,7 @@ void msPolylineComputeLineSegments(shapeObj *shape, struct polyline_lengths *pll
 
   pll->ll = msSmallMalloc(shape->numlines * sizeof(struct line_lengths));
   pll->total_length = 0;
-  
+  pll->longest_line_index = 0;
 
 
   for(i=0; i<shape->numlines; i++) {


### PR DESCRIPTION
longest_line_index can point outside pll->ll if shape only contains
lines with <2 points.

This can segfault here: https://github.com/mapserver/mapserver/blob/c6abf4224e6a1429869b9ee7c7a72dd791f74eb3/mapprimitive.c#L1821-L1822

I'm unable to create a minimal mapfile as WKT and POINT features do not support broken MultiLineStrings.
However, msPolylineComputeLineSegments does already expect lines with <2 points.
https://github.com/mapserver/mapserver/blob/c6abf4224e6a1429869b9ee7c7a72dd791f74eb3/mapprimitive.c#L1584