### PR TITLE
Fix white-space handling on mappostgis.c

### DIFF
--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1355,6 +1355,14 @@ int msPostGISParseData(layerObj *layer)
   ** What clause appear after 2nd 'using'?
   */
   for ( tmp = pos_use_2nd + 5; *tmp == ' '; tmp++ );
+  if ( strncmp ( tmp, "unique ", 7 ) == 0 )
+  {
+    for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
+  }
+  else
+  {
+    if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
+  };
 
   /*
   ** Look for the optional ' using unique ID' string first.

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1352,16 +1352,19 @@ int msPostGISParseData(layerObj *layer)
   };
 
   /*
-  ** What clause appear after 2nd 'using'?
+  ** What clause appear after 2nd 'using', if set?
   */
-  for ( tmp = pos_use_2nd + 5; *tmp == ' '; tmp++ );
-  if ( strncmp ( tmp, "unique ", 7 ) == 0 )
+  if ( pos_use_2nd )
   {
-    for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
-  }
-  else
-  {
-    if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
+    for ( tmp = pos_use_2nd + 5; *tmp == ' '; tmp++ );
+    if ( strncmp ( tmp, "unique ", 7 ) == 0 )
+    {
+      for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
+    }
+    else
+    {
+      if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
+    };
   };
 
   /*

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1416,6 +1416,7 @@ int msPostGISParseData(layerObj *layer)
   if (!pos_srid) {
     layerinfo->srid = (char*) msSmallMalloc(1);
     (layerinfo->srid)[0] = '\0'; /* no SRID, so return just null terminator*/
+/*+*
   } else {
     slength = strspn(pos_srid, "-0123456789");
     if (!slength) {

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1370,26 +1370,26 @@ int msPostGISParseData(layerObj *layer)
     for ( tmp = pos_use_1st + 5; *tmp == ' '; tmp++ );
     if ( strncmp ( tmp, "unique ", 7 ) == 0 )
     {
-/***
       if ( pos_uid )
       {
         free ( data );
+/***
         msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. Too many 'USING UNIQUE' found! %s", "msPostGISParseData()", layer->data);
+ ***/
         return MS_FAILURE;
       };
- ***/
       for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
     };
     if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
     {
-/***
       if ( pos_srid )
       {
         free ( data );
+/***
         msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. Too many 'USING SRID' found! %s", "msPostGISParseData()", layer->data);
+ ***/
         return MS_FAILURE;
       };
- ***/
       pos_srid = tmp + 5;
     };
   };

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1380,18 +1380,18 @@ int msPostGISParseData(layerObj *layer)
  ***/
       for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
     };
-/***
     if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
     {
+/***
       if ( pos_srid )
       {
         free ( data );
         msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. Too many 'USING SRID' found! %s", "msPostGISParseData()", layer->data);
         return MS_FAILURE;
       };
+ ***/
       pos_srid = tmp + 5;
     };
