### PR TITLE
Use strcpy rather than strdup

### DIFF
--- a/mapstring.c
+++ b/mapstring.c
@@ -2110,15 +2110,17 @@ char *msStrdup( const char * pszString )
   if( pszString == NULL )
     pszString = "";
 
-  pszReturn = strdup( pszString );
+  pszReturn = msSmallMalloc(strlen(pszString)+1);
 
   if( pszReturn == NULL ) {
-    fprintf(stderr, "msSmallMsStrdup(): Out of memory allocating %ld bytes.\n",
+    /*should never be here*/
+    fprintf(stderr, "msSmallMalloc(): Out of memory allocating %ld bytes.\n",
             (long) strlen(pszString) );
     exit(1);
   }
+  strcpy( pszReturn, pszString);
 
-  return( pszReturn );
+  return pszReturn;
 }
 
 


### PR DESCRIPTION
I guess I must have missed this in the original pull request. This was a fix supplied by @tbonfort and relates to this - https://github.com/mapserver/mapserver/pull/5277

This pull request includes the code from https://github.com/tbonfort/mapserver/commit/bacf44f24a2dab8eff47d98788a302b7e0b0bb49

If strdup is used on Windows/MSVC then char variables don't get set correctly (at least when using the debugger). 

I'm not sure if this should committed to master or the soon to be released 7.2 branch (which would be ideal). 

