### PR TITLE
Update C# bindings to work with SWIG 3.x

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,3 +48,12 @@ test_script:
   - cmake --build . --target pythonmapscript-wheel --config Release
 
 deploy: off
+
+after_build:
+  - cd %BUILD_FOLDER%
+  - 7z a mapserver.zip build/*
+		
+artifacts:
+  - path: mapserver.zip
+    name: mapserver
+    type: zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,7 @@ test_script:
 
 deploy: off
 
-after_build:
+after_test:
   - cd %BUILD_FOLDER%
   - 7z a mapserver.zip ./build/*
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,9 @@ build_script:
   - set SDK_INC=%BUILD_FOLDER%/sdk/%SDK%/include
   - set SDK_LIB=%BUILD_FOLDER%/sdk/%SDK%/lib
   - set SDK_BIN=%BUILD_FOLDER%/sdk/%SDK%/bin
-  - set SWIG_EXECUTABLE=%BUILD_FOLDER%/sdk/SWIG-1.3.39/swig.exe
+  - appveyor DownloadFile https://sourceforge.net/projects/swig/files/swigwin/swigwin-3.0.12/swigwin-3.0.12.zip
+  - 7z x swigwin-3.0.12.zip > nul
+  - set SWIG_EXECUTABLE=%BUILD_FOLDER%/sdk/swigwin-3.0.12/swig.exe
   - set REGEX_DIR=%BUILD_FOLDER%/sdk/regex-0.12
   - if "%platform%" == "x86" SET PYTHON_EXECUTABLE=c:/python27/python.exe
   - if "%platform%" == "x64" SET PYTHON_EXECUTABLE=c:/python27-x64/python.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,8 +51,8 @@ deploy: off
 
 after_build:
   - cd %BUILD_FOLDER%
-  - 7z a mapserver.zip build/*
-		
+  - 7z a mapserver.zip 'build/*'
+
 artifacts:
   - path: mapserver.zip
     name: mapserver

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ deploy: off
 
 after_build:
   - cd %BUILD_FOLDER%
-  - 7z a mapserver.zip 'build/*'
+  - 7z a mapserver.zip ./build/*
 
 artifacts:
   - path: mapserver.zip

--- a/mapscript/csharp/csmodule.i
+++ b/mapscript/csharp/csmodule.i
@@ -126,10 +126,10 @@ inner exceptions. Otherwise the exception message will be concatenated*/
  *****************************************************************************/
  
 %pragma(csharp) imclasscode=%{
-  public class StringArrayMarshal : IDisposable {
-    public readonly IntPtr[] _ar;
+  public class StringArrayMarshal : System.IDisposable {
+    public readonly System.IntPtr[] _ar;
     public StringArrayMarshal(string[] ar) {
-      _ar = new IntPtr[ar.Length];
+      _ar = new System.IntPtr[ar.Length];
       for (int cx = 0; cx < _ar.Length; cx++) {
 	      _ar[cx] = System.Runtime.InteropServices.Marshal.StringToHGlobalAnsi(ar[cx]);
       }
@@ -143,7 +143,7 @@ inner exceptions. Otherwise the exception message will be concatenated*/
   }
 %}
 
-%typemap(imtype, out="IntPtr") char** "IntPtr[]"
+%typemap(imtype, out="System.IntPtr") char** "System.IntPtr[]"
 %typemap(cstype) char** %{string[]%}
 %typemap(in) char** %{ $1 = ($1_ltype)$input; %}
 %typemap(out) char** %{ $result = $1; %}
@@ -161,12 +161,12 @@ inner exceptions. Otherwise the exception message will be concatenated*/
 /* specializations */
 %typemap(csvarout, excode=SWIGEXCODE2) char** formatoptions %{
     get {
-        IntPtr cPtr = $imcall;
-        IntPtr objPtr;
+        System.IntPtr cPtr = $imcall;
+        System.IntPtr objPtr;
 	    string[] ret = new string[this.numformatoptions];
         for(int cx = 0; cx < this.numformatoptions; cx++) {
-            objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, cx * System.Runtime.InteropServices.Marshal.SizeOf(typeof(IntPtr)));
-            ret[cx]= (objPtr == IntPtr.Zero) ? null : System.Runtime.InteropServices.Marshal.PtrToStringAnsi(objPtr);
+            objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, cx * System.Runtime.InteropServices.Marshal.SizeOf(typeof(System.IntPtr)));
+            ret[cx]= (objPtr == System.IntPtr.Zero) ? null : System.Runtime.InteropServices.Marshal.PtrToStringAnsi(objPtr);
         }
         $excode
         return ret;
@@ -174,12 +174,12 @@ inner exceptions. Otherwise the exception message will be concatenated*/
 %}
 %typemap(csvarout, excode=SWIGEXCODE2) char** values %{
     get {
-        IntPtr cPtr = $imcall;
-        IntPtr objPtr;
+        System.IntPtr cPtr = $imcall;
+        System.IntPtr objPtr;
 	    string[] ret = new string[this.numvalues];
         for(int cx = 0; cx < this.numvalues; cx++) {
-            objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, cx * System.Runtime.InteropServices.Marshal.SizeOf(typeof(IntPtr)));
-            ret[cx]= (objPtr == IntPtr.Zero) ? null : System.Runtime.InteropServices.Marshal.PtrToStringAnsi(objPtr);
+            objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, cx * System.Runtime.InteropServices.Marshal.SizeOf(typeof(System.IntPtr)));
+            ret[cx]= (objPtr == System.IntPtr.Zero) ? null : System.Runtime.InteropServices.Marshal.PtrToStringAnsi(objPtr);
         }
         $excode
         return ret;
@@ -191,16 +191,16 @@ inner exceptions. Otherwise the exception message will be concatenated*/
  *****************************************************************************/
 
 %typemap(ctype) outputFormatObj** "void*"
-%typemap(imtype) outputFormatObj** "IntPtr"
+%typemap(imtype) outputFormatObj** "System.IntPtr"
 %typemap(cstype) outputFormatObj** "outputFormatObj[]"
 %typemap(out) outputFormatObj** %{ $result = $1; %}
 %typemap(csout, excode=SWIGEXCODE) outputFormatObj** {
-      IntPtr cPtr = $imcall;
-	  IntPtr objPtr;
+      System.IntPtr cPtr = $imcall;
+      System.IntPtr objPtr;
       outputFormatObj[] ret = new outputFormatObj[this.numoutputformats];
       for(int cx = 0; cx < this.numoutputformats; cx++) {
-          objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, cx * System.Runtime.InteropServices.Marshal.SizeOf(typeof(IntPtr)));
-          ret[cx] = (objPtr == IntPtr.Zero) ? null : new outputFormatObj(objPtr, false, ThisOwn_false());
+          objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, cx * System.Runtime.InteropServices.Marshal.SizeOf(typeof(System.IntPtr)));
+          ret[cx] = (objPtr == System.IntPtr.Zero) ? null : new outputFormatObj(objPtr, false, ThisOwn_false());
       }
       $excode
       return ret;