- ***/
   };
 
   /*

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1373,8 +1373,8 @@ int msPostGISParseData(layerObj *layer)
       if ( pos_uid )
       {
         free ( data );
-/***
         msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. Too many 'USING UNIQUE' found! %s", "msPostGISParseData()", layer->data);
+/***
  ***/
         return MS_FAILURE;
       };

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1294,15 +1294,14 @@ msPostGISRetrievePK(layerObj *layer)
 */
 int msPostGISParseData(layerObj *layer)
 {
-  char *pos_opt, *pos_scn, *tmp, *pos_srid, *pos_uid, *pos_geom, *data;
-  char *pos_use_1st, *pos_use_2nd;
-  int slength, dsize;
+
+	char *pos_opt, *pos_scn, *tmp, *pos_srid, *pos_uid, *pos_geom, *data;
+  int slength;
   msPostGISLayerInfo *layerinfo;
 
   assert(layer != NULL);
   assert(layer->layerinfo != NULL);
 
-/*+*
   layerinfo = (msPostGISLayerInfo*)(layer->layerinfo);
 
   if (layer->debug) {
@@ -1313,17 +1312,11 @@ int msPostGISParseData(layerObj *layer)
     msSetError(MS_QUERYERR, "Missing DATA clause. DATA statement must contain 'geometry_column from table_name' or 'geometry_column from (sub-query) as sub'.", "msPostGISParseData()");
     return MS_FAILURE;
   }
-  dsize = strlen ( layer->data ) + 1;
-  data = (char*)msSmallMalloc(dsize);
-  strlcpy ( data, layer->data, dsize );
-  for ( tmp = data; *tmp; tmp++ )
-    if ( strchr ( "\t\n\r", *tmp ) ) *tmp = ' ';
- *.*/
+  data = layer->data;
 
   /*
   ** Clean up any existing strings first, as we will be populating these fields.
   */
-/*+*
   if( layerinfo->srid ) {
     free(layerinfo->srid);
     layerinfo->srid = NULL;
@@ -1340,96 +1333,41 @@ int msPostGISParseData(layerObj *layer)
     free(layerinfo->fromsource);
     layerinfo->fromsource = NULL;
   }
- *-*/
-
-  /*
-  ** Look for the optional ' using ' clauses.
-  */
-/*+*
-  pos_srid = pos_uid = NULL;
-  pos_use_1st = pos_use_2nd = NULL;
-  tmp = strcasestr(data, " using ");
-  while ( tmp )
-  {
-    pos_use_1st = pos_use_2nd;
-    pos_use_2nd = tmp + 1;
-    tmp = strcasestr(tmp+1, " using ");
-  };
- *-*/
-
-  /*
-  ** What clause appear after 2nd 'using'?
-  */
-/*+*
-  for ( tmp = pos_use_2nd + 5; *tmp == ' '; tmp++ );
-  if ( strncmp ( tmp, "unique ", 7 ) == 0 )
-  {
-    for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
-  }
-  else
-  {
-    if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
-  };
- *-*/
-
-  /*
-  ** What clause appear after 1st 'using'?
-  */
-/*+*
-  if ( !pos_uid )
-  {
-    for ( tmp = pos_use_1st + 5; *tmp == ' '; tmp++ );
-    if ( strncmp ( tmp, "unique ", 7 ) == 0 )
-      for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
-  };
-  if ( !pos_srid )
-  {
-    if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
-  };
- *-*/
 
   /*
   ** Look for the optional ' using unique ID' string first.
   */
-/*+*
+  pos_uid = strcasestr(data, " using unique ");
   if (pos_uid) {
- *-*/
     /* Find the end of this case 'using unique ftab_id using srid=33' */
-/*+*
-    tmp = strstr(pos_uid, " ");
- *-*/
+    tmp = strstr(pos_uid + 14, " ");
     /* Find the end of this case 'using srid=33 using unique ftab_id' */
-/*+*
     if (!tmp) {
       tmp = pos_uid + strlen(pos_uid);
     }
-    layerinfo->uid = (char*) msSmallMalloc((tmp - pos_uid) + 1);
-    strlcpy(layerinfo->uid, pos_uid, (tmp - pos_uid) + 1 );
+    layerinfo->uid = (char*) msSmallMalloc((tmp - (pos_uid + 14)) + 1);
+    strlcpy(layerinfo->uid, pos_uid + 14, tmp - (pos_uid + 14)+1);
     msStringTrim(layerinfo->uid);
   }
- *-*/
 
   /*
   ** Look for the optional ' using srid=333 ' string next.
   */
-/*+*
+  pos_srid = strcasestr(data, " using srid=");
   if (!pos_srid) {
     layerinfo->srid = (char*) msSmallMalloc(1);
     (layerinfo->srid)[0] = '\0'; /* no SRID, so return just null terminator*/
-/*+*
   } else {
-    slength = strspn(pos_srid, "-0123456789");
+    slength = strspn(pos_srid + 12, "-0123456789");
     if (!slength) {
-      free ( data );
-      msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. You specified 'USING SRID' but didnt have any numbers! %s", "msPostGISParseData()", layer->data);
+      msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. You specified 'USING SRID' but didn't have any numbers! %s", "msPostGISParseData()", data);
       return MS_FAILURE;
     } else {
       layerinfo->srid = (char*) msSmallMalloc(slength + 1);
-      strlcpy(layerinfo->srid, pos_srid, slength+1);
+      strlcpy(layerinfo->srid, pos_srid + 12, slength+1);
       msStringTrim(layerinfo->srid);
     }
   }
- *-*/
 
   /*
   ** This is a little hack so the rest of the code works.
@@ -1437,107 +1375,71 @@ int msPostGISParseData(layerObj *layer)
   **
   ** If they are both set, return the smaller one.
   */
-  /*
-  ** If pos_use_1st set, then it smaller.
-  */
-/*+*
-  if (pos_use_1st) {
-    pos_opt = pos_use_1st;
+  if (pos_srid && pos_uid) {
+    pos_opt = (pos_srid > pos_uid) ? pos_uid : pos_srid;
   }
- *-*/
   /* If one or none is set, return the larger one. */
-/*+*
   else {
-    pos_opt = pos_use_2nd;
+    pos_opt = (pos_srid > pos_uid) ? pos_srid : pos_uid;
   }
- *-*/
   /* No pos_opt? Move it to the end of the string. */
-/*+*
   if (!pos_opt) {
     pos_opt = data + strlen(data);
   }
- *-*/
-  /* Back the last non-space character. */
-/*+*
-  for ( --pos_opt; *pos_opt != ' '; pos_opt-- );
- *-*/
 
   /*
   ** Scan for the 'geometry from table' or 'geometry from () as foo' clause.
   */
 
   /* Find the first non-white character to start from */
-/*+*
   pos_geom = data;
   while( *pos_geom == ' ' || *pos_geom == '\t' || *pos_geom == '\n' || *pos_geom == '\r' )
     pos_geom++;
- *-*/
 
   /* Find the end of the geom column name */
-/*+*
   pos_scn = strcasestr(data, " from ");
   if (!pos_scn) {
-    free ( data );
-    msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. Must contain 'geometry from table' or 'geometry from (subselect) as foo'. %s", "msPostGISParseData()", layer->data);
+    msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. Must contain 'geometry from table' or 'geometry from (subselect) as foo'. %s", "msPostGISParseData()", data);
     return MS_FAILURE;
   }
- *-*/
 
   /* Copy the geometry column name */
-/*+*
   layerinfo->geomcolumn = (char*) msSmallMalloc((pos_scn - pos_geom) + 1);
-  strlcpy(layerinfo->geomcolumn, pos_geom, pos_scn - pos_geom + 1);
+  strlcpy(layerinfo->geomcolumn, pos_geom, pos_scn - pos_geom+1);
   msStringTrim(layerinfo->geomcolumn);
- *-*/
 
   /* Copy the table name or sub-select clause */
-/*+*
-  pos_scn += 6;
-  while ( *pos_scn == ' ' ) pos_scn++;
-  layerinfo->fromsource = (char*) msSmallMalloc((pos_opt + 1) - pos_scn);
-  strlcpy(layerinfo->fromsource, ( layer->data - data ) + pos_scn, pos_opt - pos_scn + 1);
+  layerinfo->fromsource = (char*) msSmallMalloc((pos_opt - (pos_scn + 6)) + 1);
+  strlcpy(layerinfo->fromsource, pos_scn + 6, pos_opt - (pos_scn + 6)+1);
   msStringTrim(layerinfo->fromsource);
- *-*/
 
   /* Something is wrong, our goemetry column and table references are not there. */
-/*+*
   if (strlen(layerinfo->fromsource) < 1 || strlen(layerinfo->geomcolumn) < 1) {
-    free ( data );
-    msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable.  Must contain 'geometry from table' or 'geometry from (subselect) as foo'. %s", "msPostGISParseData()", layer->data);
+    msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable.  Must contain 'geometry from table' or 'geometry from (subselect) as foo'. %s", "msPostGISParseData()", data);
     return MS_FAILURE;
   }
- *-*/
 
   /*
   ** We didn't find a ' using unique ' in the DATA string so try and find a
   ** primary key on the table.
   */
-/*+*
   if ( ! (layerinfo->uid) ) {
     if ( strstr(layerinfo->fromsource, " ") ) {
-      free ( data );
       msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable.  You must specify 'using unique' when supplying a subselect in the data definition.", "msPostGISParseData()");
       return MS_FAILURE;
     }
     if ( msPostGISRetrievePK(layer) != MS_SUCCESS ) {
- *-*/
       /* No user specified unique id so we will use the PostgreSQL oid */
       /* TODO: Deprecate this, oids are deprecated in PostgreSQL */
-/*+*
       layerinfo->uid = msStrdup("oid");
     }
   }
- *-*/
 
-/*+*
   if (layer->debug) {
     msDebug("msPostGISParseData: unique_column=%s, srid=%s, geom_column_name=%s, table_name=%s\n", layerinfo->uid, layerinfo->srid, layerinfo->geomcolumn, layerinfo->fromsource);
   }
-  free ( data );
- *-*/
   return MS_SUCCESS;
 }
