### PR TITLE
Add Python methods to hashtable so it can be used like a dict

### DIFF
--- a/mapscript/python/pymodule.i
+++ b/mapscript/python/pymodule.i
@@ -105,11 +105,11 @@ CreateTupleFromDoubleArray( double *first, unsigned int size ) {
     def __setitem__(self, key, value):
         return self.set(key, value)
 
-    def __delitem__(self, k) :
+    def __delitem__(self, key) :
         return self.remove(key)
 
-    def __contains__(self, k):
-        return k.lower() in [key.lower() for k in self.keys()]
+    def __contains__(self, key):
+        return key.lower() in [k.lower() for k in self.keys()]
 
     def __len__(self):
         return self.numitems
@@ -125,7 +125,8 @@ CreateTupleFromDoubleArray( double *first, unsigned int size ) {
                 keys.append(k)
             else :
                 break
-                return keys
+
+        return keys
             
     %}
 };

--- a/mapscript/python/pymodule.i
+++ b/mapscript/python/pymodule.i
@@ -93,66 +93,28 @@ CreateTupleFromDoubleArray( double *first, unsigned int size ) {
   $result = t_output_helper($result,r);
 }
 
-
-/*
- * Typemap hashTableObj* -> dict
- */
-%typemap(out) hashTableObj*
-{
-  /* %typemap(out) hashTableObj* */
-  const char* key;
-  hashTableObj *hashTable = $1;
-  $result = PyDict_New();
-  key = msFirstKeyFromHashTable(hashTable);
-  while( key )
-  {
-    const char* val = msLookupHashTable(hashTable, key);
-    if( val )
-    {
-%#if PY_VERSION_HEX >= 0x03000000
-        PyObject *py_key = PyUnicode_FromString(key);
-        PyObject *py_val = PyUnicode_FromString(val);
-%#else
-        PyObject *py_key = PyString_FromString(key);
-        PyObject *py_val = PyString_FromString(val);
-%#endif
-
-        PyDict_SetItem($result, py_key, py_val );
-        Py_DECREF(py_key);
-        Py_DECREF(py_val);
-    }
-    key = msNextKeyFromHashTable(hashTable, key);
-  }
-}
-
-%typemap(freearg) hashTableObj*
-{
-  /* %typemap(freearg) hashTableObj* */
-  msFreeHashTable( $1 );
-}
-
 /*
 * Add dict methods to the hashTableObj object
 */
 %extend hashTableObj{
     %pythoncode %{
 
-    def __getitem__(self, key) :
+    def __getitem__(self, key):
         return self.get(key)
 
-    def __setitem__(self, key, value) :
+    def __setitem__(self, key, value):
         return self.set(key, value)
 
     def __delitem__(self, k) :
         return self.remove(key)
 
-    def __contains__(self, k) :
+    def __contains__(self, k):
         return k.lower() in [key.lower() for k in self.keys()]
 
-    def __len__(self) :
+    def __len__(self):
         return self.numitems
 
-    def keys(self) :
+    def keys(self):
 
         keys = []
         k = None
@@ -165,7 +127,7 @@ CreateTupleFromDoubleArray( double *first, unsigned int size ) {
                 break
                 return keys
             
-    % }
+    %}
 };
 
 /**************************************************************************

--- a/mapscript/python/pymodule.i
+++ b/mapscript/python/pymodule.i
@@ -131,7 +131,42 @@ CreateTupleFromDoubleArray( double *first, unsigned int size ) {
   msFreeHashTable( $1 );
 }
 
+/*
+* Add dict methods to the hashTableObj object
+*/
+%extend hashTableObj{
+    %pythoncode %{
 
+    def __getitem__(self, key) :
+        return self.get(key)
+
+    def __setitem__(self, key, value) :
+        return self.set(key, value)
+
+    def __delitem__(self, k) :
+        return self.remove(key)
+
+    def __contains__(self, k) :
+        return k.lower() in [key.lower() for k in self.keys()]
+
+    def __len__(self) :
+        return self.numitems
+
+    def keys(self) :
+
+        keys = []
+        k = None
+
+        while True :
+            k = self.nextKey(k)
+            if k :
+                keys.append(k)
+            else :
+                break
+                return keys
+            
+    % }
+};
 
 /**************************************************************************
  * MapServer Errors and Python Exceptions

--- a/mapscript/python/tests/cases/hashtest.py
+++ b/mapscript/python/tests/cases/hashtest.py
@@ -85,17 +85,28 @@ class HashTableBaseTestCase:
         key = self.table.nextKey(key)
         assert key == None, key
 
-# TODO
-#    def testKeys(self):
-#        "get sequence of keys"
-#        keys = self.table.keys()
-#        assert keys == self.keys, keys
-#
-#    def testValues(self):
-#        "get sequence of values"
-#        values = self.table.values()
-#        assert values == self.values, values
+    # tests using the Python dictionary access methods
 
+    def testDictKeys(self):
+        assert sorted(self.keys) ==  sorted(self.table.keys())
+
+    def testDictItems(self):
+        assert len(self.keys) ==  len(self.table)
+
+    def testCheckDictContains(self):
+        for key in self.keys:
+            assert key in self.table.keys()
+
+    def testGetDictValue(self):
+        for key, value in zip(self.keys, self.values):
+            assert self.table[key] == value
+            assert self.table[key.upper()] == value
+            assert self.table[key.capitalize()] == value
+
+    def testRemoveDictItem(self):
+        key = self.keys[0]
+        del self.table[key]
+        assert self.table[key] == None
 
 # ===========================================================================
 # Test begins now


### PR DESCRIPTION
Supersedes #5614

Add various Python methods so that a hashtable can be used like a dict. See #5582 for background. 
API is now as follows:

```python
import mapscript
ht = mapscript.hashTableObj()

ht["key1"] = "value1"
ht["key2"] = "value2"
ht["key3"] = "value3"
ht["key4"] = "value4"

del ht["key1"]
print(ht.keys)
print(len(ht))
print("k1" in ht)
print(len(ht))
```

Or for a more concrete example:

```python

print(map.web.metadata.keys()) # ['wms_srs', 'ows_enable_request', 'ows_http_max_age']
print(map.web.metadata["wms_srs"]) # EPSG:4326
map.web.metadata["wms_srs"] = "EPSG:2157"
print(map.web.metadata["wms_srs"])  # EPSG:2157
```