### PR TITLE
Use strcpy rather than strdup

### DIFF
--- a/mapstring.c
+++ b/mapstring.c
@@ -2103,22 +2103,24 @@ int msStringIsInteger(const char *string)
 
 /* Safe version of msStrdup(). This function is taken from gdal/cpl. */
 
-char *msStrdup( const char * pszString )
+char *msStrdup(const char * pszString)
 {
-  char        *pszReturn;
+    char        *pszReturn;
 
-  if( pszString == NULL )
-    pszString = "";
+    if (pszString == NULL)
+        pszString = "";
 
-  pszReturn = strdup( pszString );
+    pszReturn = msSmallMalloc(strlen(pszString) + 1);
 
-  if( pszReturn == NULL ) {
-    fprintf(stderr, "msSmallMsStrdup(): Out of memory allocating %ld bytes.\n",
-            (long) strlen(pszString) );
-    exit(1);
-  }
+    if (pszReturn == NULL) {
+        /*should never be here*/
+        fprintf(stderr, "msSmallMalloc(): Out of memory allocating %ld bytes.\n",
+            (long)strlen(pszString));
+        exit(1);
+    }
+    strcpy(pszReturn, pszString);
 
-  return( pszReturn );
+    return pszReturn;
 }
 
 

--- a/mapstring.c
+++ b/mapstring.c
@@ -2105,11 +2105,14 @@ int msStringIsInteger(const char *string)
 
 char *msStrdup(const char * pszString)
 {
-    size_t nStringLength = strlen(pszString) + 1; /* null terminated byte*/
-    char *pszReturn = malloc(nStringLength);
+    size_t nStringLength; 
+    char *pszReturn;
 
     if (pszString == NULL)
         pszString = "";
+
+    nStringLength = strlen(pszString) + 1; /* null terminated byte */
+    pszReturn = malloc(nStringLength);
 
     if (pszReturn == NULL) {
         fprintf(stderr, "msSmallMalloc(): Out of memory allocating %ld bytes.\n",

--- a/mapstring.c
+++ b/mapstring.c
@@ -2105,20 +2105,19 @@ int msStringIsInteger(const char *string)
 
 char *msStrdup(const char * pszString)
 {
-    char        *pszReturn;
 
     if (pszString == NULL)
         pszString = "";
 
-    pszReturn = msSmallMalloc(strlen(pszString) + 1);
+    unsigned int nStringLength = strlen(pszString);
+    char *pszReturn = malloc(nStringLength + 1);
+    memcpy(pszReturn, pszString, nStringLength + 1); /* null terminated byte*/
 
     if (pszReturn == NULL) {
-        /*should never be here*/
         fprintf(stderr, "msSmallMalloc(): Out of memory allocating %ld bytes.\n",
             (long)strlen(pszString));
         exit(1);
     }
-    strcpy(pszReturn, pszString);
 
     return pszReturn;
 }

--- a/mapstring.c
+++ b/mapstring.c
@@ -2105,19 +2105,19 @@ int msStringIsInteger(const char *string)
 
 char *msStrdup(const char * pszString)
 {
+    size_t nStringLength = strlen(pszString) + 1; /* null terminated byte*/
+    char *pszReturn = malloc(nStringLength);
 
     if (pszString == NULL)
         pszString = "";
-
-    unsigned int nStringLength = strlen(pszString);
-    char *pszReturn = malloc(nStringLength + 1);
-    memcpy(pszReturn, pszString, nStringLength + 1); /* null terminated byte*/
 
     if (pszReturn == NULL) {
         fprintf(stderr, "msSmallMalloc(): Out of memory allocating %ld bytes.\n",
             (long)strlen(pszString));
         exit(1);
     }
+
+    memcpy(pszReturn, pszString, nStringLength);
 
     return pszReturn;
 }


### PR DESCRIPTION
I guess I must have missed this in the original pull request. This was a fix supplied by @tbonfort and relates to this - https://github.com/mapserver/mapserver/pull/5277

This pull request includes the code from https://github.com/tbonfort/mapserver/commit/bacf44f24a2dab8eff47d98788a302b7e0b0bb49

If strdup is used on Windows/MSVC then char variables don't get set correctly (at least when using the debugger). 