-
 
 
 /*

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1368,17 +1368,19 @@ int msPostGISParseData(layerObj *layer)
   if ( pos_use_1st )
   {
     for ( tmp = pos_use_1st + 5; *tmp == ' '; tmp++ );
-/***
     if ( strncmp ( tmp, "unique ", 7 ) == 0 )
     {
+/***
       if ( pos_uid )
       {
         free ( data );
         msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. Too many 'USING UNIQUE' found! %s", "msPostGISParseData()", layer->data);
         return MS_FAILURE;
       };
+ ***/
       for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
     };
+/***
     if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
     {
       if ( pos_srid )

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1365,10 +1365,10 @@ int msPostGISParseData(layerObj *layer)
   /*
   ** What clause appear after 1st 'using', if set?
   */
-/***
   if ( pos_use_1st )
   {
     for ( tmp = pos_use_1st + 5; *tmp == ' '; tmp++ );
+/***
     if ( strncmp ( tmp, "unique ", 7 ) == 0 )
     {
       if ( pos_uid )
@@ -1389,8 +1389,8 @@ int msPostGISParseData(layerObj *layer)
       };
       pos_srid = tmp + 5;
     };
-  };
  ***/
+  };
 
   /*
   ** Look for the optional ' using unique ID' string first.

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1352,6 +1352,11 @@ int msPostGISParseData(layerObj *layer)
   };
 
   /*
+  ** What clause appear after 2nd 'using'?
+  */
+  for ( tmp = pos_use_2nd + 5; *tmp == ' '; tmp++ );
+
+  /*
   ** Look for the optional ' using unique ID' string first.
   */
   pos_uid = strcasestr(data, " using unique ");

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1296,6 +1296,7 @@ int msPostGISParseData(layerObj *layer)
 {
   char *pos_opt, *pos_scn, *tmp, *pos_srid, *pos_uid, *pos_geom, *data;
   int slength, dsize;
+  char *pos_use_1st, *pos_use_2nd;
   msPostGISLayerInfo *layerinfo;
 
   assert(layer != NULL);
@@ -1336,6 +1337,12 @@ int msPostGISParseData(layerObj *layer)
     free(layerinfo->fromsource);
     layerinfo->fromsource = NULL;
   }
