### PR TITLE
Fix MSSql query generator when using filters with multiple parameters

### DIFF
--- a/mapmssql2008.c
+++ b/mapmssql2008.c
@@ -2387,6 +2387,11 @@ int process_node(layerObj* layer, expressionObj *filter)
        break;
     /* literal tokens */
     case MS_TOKEN_LITERAL_BOOLEAN:
+      if(layerinfo->current_node->tokenval.dblval == MS_TRUE)
+        filter->native_string = msStringConcatenate(filter->native_string, "1");
+      else
+        filter->native_string = msStringConcatenate(filter->native_string, "0");
+      break;
     case MS_TOKEN_LITERAL_NUMBER:
       strtmpl = "%lf";
       snippet = (char *) msSmallMalloc(strlen(strtmpl) + 16);


### PR DESCRIPTION
This WFS filter 
`<Filter>
	<AND>
		<PropertyIsEqualTo><PropertyName>Status</PropertyName><Literal>Open</Literal></PropertyIsEqualTo>
		<BBOX><Box srsName='EPSG:3857'><coordinates>...</coordinates></Box></BBOX>
	</AND>
</Filter>`

generates this TSQL query : 
`WHERE ((Geography.STIntersects(geography::STGeomFromText('POLYGON ((...))', 4326)) = 1.000000 AND ([Status] = 'Open'))) and Geography.STIntersects(geography::STGeomFromText('POLYGON((...))',4326)) = 1 `

The `1.000000` seems harmless but causes a big performance issue. In my case, the SQL spatial index is not used. 

This PR generates the following TSQL query and solves the issue.
`WHERE ((Geography.STIntersects(geography::STGeomFromText('POLYGON ((...))', 4326)) = 1 AND ([Status] = 'Open'))) and Geography.STIntersects(geography::STGeomFromText('POLYGON((...))',4326)) = 1 `