@@ -208,12 +208,12 @@ inner exceptions. Otherwise the exception message will be concatenated*/
 
 %typemap(csvarout, excode=SWIGEXCODE2) outputFormatObj** %{
     get {
-	  IntPtr cPtr = $imcall;
-	  IntPtr objPtr;
+	  System.IntPtr cPtr = $imcall;
+	  System.IntPtr objPtr;
       outputFormatObj[] ret = new outputFormatObj[this.numoutputformats];
       for(int cx = 0; cx < this.numoutputformats; cx++) {
-          objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, cx * System.Runtime.InteropServices.Marshal.SizeOf(typeof(IntPtr)));
-          ret[cx] = (objPtr == IntPtr.Zero) ? null : new outputFormatObj(objPtr, false, ThisOwn_false());
+          objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, cx * System.Runtime.InteropServices.Marshal.SizeOf(typeof(System.IntPtr)));
+          ret[cx] = (objPtr == System.IntPtr.Zero) ? null : new outputFormatObj(objPtr, false, ThisOwn_false());
       }
       $excode
       return ret;
@@ -225,7 +225,7 @@ inner exceptions. Otherwise the exception message will be concatenated*/
  *****************************************************************************/
 
 %pragma(csharp) imclasscode=%{
-  public delegate void SWIGByteArrayDelegate(IntPtr data, int size);
+  public delegate void SWIGByteArrayDelegate(System.IntPtr data, int size);
 %}
 
 %insert(runtime) %{
@@ -241,8 +241,8 @@ static SWIG_CSharpByteArrayHelperCallback SWIG_csharp_bytearray_callback = NULL;
 %typemap(in) SWIG_CSharpByteArrayHelperCallback %{ $1 = ($1_ltype)$input; %}
 %typemap(csin) SWIG_CSharpByteArrayHelperCallback "$csinput"
 
-%typemap(imtype) (unsigned char* pixels) "IntPtr"
-%typemap(cstype) (unsigned char* pixels) "IntPtr"
+%typemap(imtype) (unsigned char* pixels) "System.IntPtr"
+%typemap(cstype) (unsigned char* pixels) "System.IntPtr"
 %typemap(in) (unsigned char* pixels) %{ $1 = ($1_ltype)$input; %}
 %typemap(csin) (unsigned char* pixels) "$csinput"
 
@@ -289,7 +289,7 @@ static SWIG_CSharpByteArrayHelperCallback SWIG_csharp_bytearray_callback = NULL;
 %ignore imageObj::write;
 %typemap(cscode) imageObj, struct imageObj %{
   private byte[] gdbuffer;
-  private void CreateByteArray(IntPtr data, int size)
+  private void CreateByteArray(System.IntPtr data, int size)
   {
       gdbuffer = new byte[size];
       Marshal.Copy(data, gdbuffer, 0, size);
@@ -313,7 +313,7 @@ static SWIG_CSharpByteArrayHelperCallback SWIG_csharp_bytearray_callback = NULL;
 %csmethodmodifiers processLegendTemplate "private";
 %csmethodmodifiers processQueryTemplate "private";
 
-%typemap(csinterfaces) mapObj "IDisposable, System.Runtime.Serialization.ISerializable"; 
+%typemap(csinterfaces) mapObj "System.IDisposable, System.Runtime.Serialization.ISerializable"; 
 %typemap(csattributes) mapObj  "[Serializable]"
 %typemap(cscode) mapObj, struct mapObj %{  
   public string processTemplate(int bGenerateImages, string[] names, string[] values)
@@ -375,13 +375,13 @@ static SWIG_CSharpByteArrayHelperCallback SWIG_csharp_bytearray_callback = NULL;
 %pragma(csharp) imclasscode=%{
   protected class SWIGByteArrayHelper 
 	{
-		public delegate void SWIGByteArrayDelegate(IntPtr data, int size);
+		public delegate void SWIGByteArrayDelegate(System.IntPtr data, int size);
 		static SWIGByteArrayDelegate bytearrayDelegate = new SWIGByteArrayDelegate(CreateByteArray);
 
-		[DllImport("$dllimport", EntryPoint="SWIGRegisterByteArrayCallback_$module")]
+		[System.Runtime.InteropServices.DllImport("$dllimport", System.Runtime.InteropServices.EntryPoint="SWIGRegisterByteArrayCallback_$module")]
 		public static extern void SWIGRegisterByteArrayCallback_mapscript(SWIGByteArrayDelegate bytearrayDelegate);
 
-		static void CreateByteArray(IntPtr data, int size) 
+		static void CreateByteArray(System.IntPtr data, int size)
 		{
 			arraybuffer = new byte[size];
 			Marshal.Copy(data, arraybuffer, 0, size);
@@ -418,13 +418,13 @@ DllExport void SWIGSTDCALL SWIGRegisterByteArrayCallback_$module(SWIG_CSharpByte
 %}
 
 /* Typemaps for pattern array */
-%typemap(imtype) (double pattern[ANY]) "IntPtr"
+%typemap(imtype) (double pattern[ANY]) "System.IntPtr"
 %typemap(cstype) (double pattern[ANY]) "double[]"
 %typemap(in) (double pattern[ANY]) %{ $1 = ($1_ltype)$input; %}
 %typemap(csin) (double pattern[ANY]) "$csinput"
 %typemap(csvarout, excode=SWIGEXCODE2) (double pattern[ANY]) %{
     get {
-      IntPtr cPtr = $imcall;
+        System.IntPtr cPtr = $imcall;
       double[] ret = new double[patternlength];
       if (patternlength > 0) {       
 	        System.Runtime.InteropServices.Marshal.Copy(cPtr, ret, 0, patternlength);
@@ -433,7 +433,7 @@ DllExport void SWIGSTDCALL SWIGRegisterByteArrayCallback_$module(SWIG_CSharpByte
       return ret;
     } 
     set {
-      IntPtr cPtr = $imcall;
+        System.IntPtr cPtr = $imcall;
       if (value.Length > 0) {       
 	        System.Runtime.InteropServices.Marshal.Copy(value, 0, cPtr, value.Length);
       }
@@ -444,14 +444,14 @@ DllExport void SWIGSTDCALL SWIGRegisterByteArrayCallback_$module(SWIG_CSharpByte
 %typemap(csvarin, excode="") (double pattern[ANY]) %{$excode%}
 
 /* Typemaps for int array */
-%typemap(imtype, out="IntPtr") int *panIndexes "int[]"
+%typemap(imtype, out="System.IntPtr") int *panIndexes "int[]"
 %typemap(cstype) int *panIndexes %{int[]%}
 %typemap(in) int *panIndexes %{ $1 = ($1_ltype)$input; %}
 %typemap(csin) (int *panIndexes)  "$csinput"
 
 /* Typemaps for device handle */
-%typemap(imtype) (void* device)  %{IntPtr%}
-%typemap(cstype) (void* device) %{IntPtr%}
+%typemap(imtype) (void* device)  %{ System.IntPtr%}
+%typemap(cstype) (void* device) %{ System.IntPtr%}
 %typemap(in) (void* device) %{ $1 = ($1_ltype)$input; %}
 %typemap(csin) (void* device)  "$csinput"
 
@@ -474,7 +474,7 @@ DllExport void SWIGSTDCALL SWIGRegisterByteArrayCallback_$module(SWIG_CSharpByte
 %}
 
 %typemap(csout, excode=SWIGEXCODE) classObj* getClass, layerObj* getLayer, layerObj *getLayerByName, styleObj* getStyle {
-    IntPtr cPtr = $imcall;
-    $csclassname ret = (cPtr == IntPtr.Zero) ? null : new $csclassname(cPtr, $owner, ThisOwn_false());$excode
+    System.IntPtr cPtr = $imcall;
+    $csclassname ret = (cPtr == System.IntPtr.Zero) ? null : new $csclassname(cPtr, $owner, ThisOwn_false());$excode
     return ret;
   }

--- a/mapscript/csharp/csmodule.i
+++ b/mapscript/csharp/csmodule.i
@@ -378,7 +378,7 @@ static SWIG_CSharpByteArrayHelperCallback SWIG_csharp_bytearray_callback = NULL;
 		public delegate void SWIGByteArrayDelegate(System.IntPtr data, int size);
 		static SWIGByteArrayDelegate bytearrayDelegate = new SWIGByteArrayDelegate(CreateByteArray);
 
-		[System.Runtime.InteropServices.DllImport("$dllimport", System.Runtime.InteropServices.EntryPoint="SWIGRegisterByteArrayCallback_$module")]
+		[System.Runtime.InteropServices.DllImport("$dllimport", EntryPoint="SWIGRegisterByteArrayCallback_$module")]
 		public static extern void SWIGRegisterByteArrayCallback_mapscript(SWIGByteArrayDelegate bytearrayDelegate);
 
 		static void CreateByteArray(System.IntPtr data, int size)
@@ -393,7 +393,7 @@ static SWIG_CSharpByteArrayHelperCallback SWIG_csharp_bytearray_callback = NULL;
 		}
 	}
 	protected static SWIGByteArrayHelper bytearrayHelper = new SWIGByteArrayHelper();
-	[ThreadStatic] 
+	[System.ThreadStatic] 
 	private static byte[] arraybuffer;
 
 	internal static byte[] GetBytes()

--- a/mapscript/csharp/csmodule.i
+++ b/mapscript/csharp/csmodule.i
@@ -138,7 +138,7 @@ inner exceptions. Otherwise the exception message will be concatenated*/
 	  for (int cx = 0; cx < _ar.Length; cx++) {
           System.Runtime.InteropServices.Marshal.FreeHGlobal(_ar[cx]);
       }
-      GC.SuppressFinalize(this);
+      System.GC.SuppressFinalize(this);
     }
   }
 %}
@@ -292,7 +292,7 @@ static SWIG_CSharpByteArrayHelperCallback SWIG_csharp_bytearray_callback = NULL;
   private void CreateByteArray(System.IntPtr data, int size)
   {
       gdbuffer = new byte[size];
-      Marshal.Copy(data, gdbuffer, 0, size);
+      System.Runtime.InteropServices.Marshal.Copy(data, gdbuffer, 0, size);
   }
   
   public byte[] getBytes()
@@ -319,21 +319,21 @@ static SWIG_CSharpByteArrayHelperCallback SWIG_csharp_bytearray_callback = NULL;
   public string processTemplate(int bGenerateImages, string[] names, string[] values)
   {
 	if (names.Length != values.Length)
-	    throw new ArgumentException("Invalid array length specified!");
+	    throw new System.ArgumentException("Invalid array length specified!");
 	return processTemplate(bGenerateImages, names, values, values.Length);
   }
   
   public string processLegendTemplate(string[] names, string[] values)
   {
 	if (names.Length != values.Length)
-	    throw new ArgumentException("Invalid array length specified!");
+	    throw new System.ArgumentException("Invalid array length specified!");
 	return processLegendTemplate(names, values, values.Length);
   }
   
   public string processQueryTemplate(string[] names, string[] values)
   {
 	if (names.Length != values.Length)
-	    throw new ArgumentException("Invalid array length specified!");
+	    throw new System.ArgumentException("Invalid array length specified!");
 	return processQueryTemplate(names, values, values.Length);
   }
  
@@ -384,7 +384,7 @@ static SWIG_CSharpByteArrayHelperCallback SWIG_csharp_bytearray_callback = NULL;
 		static void CreateByteArray(System.IntPtr data, int size)
 		{
 			arraybuffer = new byte[size];
-			Marshal.Copy(data, arraybuffer, 0, size);
+			System.Runtime.InteropServices.Marshal.Copy(data, arraybuffer, 0, size);
 		}
 
 		static SWIGByteArrayHelper() 

--- a/mapscript/csharp/swig_csharp_extensions.i
+++ b/mapscript/csharp/swig_csharp_extensions.i
@@ -34,19 +34,19 @@
   static $imclassname() {
   }
 
-  public class UTF8Marshaler : ICustomMarshaler {
+  public class UTF8Marshaler : System.Runtime.InteropServices.ICustomMarshaler {
     static UTF8Marshaler static_instance;
 
-    public IntPtr MarshalManagedToNative(object managedObj) {
+    public System.IntPtr MarshalManagedToNative(object managedObj) {
         if (managedObj == null)
-            return IntPtr.Zero;
+            return System.IntPtr.Zero;
         if (!(managedObj is string))
             throw new MarshalDirectiveException(
                    "UTF8Marshaler must be used on a string.");
 
         // not null terminated
         byte[] strbuf = System.Text.Encoding.UTF8.GetBytes((string)managedObj); 
-        IntPtr buffer = Marshal.AllocHGlobal(strbuf.Length + 1);
+        System.IntPtr buffer = Marshal.AllocHGlobal(strbuf.Length + 1);
         Marshal.Copy(strbuf, 0, buffer, strbuf.Length);
 
         // write the terminating null
@@ -54,14 +54,14 @@
         return buffer;
     }
 
-    public object MarshalNativeToManaged(IntPtr pNativeData) {	
+    public object MarshalNativeToManaged(System.IntPtr pNativeData) {
 	    int len = Marshal.PtrToStringAnsi(pNativeData).Length;
         byte[] utf8data = new byte[len];
         Marshal.Copy(pNativeData, utf8data, 0, len);
         return System.Text.Encoding.UTF8.GetString(utf8data);
     }
 
-    public void CleanUpNativeData(IntPtr pNativeData) {
+    public void CleanUpNativeData(System.IntPtr pNativeData) {
         Marshal.FreeHGlobal(pNativeData);            
     }
 
@@ -72,7 +72,7 @@
         return -1;
     }
 
-    public static ICustomMarshaler GetInstance(string cookie) {
+    public static System.Runtime.InteropServices.ICustomMarshaler GetInstance(string cookie) {
         if (static_instance == null) {
             return static_instance = new UTF8Marshaler();
         }
@@ -81,8 +81,8 @@
   }
 %}
 
-%typemap(imtype, inattributes="[MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]", 
-  outattributes="[return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]") 
+%typemap(imtype, inattributes="[System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]", 
+  outattributes="[return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]") 
   char *, char *&, char[ANY], char[]   "string"
 
 %typemap(csout, excode=SWIGEXCODE) SWIGTYPE {
@@ -98,8 +98,8 @@
   }
 %typemap(csout, excode=SWIGEXCODE, new="1") SWIGTYPE *, SWIGTYPE [], SWIGTYPE (CLASS::*) {
     /* %typemap(csout, excode=SWIGEXCODE, new="1") SWIGTYPE *, SWIGTYPE [], SWIGTYPE (CLASS::*) */
-    IntPtr cPtr = $imcall;
-    $csclassname ret = (cPtr == IntPtr.Zero) ? null : new $csclassname(cPtr, $owner, ThisOwn_$owner());$excode
+    System.IntPtr cPtr = $imcall;
+    $csclassname ret = (cPtr == System.IntPtr.Zero) ? null : new $csclassname(cPtr, $owner, ThisOwn_$owner());$excode
     return ret;
   }
 %typemap(csvarout, excode=SWIGEXCODE2) SWIGTYPE %{
@@ -117,36 +117,36 @@
 %typemap(csvarout, excode=SWIGEXCODE2) SWIGTYPE *, struct SWIGTYPE *, SWIGTYPE [], SWIGTYPE (CLASS::*) %{
     /* %typemap(csvarout, excode=SWIGEXCODE2) SWIGTYPE *, SWIGTYPE [], SWIGTYPE (CLASS::*) */
     get {
-      IntPtr cPtr = $imcall;
-      $csclassname ret = (cPtr == IntPtr.Zero) ? null : new $csclassname(cPtr, $owner, ThisOwn_$owner());$excode
+      System.IntPtr cPtr = $imcall;
+      $csclassname ret = (cPtr == System.IntPtr.Zero) ? null : new $csclassname(cPtr, $owner, ThisOwn_$owner());$excode
       return ret;
     } %}
 %typemap(csout, excode=SWIGEXCODE) SWIGTYPE *& {
     /* %typemap(csout, excode=SWIGEXCODE) SWIGTYPE *& */
-    IntPtr cPtr = $imcall;
-    $*csclassname ret = (cPtr == IntPtr.Zero) ? null : new $*csclassname(cPtr, $owner, ThisOwn_$owner());$excode
+    System.IntPtr cPtr = $imcall;
+    $*csclassname ret = (cPtr == System.IntPtr.Zero) ? null : new $*csclassname(cPtr, $owner, ThisOwn_$owner());$excode
     return ret;
   }
 // Proxy classes (base classes, ie, not derived classes)
 %typemap(csbody) SWIGTYPE %{
   /* %typemap(csbody) SWIGTYPE */
-  private HandleRef swigCPtr;
+  private System.Runtime.InteropServices.HandleRef swigCPtr;
   protected bool swigCMemOwn;
   protected object swigParentRef;
   
   protected static object ThisOwn_true() { return null; }
   protected object ThisOwn_false() { return this; }
 
-  internal $csclassname(IntPtr cPtr, bool cMemoryOwn, object parent) {
+  internal $csclassname(System.IntPtr cPtr, bool cMemoryOwn, object parent) {
     swigCMemOwn = cMemoryOwn;
     swigParentRef = parent;
-    swigCPtr = new HandleRef(this, cPtr);
+    swigCPtr = new System.Runtime.InteropServices.HandleRef(this, cPtr);
   }
 
-  internal static HandleRef getCPtr($csclassname obj) {
-    return (obj == null) ? new HandleRef(null, IntPtr.Zero) : obj.swigCPtr;
+  internal static System.Runtime.InteropServices.HandleRef getCPtr($csclassname obj) {
+    return (obj == null) ? new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero) : obj.swigCPtr;
   }
-  internal static HandleRef getCPtrAndDisown($csclassname obj, object parent) {
+  internal static System.Runtime.InteropServices.HandleRef getCPtrAndDisown($csclassname obj, object parent) {
     if (obj != null)
     {
       obj.swigCMemOwn = false;
@@ -155,10 +155,10 @@
     }
     else
     {
-      return new HandleRef(null, IntPtr.Zero);
+      return new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
     }
   }
-  internal static HandleRef getCPtrAndSetReference($csclassname obj, object parent) {
+  internal static System.Runtime.InteropServices.HandleRef getCPtrAndSetReference($csclassname obj, object parent) {
     if (obj != null)
     {
       obj.swigParentRef = parent;
@@ -166,7 +166,7 @@
     }
     else
     {
-      return new HandleRef(null, IntPtr.Zero);
+      return new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
     }
   }
 %}
@@ -174,16 +174,16 @@
 // Derived proxy classes
 %typemap(csbody_derived) SWIGTYPE %{
   /* %typemap(csbody_derived) SWIGTYPE */
-  private HandleRef swigCPtr;
+  private System.Runtime.InteropServices.HandleRef swigCPtr;
 
-  internal $csclassname(IntPtr cPtr, bool cMemoryOwn, object parent) : base($modulePINVOKE.$csclassnameUpcast(cPtr), cMemoryOwn, parent) {
-    swigCPtr = new HandleRef(this, cPtr);
+  internal $csclassname(System.IntPtr cPtr, bool cMemoryOwn, object parent) : base($modulePINVOKE.$csclassnameUpcast(cPtr), cMemoryOwn, parent) {
+    swigCPtr = new System.Runtime.InteropServices.HandleRef(this, cPtr);
   }
 
-  internal static HandleRef getCPtr($csclassname obj) {
-    return (obj == null) ? new HandleRef(null, IntPtr.Zero) : obj.swigCPtr;
+  internal static System.Runtime.InteropServices.HandleRef getCPtr($csclassname obj) {
+    return (obj == null) ? new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero) : obj.swigCPtr;
   }
-  internal static HandleRef getCPtrAndDisown($csclassname obj, object parent) {
+  internal static System.Runtime.InteropServices.HandleRef getCPtrAndDisown($csclassname obj, object parent) {
     if (obj != null)
     {
       obj.swigCMemOwn = false;
@@ -192,10 +192,10 @@
     }
     else
     {
-      return new HandleRef(null, IntPtr.Zero);
+      return new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
     }
   }
-  internal static HandleRef getCPtrAndSetReference($csclassname obj, object parent) {
+  internal static System.Runtime.InteropServices.HandleRef getCPtrAndSetReference($csclassname obj, object parent) {
     if (obj != null)
     {
       obj.swigParentRef = parent;
@@ -203,7 +203,7 @@
     }
     else
     {
-      return new HandleRef(null, IntPtr.Zero);
+      return new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
     }
   }
 %}
@@ -211,18 +211,18 @@
 // Typewrapper classes
 %typemap(csbody) SWIGTYPE *, SWIGTYPE &, SWIGTYPE [], SWIGTYPE (CLASS::*) %{
   /* %typemap(csbody) SWIGTYPE *, SWIGTYPE &, SWIGTYPE [], SWIGTYPE (CLASS::*) */
-  private HandleRef swigCPtr;
+  private System.Runtime.InteropServices.HandleRef swigCPtr;
 
-  internal $csclassname(IntPtr cPtr, bool futureUse, object parent) {
-    swigCPtr = new HandleRef(this, cPtr);
+  internal $csclassname(System.IntPtr cPtr, bool futureUse, object parent) {
+    swigCPtr = new System.Runtime.InteropServices.HandleRef(this, cPtr);
   }
 
   protected $csclassname() {
-    swigCPtr = new HandleRef(null, IntPtr.Zero);
+    swigCPtr = new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
   }
 
-  internal static HandleRef getCPtr($csclassname obj) {
-    return (obj == null) ? new HandleRef(null, IntPtr.Zero) : obj.swigCPtr;
+  internal static System.Runtime.InteropServices.HandleRef getCPtr($csclassname obj) {
+    return (obj == null) ? new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero) : obj.swigCPtr;
   }
 %}
 
@@ -239,11 +239,11 @@
 
 %typemap(csdestruct, methodname="Dispose", methodmodifiers="public") SWIGTYPE {
   lock(this) {
-      if(swigCPtr.Handle != IntPtr.Zero && swigCMemOwn) {
+      if(swigCPtr.Handle != System.IntPtr.Zero && swigCMemOwn) {
         swigCMemOwn = false;
         $imcall;
       }
-      swigCPtr = new HandleRef(null, IntPtr.Zero);
+      swigCPtr = new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
       swigParentRef = null;
       GC.SuppressFinalize(this);
     }
@@ -251,11 +251,11 @@
 
 %typemap(csdestruct_derived, methodname="Dispose", methodmodifiers="public") TYPE {
   lock(this) {
-      if(swigCPtr.Handle != IntPtr.Zero && swigCMemOwn) {
+      if(swigCPtr.Handle != System.IntPtr.Zero && swigCMemOwn) {
         swigCMemOwn = false;
         $imcall;
       }
-      swigCPtr = new HandleRef(null, IntPtr.Zero);
+      swigCPtr = new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
       swigParentRef = null;
       GC.SuppressFinalize(this);
       base.Dispose();
@@ -267,7 +267,7 @@
 
 %pragma(csharp) modulecode=%{
   /* %pragma(csharp) modulecode */
-  internal class $moduleObject : IDisposable {
+  internal class $moduleObject : System.IDisposable {
 	public virtual void Dispose() {
       
     }
@@ -276,7 +276,7 @@
   protected static object ThisOwn_true() { return null; }
   protected static object ThisOwn_false() { return the$moduleObject; }
   
-  [DllImport("$dllimport", EntryPoint="SetEnvironmentVariable")]
+  [System.Runtime.InteropServices.DllImport("$dllimport", System.Runtime.InteropServices.EntryPoint="SetEnvironmentVariable")]
   public static extern int SetEnvironmentVariable(string envstring);
 %}
 

--- a/mapscript/csharp/swig_csharp_extensions.i
+++ b/mapscript/csharp/swig_csharp_extensions.i
@@ -41,28 +41,28 @@
         if (managedObj == null)
             return System.IntPtr.Zero;
         if (!(managedObj is string))
-            throw new MarshalDirectiveException(
+            throw new System.Runtime.InteropServices.MarshalDirectiveException(
                    "UTF8Marshaler must be used on a string.");
 
         // not null terminated
         byte[] strbuf = System.Text.Encoding.UTF8.GetBytes((string)managedObj); 
-        System.IntPtr buffer = Marshal.AllocHGlobal(strbuf.Length + 1);
-        Marshal.Copy(strbuf, 0, buffer, strbuf.Length);
+        System.IntPtr buffer = System.Runtime.InteropServices.Marshal.AllocHGlobal(strbuf.Length + 1);
+        System.Runtime.InteropServices.Marshal.Copy(strbuf, 0, buffer, strbuf.Length);
 
         // write the terminating null
-        Marshal.WriteByte(buffer, strbuf.Length, 0); 
+        System.Runtime.InteropServices.Marshal.WriteByte(buffer, strbuf.Length, 0); 
         return buffer;
     }
 
     public object MarshalNativeToManaged(System.IntPtr pNativeData) {
-	    int len = Marshal.PtrToStringAnsi(pNativeData).Length;
+	    int len = System.Runtime.InteropServices.Marshal.PtrToStringAnsi(pNativeData).Length;
         byte[] utf8data = new byte[len];
-        Marshal.Copy(pNativeData, utf8data, 0, len);
+        System.Runtime.InteropServices.Marshal.Copy(pNativeData, utf8data, 0, len);
         return System.Text.Encoding.UTF8.GetString(utf8data);
     }
 
     public void CleanUpNativeData(System.IntPtr pNativeData) {
-        Marshal.FreeHGlobal(pNativeData);            
+        System.Runtime.InteropServices.Marshal.FreeHGlobal(pNativeData);            
     }
 
     public void CleanUpManagedData(object managedObj) {
@@ -245,7 +245,7 @@
       }
       swigCPtr = new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
       swigParentRef = null;
-      GC.SuppressFinalize(this);
+      System.GC.SuppressFinalize(this);
     }
   }
 
@@ -257,7 +257,7 @@
       }
       swigCPtr = new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
       swigParentRef = null;
-      GC.SuppressFinalize(this);
+      System.GC.SuppressFinalize(this);
       base.Dispose();
     }
   }

--- a/mapscript/csharp/swig_csharp_extensions.i
+++ b/mapscript/csharp/swig_csharp_extensions.i
@@ -31,8 +31,8 @@
 
 // Ensure the class is not marked BeforeFieldInit causing memory corruption with CLR4 
 %pragma(csharp) imclasscode=%{
-  static $imclassname() {
-  }
+  //static $imclassname() {
+  //}
 
   public class UTF8Marshaler : System.Runtime.InteropServices.ICustomMarshaler {
     static UTF8Marshaler static_instance;
@@ -276,7 +276,7 @@
   protected static object ThisOwn_true() { return null; }
   protected static object ThisOwn_false() { return the$moduleObject; }
   
-  [System.Runtime.InteropServices.DllImport("$dllimport", System.Runtime.InteropServices.EntryPoint="SetEnvironmentVariable")]
+  [System.Runtime.InteropServices.DllImport("$dllimport", EntryPoint="SetEnvironmentVariable")]
   public static extern int SetEnvironmentVariable(string envstring);
 %}
 


### PR DESCRIPTION
See https://github.com/mapserver/mapserver/issues/5575

This initial pull request brings the number of errors when building with SWIG 3.0.12 from `1592 Error(s)` to`8 Error(s)`.

The remaining errors are:

```
[00:02:38]   mapscript.cs(25,58): error CS0234: The type or namespace name 'EntryPoint' does not exist in the namespace 'System.Runtime.InteropServices' (are you missing an assembly reference?) [C:\projects\mapserver\build\mapscript\csharp\mapscript.vcxproj]
[00:02:38]   mapscript.cs(25,4): error CS1729: 'DllImportAttribute' does not contain a constructor that takes 2 arguments [C:\projects\mapserver\build\mapscript\csharp\mapscript.vcxproj]
[00:02:38]   mapscriptPINVOKE.cs(191,10): error CS0111: Type 'mapscriptPINVOKE' already defines a member called '.cctor' with the same parameter types [C:\projects\mapserver\build\mapscript\csharp\mapscript.vcxproj]
[00:02:38]   mapscriptPINVOKE.cs(313,3): error CS0246: The type or namespace name 'ThreadStaticAttribute' could not be found (are you missing a using directive or an assembly reference?) [C:\projects\mapserver\build\mapscript\csharp\mapscript.vcxproj]
[00:02:38]   mapscriptPINVOKE.cs(313,3): error CS0246: The type or namespace name 'ThreadStatic' could not be found (are you missing a using directive or an assembly reference?) [C:\projects\mapserver\build\mapscript\csharp\mapscript.vcxproj]
[00:02:38]   mapscriptPINVOKE.cs(298,58): error CS0234: The type or namespace name 'EntryPoint' does not exist in the namespace 'System.Runtime.InteropServices' (are you missing an assembly reference?) [C:\projects\mapserver\build\mapscript\csharp\mapscript.vcxproj]
[00:02:38]   mapscriptPINVOKE.cs(298,4): error CS1729: 'DllImportAttribute' does not contain a constructor that takes 2 arguments [C:\projects\mapserver\build\mapscript\csharp\mapscript.vcxproj]
```