+
+  /*
+  ** Look for the optional ' using ' clauses.
+  */
+  pos_srid = pos_uid = NULL;
+  pos_use_1st = pos_use_2nd = NULL;
 
   /*
   ** Look for the optional ' using unique ID' string first.

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1401,7 +1401,7 @@ int msPostGISParseData(layerObj *layer)
       tmp = pos_uid + strlen(pos_uid);
     }
     layerinfo->uid = (char*) msSmallMalloc((tmp - pos_uid) + 1);
-    strlcpy(layerinfo->uid, pos_uid + 14, (tmp - pos_uid) + 1);
+    strlcpy(layerinfo->uid, pos_uid, (tmp - pos_uid) + 1);
     msStringTrim(layerinfo->uid);
   }
 
@@ -1412,7 +1412,7 @@ int msPostGISParseData(layerObj *layer)
     layerinfo->srid = (char*) msSmallMalloc(1);
     (layerinfo->srid)[0] = '\0'; /* no SRID, so return just null terminator*/
   } else {
-    slength = strspn(pos_srid + 12, "-0123456789");
+    slength = strspn(pos_srid, "-0123456789");
     if (!slength) {
       free ( data );
       msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. You specified 'USING SRID' but didn't have any numbers! %s", "msPostGISParseData()", layer->data);
@@ -1443,7 +1443,7 @@ int msPostGISParseData(layerObj *layer)
     pos_opt = data + strlen(data);
   }
   /* Back the last non-space character. */
-  for ( --pos_opt; *pos_opt != ' '; pos_opt-- );
+  for ( --pos_opt; *pos_opt == ' '; pos_opt-- );
 
   /*
   ** Scan for the 'geometry from table' or 'geometry from () as foo' clause.
@@ -1462,13 +1462,13 @@ int msPostGISParseData(layerObj *layer)
 
   /* Copy the geometry column name */
   layerinfo->geomcolumn = (char*) msSmallMalloc((pos_scn - pos_geom) + 1);
-  strlcpy(layerinfo->geomcolumn, pos_geom, pos_scn - pos_geom + 1);
+  strlcpy(layerinfo->geomcolumn, pos_geom, (pos_scn - pos_geom) + 1);
   msStringTrim(layerinfo->geomcolumn);
 
   /* Copy the table name or sub-select clause */
   for ( pos_scn += 6; *pos_scn == ' '; pos_scn++ );
-  layerinfo->fromsource = (char*) msSmallMalloc((pos_opt + 1) - pos_scn);
-  strlcpy(layerinfo->fromsource, ( layer->data - data ) + pos_scn, pos_opt - pos_scn + 1);
+  layerinfo->fromsource = (char*) msSmallMalloc((pos_opt + 1) - pos_scn + 1);
+  strlcpy(layerinfo->fromsource, ( layer->data - data ) + pos_scn, (pos_opt + 1) - pos_scn + 1);
   msStringTrim(layerinfo->fromsource);
 
   /* Something is wrong, our goemetry column and table references are not there. */

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1343,6 +1343,13 @@ int msPostGISParseData(layerObj *layer)
   */
   pos_srid = pos_uid = NULL;
   pos_use_1st = pos_use_2nd = NULL;
+  tmp = strcasestr(data, " using ");
+  while ( tmp )
+  {
+    pos_use_1st = pos_use_2nd;
+    pos_use_2nd = tmp + 1;
+    tmp = strcasestr(tmp+1, " using ");
+  };
 
   /*
   ** Look for the optional ' using unique ID' string first.

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1294,8 +1294,7 @@ msPostGISRetrievePK(layerObj *layer)
 */
 int msPostGISParseData(layerObj *layer)
 {
-
-	char *pos_opt, *pos_scn, *tmp, *pos_srid, *pos_uid, *pos_geom, *data;
+  char *pos_opt, *pos_scn, *tmp, *pos_srid, *pos_uid, *pos_geom, *data;
   int slength;
   msPostGISLayerInfo *layerinfo;
 
@@ -1440,6 +1439,8 @@ int msPostGISParseData(layerObj *layer)
   }
   return MS_SUCCESS;
 }
+
+
 
 
 /*

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1357,10 +1357,8 @@ int msPostGISParseData(layerObj *layer)
   if ( pos_use_2nd )
   {
     for ( tmp = pos_use_2nd + 5; *tmp == ' '; tmp++ );
-/***
     if ( strncmp ( tmp, "unique ", 7 ) == 0 )
       for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
- ***/
     if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
   };
 

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1382,14 +1382,14 @@ int msPostGISParseData(layerObj *layer)
     };
     if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
     {
+/***
       if ( pos_srid )
       {
         free ( data );
-/***
         msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. Too many 'USING SRID' found! %s", "msPostGISParseData()", layer->data);
- ***/
         return MS_FAILURE;
       };
+ ***/
       pos_srid = tmp + 5;
     };
   };

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1314,6 +1314,8 @@ int msPostGISParseData(layerObj *layer)
   dsize = strlen ( layer->data ) + 1;
   data = (char*)msSmallMalloc(dsize);
   strlcpy ( data, layer->data, dsize );
+  for ( tmp = data; *tmp; tmp++ )
+    if ( strchr ( "\t\n\r", *tmp ) ) *tmp = ' ';
 
   /*
   ** Clean up any existing strings first, as we will be populating these fields.

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1443,7 +1443,7 @@ int msPostGISParseData(layerObj *layer)
     pos_opt = data + strlen(data);
   }
   /* Back after the last non-space character. */
-  for ( pos_opt; *(pos_opt-1) == ' '; pos_opt-- );
+  for ( pos_opt; ( pos_opt > data ) && ( *(pos_opt-1) == ' ' ); pos_opt-- );
 
   /*
   ** Scan for the 'geometry from table' or 'geometry from () as foo' clause.
@@ -1467,6 +1467,12 @@ int msPostGISParseData(layerObj *layer)
 
   /* Copy the table name or sub-select clause */
   for ( pos_scn += 6; *pos_scn == ' '; pos_scn++ );
+  if ( pos_opt - pos_scn < 1 )
+  {
+    free ( data );
+    msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable.  Must contain 'geometry from table' or 'geometry from (subselect) as foo'. %s", "msPostGISParseData()", layer->data);
+    return MS_FAILURE;
+  };
   layerinfo->fromsource = (char*) msSmallMalloc(pos_opt - pos_scn + 1);
   strlcpy(layerinfo->fromsource, ( layer->data - data ) + pos_scn, pos_opt - pos_scn + 1);
   msStringTrim(layerinfo->fromsource);

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1380,16 +1380,16 @@ int msPostGISParseData(layerObj *layer)
       };
       for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
     };
-    if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
+    if ( strncmp ( tmp, "srid=", 5 ) == 0 )
     {
-/***
       if ( pos_srid )
       {
         free ( data );
         msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. Too many 'USING SRID' found! %s", "msPostGISParseData()", layer->data);
+/***
+ ***/
         return MS_FAILURE;
       };
- ***/
       pos_srid = tmp + 5;
     };
   };

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1354,15 +1354,15 @@ int msPostGISParseData(layerObj *layer)
   /*
   ** What clause appear after 2nd 'using', if set?
   */
-/***
   if ( pos_use_2nd )
   {
     for ( tmp = pos_use_2nd + 5; *tmp == ' '; tmp++ );
+/***
     if ( strncmp ( tmp, "unique ", 7 ) == 0 )
       for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
     if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
-  };
  ***/
+  };
 
   /*
   ** What clause appear after 1st 'using', if set?

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1442,8 +1442,8 @@ int msPostGISParseData(layerObj *layer)
   if (!pos_opt) {
     pos_opt = data + strlen(data);
   }
-  /* Back the last non-space character. */
-  for ( --pos_opt; *pos_opt == ' '; pos_opt-- );
+  /* Back after the last non-space character. */
+  for ( pos_opt; *(pos_opt-1) == ' '; pos_opt-- );
 
   /*
   ** Scan for the 'geometry from table' or 'geometry from () as foo' clause.
@@ -1467,8 +1467,8 @@ int msPostGISParseData(layerObj *layer)
 
   /* Copy the table name or sub-select clause */
   for ( pos_scn += 6; *pos_scn == ' '; pos_scn++ );
-  layerinfo->fromsource = (char*) msSmallMalloc((pos_opt + 1) - pos_scn + 1);
-  strlcpy(layerinfo->fromsource, ( layer->data - data ) + pos_scn, (pos_opt + 1) - pos_scn + 1);
+  layerinfo->fromsource = (char*) msSmallMalloc(pos_opt - pos_scn + 1);
+  strlcpy(layerinfo->fromsource, ( layer->data - data ) + pos_scn, pos_opt - pos_scn + 1);
   msStringTrim(layerinfo->fromsource);
 
   /* Something is wrong, our goemetry column and table references are not there. */

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1295,7 +1295,7 @@ msPostGISRetrievePK(layerObj *layer)
 int msPostGISParseData(layerObj *layer)
 {
   char *pos_opt, *pos_scn, *tmp, *pos_srid, *pos_uid, *pos_geom, *data;
-  int slength;
+  int slength, dsize;
   msPostGISLayerInfo *layerinfo;
 
   assert(layer != NULL);
@@ -1439,7 +1439,6 @@ int msPostGISParseData(layerObj *layer)
   }
   return MS_SUCCESS;
 }
-
 
 
 

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1295,7 +1295,8 @@ msPostGISRetrievePK(layerObj *layer)
 int msPostGISParseData(layerObj *layer)
 {
   char *pos_opt, *pos_scn, *tmp, *pos_srid, *pos_uid, *pos_geom, *data;
-  int slength;
+  char *pos_use_1st, *pos_use_2nd;
+  int slength, dsize;
   msPostGISLayerInfo *layerinfo;
 
   assert(layer != NULL);
@@ -1311,7 +1312,11 @@ int msPostGISParseData(layerObj *layer)
     msSetError(MS_QUERYERR, "Missing DATA clause. DATA statement must contain 'geometry_column from table_name' or 'geometry_column from (sub-query) as sub'.", "msPostGISParseData()");
     return MS_FAILURE;
   }
-  data = layer->data;
+  dsize = strlen ( layer->data ) + 1;
+  data = (char*)msSmallMalloc(dsize);
+  strlcpy ( data, layer->data, dsize );
+  for ( tmp = data; *tmp; tmp++ )
+    if ( strchr ( "\t\n\r", *tmp ) ) *tmp = ' ';
 
   /*
   ** Clean up any existing strings first, as we will be populating these fields.
@@ -1334,36 +1339,75 @@ int msPostGISParseData(layerObj *layer)
   }
 
   /*
+  ** Look for the optional ' using ' clauses.
+  */
+  pos_srid = pos_uid = NULL;
+  pos_use_1st = pos_use_2nd = NULL;
+  tmp = strcasestr(data, " using ");
+  while ( tmp )
+  {
+    pos_use_1st = pos_use_2nd;
+    pos_use_2nd = tmp + 1;
+    tmp = strcasestr(tmp+1, " using ");
+  };
+
+  /*
+  ** What clause appear after 2nd 'using'?
+  */
+  for ( tmp = pos_use_2nd + 5; *tmp == ' '; tmp++ );
+  if ( strncmp ( tmp, "unique ", 7 ) == 0 )
+  {
+    for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
+  }
+  else
+  {
+    if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
+  };
+
+  /*
+  ** What clause appear after 1st 'using'?
+  */
+  if ( !pos_uid )
+  {
+    for ( tmp = pos_use_1st + 5; *tmp == ' '; tmp++ );
+    if ( strncmp ( tmp, "unique ", 7 ) == 0 )
+      for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
+  };
+  if ( !pos_srid )
+  {
+    if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
+  };
+
+  /*
   ** Look for the optional ' using unique ID' string first.
   */
-  pos_uid = strcasestr(data, " using unique ");
   if (pos_uid) {
     /* Find the end of this case 'using unique ftab_id using srid=33' */
-    tmp = strstr(pos_uid + 14, " ");
+    tmp = strstr(pos_uid, " ");
     /* Find the end of this case 'using srid=33 using unique ftab_id' */
     if (!tmp) {
       tmp = pos_uid + strlen(pos_uid);
     }
-    layerinfo->uid = (char*) msSmallMalloc((tmp - (pos_uid + 14)) + 1);
-    strlcpy(layerinfo->uid, pos_uid + 14, tmp - (pos_uid + 14)+1);
+    layerinfo->uid = (char*) msSmallMalloc((tmp - pos_uid) + 1);
+    strlcpy(layerinfo->uid, pos_uid, (tmp - pos_uid) + 1 );
     msStringTrim(layerinfo->uid);
   }
 
   /*
   ** Look for the optional ' using srid=333 ' string next.
   */
-  pos_srid = strcasestr(data, " using srid=");
   if (!pos_srid) {
     layerinfo->srid = (char*) msSmallMalloc(1);
     (layerinfo->srid)[0] = '\0'; /* no SRID, so return just null terminator*/
   } else {
-    slength = strspn(pos_srid + 12, "-0123456789");
+    slength = strspn(pos_srid, "-0123456789");
     if (!slength) {
-      msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. You specified 'USING SRID' but didn't have any numbers! %s", "msPostGISParseData()", data);
+      free ( data );
+      msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. You specified 'USING SRID' but didnt have any numbers! %s", "msPostGISParseData()", layer->data);
       return MS_FAILURE;
     } else {
       layerinfo->srid = (char*) msSmallMalloc(slength + 1);
-      strlcpy(layerinfo->srid, pos_srid + 12, slength+1);
+      strlcpy(layerinfo->srid, pos_srid, slength+1);
       msStringTrim(layerinfo->srid);
     }
   }
@@ -1374,17 +1418,22 @@ int msPostGISParseData(layerObj *layer)
   **
   ** If they are both set, return the smaller one.
   */
-  if (pos_srid && pos_uid) {
-    pos_opt = (pos_srid > pos_uid) ? pos_uid : pos_srid;
+  /*
+  ** If pos_use_1st set, then it smaller.
+  */
+  if (pos_use_1st) {
+    pos_opt = pos_use_1st;
   }
   /* If one or none is set, return the larger one. */
   else {
-    pos_opt = (pos_srid > pos_uid) ? pos_srid : pos_uid;
+    pos_opt = pos_use_2nd;
   }
   /* No pos_opt? Move it to the end of the string. */
   if (!pos_opt) {
     pos_opt = data + strlen(data);
   }
+  /* Back the last non-space character. */
+  for ( --pos_opt; *pos_opt != ' '; pos_opt-- );
 
   /*
   ** Scan for the 'geometry from table' or 'geometry from () as foo' clause.
@@ -1398,23 +1447,27 @@ int msPostGISParseData(layerObj *layer)
   /* Find the end of the geom column name */
   pos_scn = strcasestr(data, " from ");
   if (!pos_scn) {
-    msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. Must contain 'geometry from table' or 'geometry from (subselect) as foo'. %s", "msPostGISParseData()", data);
+    free ( data );
+    msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. Must contain 'geometry from table' or 'geometry from (subselect) as foo'. %s", "msPostGISParseData()", layer->data);
     return MS_FAILURE;
   }
 
   /* Copy the geometry column name */
   layerinfo->geomcolumn = (char*) msSmallMalloc((pos_scn - pos_geom) + 1);
-  strlcpy(layerinfo->geomcolumn, pos_geom, pos_scn - pos_geom+1);
+  strlcpy(layerinfo->geomcolumn, pos_geom, pos_scn - pos_geom + 1);
   msStringTrim(layerinfo->geomcolumn);
 
   /* Copy the table name or sub-select clause */
-  layerinfo->fromsource = (char*) msSmallMalloc((pos_opt - (pos_scn + 6)) + 1);
-  strlcpy(layerinfo->fromsource, pos_scn + 6, pos_opt - (pos_scn + 6)+1);
+  pos_scn += 6;
+  while ( *pos_scn == ' ' ) pos_scn++;
+  layerinfo->fromsource = (char*) msSmallMalloc((pos_opt + 1) - pos_scn);
+  strlcpy(layerinfo->fromsource, ( layer->data - data ) + pos_scn, pos_opt - pos_scn + 1);
   msStringTrim(layerinfo->fromsource);
 
   /* Something is wrong, our goemetry column and table references are not there. */
   if (strlen(layerinfo->fromsource) < 1 || strlen(layerinfo->geomcolumn) < 1) {
-    msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable.  Must contain 'geometry from table' or 'geometry from (subselect) as foo'. %s", "msPostGISParseData()", data);
+    free ( data );
+    msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable.  Must contain 'geometry from table' or 'geometry from (subselect) as foo'. %s", "msPostGISParseData()", layer->data);
     return MS_FAILURE;
   }
 
@@ -1424,6 +1477,7 @@ int msPostGISParseData(layerObj *layer)
   */
   if ( ! (layerinfo->uid) ) {
     if ( strstr(layerinfo->fromsource, " ") ) {
+      free ( data );
       msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable.  You must specify 'using unique' when supplying a subselect in the data definition.", "msPostGISParseData()");
       return MS_FAILURE;
     }
@@ -1437,6 +1491,7 @@ int msPostGISParseData(layerObj *layer)
   if (layer->debug) {
     msDebug("msPostGISParseData: unique_column=%s, srid=%s, geom_column_name=%s, table_name=%s\n", layerinfo->uid, layerinfo->srid, layerinfo->geomcolumn, layerinfo->fromsource);
   }
+  free ( data );
   return MS_SUCCESS;
 }
 

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1363,6 +1363,7 @@ int msPostGISParseData(layerObj *layer)
   } else {
     slength = strspn(pos_srid + 12, "-0123456789");
     if (!slength) {
+      free ( data );
       msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. You specified 'USING SRID' but didn't have any numbers! %s", "msPostGISParseData()", data);
       return MS_FAILURE;
     } else {
@@ -1402,6 +1403,7 @@ int msPostGISParseData(layerObj *layer)
   /* Find the end of the geom column name */
   pos_scn = strcasestr(data, " from ");
   if (!pos_scn) {
+    free ( data );
     msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable. Must contain 'geometry from table' or 'geometry from (subselect) as foo'. %s", "msPostGISParseData()", data);
     return MS_FAILURE;
   }
@@ -1418,6 +1420,7 @@ int msPostGISParseData(layerObj *layer)
 
   /* Something is wrong, our goemetry column and table references are not there. */
   if (strlen(layerinfo->fromsource) < 1 || strlen(layerinfo->geomcolumn) < 1) {
+    free ( data );
     msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable.  Must contain 'geometry from table' or 'geometry from (subselect) as foo'. %s", "msPostGISParseData()", data);
     return MS_FAILURE;
   }
@@ -1428,6 +1431,7 @@ int msPostGISParseData(layerObj *layer)
   */
   if ( ! (layerinfo->uid) ) {
     if ( strstr(layerinfo->fromsource, " ") ) {
+      free ( data );
       msSetError(MS_QUERYERR, "Error parsing PostGIS DATA variable.  You must specify 'using unique' when supplying a subselect in the data definition.", "msPostGISParseData()");
       return MS_FAILURE;
     }
@@ -1441,6 +1445,7 @@ int msPostGISParseData(layerObj *layer)
   if (layer->debug) {
     msDebug("msPostGISParseData: unique_column=%s, srid=%s, geom_column_name=%s, table_name=%s\n", layerinfo->uid, layerinfo->srid, layerinfo->geomcolumn, layerinfo->fromsource);
   }
+  free ( data );
   return MS_SUCCESS;
 }
 

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1354,6 +1354,7 @@ int msPostGISParseData(layerObj *layer)
   /*
   ** What clause appear after 2nd 'using', if set?
   */
+/***
   if ( pos_use_2nd )
   {
     for ( tmp = pos_use_2nd + 5; *tmp == ' '; tmp++ );
@@ -1361,10 +1362,12 @@ int msPostGISParseData(layerObj *layer)
       for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
     if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
   };
+ ***/
 
   /*
   ** What clause appear after 1st 'using', if set?
   */
+/***
   if ( pos_use_1st )
   {
     for ( tmp = pos_use_1st + 5; *tmp == ' '; tmp++ );
@@ -1389,6 +1392,7 @@ int msPostGISParseData(layerObj *layer)
       pos_srid = tmp + 5;
     };
   };
+ ***/
 
   /*
   ** Look for the optional ' using unique ID' string first.

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1311,7 +1311,9 @@ int msPostGISParseData(layerObj *layer)
     msSetError(MS_QUERYERR, "Missing DATA clause. DATA statement must contain 'geometry_column from table_name' or 'geometry_column from (sub-query) as sub'.", "msPostGISParseData()");
     return MS_FAILURE;
   }
-  data = layer->data;
+  dsize = strlen ( layer->data ) + 1;
+  data = (char*)msSmallMalloc(dsize);
+  strlcpy ( data, layer->data, dsize );
 
   /*
   ** Clean up any existing strings first, as we will be populating these fields.

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -1360,8 +1360,8 @@ int msPostGISParseData(layerObj *layer)
 /***
     if ( strncmp ( tmp, "unique ", 7 ) == 0 )
       for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ );
-    if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
  ***/
+    if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
   };
 
   /*


### PR DESCRIPTION
Fix white-space handling on function msPostGISParseData.
The DATA field contains " from\n" generate invalid SQL, because '\n' don't handled as white-space.