### PR TITLE
Fix Appveyor path errors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,8 @@ build_script:
   - if "%platform%" == "x86" SET VS_FULL=%VS_VERSION%
   - if "%platform%" == "x86" SET SDK=release-1911
   - if "%platform%" == "x64" SET SDK=release-1911-x64
-  - if "%platform%" == "x64" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  - if "%platform%" == "x86" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars64.bat"
+  - if "%platform%" == "x86" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars32.bat"
   - echo "%VS_FULL%"
   - set SDK_ZIP=%SDK%-dev.zip
   - set SDK_URL=http://download.gisinternals.com/sdk/downloads/%SDK_ZIP%
@@ -28,34 +28,31 @@ build_script:
   - appveyor DownloadFile "%SDK_URL%"
   - 7z x "%SDK_ZIP%" > nul
   - cd %SDK%
-  - cd lib
-  - copy libpng.lib libpng.lib.lib
   - cd ..
   - cd ..
-  - cd ..
-  - set SDK_PREFIX=%CD%\sdk\%SDK%
-  - set SDK_INC=%CD%\sdk\%SDK%\include
-  - set SDK_LIB=%CD%\sdk\%SDK%\lib
-  - set SDK_BIN=%CD%\sdk\%SDK%\bin
-  - set SWIG_EXECUTABLE=%CD%\sdk\SWIG-1.3.39\swig.exe
-  - set REGEX_DIR=%CD%\sdk\regex-0.12
-  - if "%platform%" == "x86" SET PYTHON_EXECUTABLE=c:\python27\python.exe
-  - if "%platform%" == "x64" SET PYTHON_EXECUTABLE=c:\python27-x64\python.exe
+  - set SDK_PREFIX=%CD%/sdk/%SDK%
+  - set SDK_INC=%CD%/sdk/%SDK%/include
+  - set SDK_LIB=%CD%/sdk/%SDK%/lib
+  - set SDK_BIN=%CD%/sdk/%SDK%/bin
+  - set SWIG_EXECUTABLE=%CD%/sdk/SWIG-1.3.39/swig.exe
+  - set REGEX_DIR=%CD%/sdk/regex-0.12
+  - if "%platform%" == "x86" SET PYTHON_EXECUTABLE=c:/python27/python.exe
+  - if "%platform%" == "x64" SET PYTHON_EXECUTABLE=c:/python27-x64/python.exe
   - mkdir build
   - cd build
-  - cmake -G "%VS_FULL%" .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%SDK_PREFIX% -DFREETYPE_INCLUDE_DIR_freetype2=%SDK_INC%\freetype -DFREETYPE_INCLUDE_DIR_ft2build=%SDK_INC%\freetype -DFREETYPE_LIBRARY=%SDK_LIB%\freetype.lib -DZLIB_INCLUDE_DIR=%SDK_INC% -DZLIB_LIBRARY=%SDK_LIB%\zlib.lib -DPNG_PNG_INCLUDE_DIR=%SDK_INC% -DPNG_LIBRARY=%SDK_LIB%\libpng.lib -DPNG_LIBRARIES=%SDK_LIB%\libpng.lib -DJPEG_INCLUDE_DIR=%SDK_INC% -DJPEG_LIBRARY=%SDK_LIB%\libjpeg.lib -DWITH_PROJ=1 -DPROJ_INCLUDE_DIR=%SDK_INC% -DPROJ_LIBRARY=%SDK_LIB%\proj_i.lib -DFRIBIDI_INCLUDE_DIR=%SDK_INC% -DFRIBIDI_LIBRARY=%SDK_LIB%\fribidi.lib -DHARFBUZZ_INCLUDE_DIR=%SDK_INC%\harfbuzz -DHARFBUZZ_LIBRARY=%SDK_LIB%\harfbuzz.lib -DICONV_INCLUDE_DIR=%SDK_INC% -DICONV_LIBRARY=%SDK_LIB%\iconv.lib -DICONV_DLL=%SDK_BIN%\iconv.dll -DCAIRO_INCLUDE_DIR=%SDK_INC% -DCAIRO_LIBRARY=%SDK_LIB%\cairo.lib -DFCGI_INCLUDE_DIR=%SDK_INC% -DFCGI_LIBRARY=%SDK_LIB%\libfcgi.lib -DGEOS_INCLUDE_DIR=%SDK_INC% -DGEOS_LIBRARY=%SDK_LIB%\geos_c.lib -DPOSTGRESQL_INCLUDE_DIR=%SDK_INC% -DPOSTGRESQL_LIBRARY=%SDK_LIB%\libpqdll.lib -DGDAL_INCLUDE_DIR=%SDK_INC% -DGDAL_LIBRARY=%SDK_LIB%\gdal_i.lib -DLIBXML2_INCLUDE_DIR=%SDK_INC%\libxml -DLIBXML2_LIBRARIES=%SDK_LIB%\libxml2.lib -DGIF_INCLUDE_DIR=%SDK_INC% -DGIF_LIBRARY=%SDK_LIB%\giflib.lib -DWITH_CURL=1 -DCURL_INCLUDE_DIR=%SDK_INC% -DCURL_LIBRARY=%SDK_LIB%\libcurl_imp.lib -DMS_EXTERNAL_LIBS=wsock32.lib -DWITH_SOS=1 -DWITH_CLIENT_WFS=1 -DWITH_CLIENT_WMS=1 -DSVG_INCLUDE_DIR=%SDK_INC% -DSVG_LIBRARY=%SDK_LIB%\libsvg.lib -DSVGCAIRO_INCLUDE_DIR=%SDK_INC% -DSVGCAIRO_LIBRARY=%SDK_LIB%\libsvg-cairo.lib -DWITH_SVGCAIRO=1 -DREGEX_DIR=%REGEX_DIR% -DWITH_POINT_Z_M=1 -DWITH_KML=1 -DWITH_THREAD_SAFETY=1 -DSWIG_EXECUTABLE=%SWIG_EXECUTABLE% -DWITH_PYTHON=1 -DPYTHON_EXECUTABLE=%PYTHON_EXECUTABLE% -DWITH_CSHARP=1 -DWITH_PROTOBUFC=0
+  - cmake -G "%VS_FULL%" .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%SDK_PREFIX% -DFREETYPE_INCLUDE_DIR_freetype2=%SDK_INC%/freetype -DFREETYPE_INCLUDE_DIR_ft2build=%SDK_INC%/freetype -DFREETYPE_LIBRARY=%SDK_LIB%/freetype.lib -DZLIB_INCLUDE_DIR=%SDK_INC% -DZLIB_LIBRARY=%SDK_LIB%/zlib.lib -DPNG_PNG_INCLUDE_DIR=%SDK_INC% -DPNG_LIBRARY=%SDK_LIB%/libpng.lib -DPNG_LIBRARIES=%SDK_LIB%/libpng.lib -DJPEG_INCLUDE_DIR=%SDK_INC% -DJPEG_LIBRARY=%SDK_LIB%/libjpeg.lib -DWITH_PROJ=1 -DPROJ_INCLUDE_DIR=%SDK_INC% -DPROJ_LIBRARY=%SDK_LIB%/proj_i.lib -DFRIBIDI_INCLUDE_DIR=%SDK_INC% -DFRIBIDI_LIBRARY=%SDK_LIB%/fribidi.lib -DHARFBUZZ_INCLUDE_DIR=%SDK_INC%/harfbuzz -DHARFBUZZ_LIBRARY=%SDK_LIB%/harfbuzz.lib -DICONV_INCLUDE_DIR=%SDK_INC% -DICONV_LIBRARY=%SDK_LIB%/iconv.lib -DICONV_DLL=%SDK_BIN%/iconv.dll -DCAIRO_INCLUDE_DIR=%SDK_INC% -DCAIRO_LIBRARY=%SDK_LIB%/cairo.lib -DFCGI_INCLUDE_DIR=%SDK_INC% -DFCGI_LIBRARY=%SDK_LIB%/libfcgi.lib -DGEOS_INCLUDE_DIR=%SDK_INC% -DGEOS_LIBRARY=%SDK_LIB%/geos_c.lib -DPOSTGRESQL_INCLUDE_DIR=%SDK_INC% -DPOSTGRESQL_LIBRARY=%SDK_LIB%/libpqdll.lib -DGDAL_INCLUDE_DIR=%SDK_INC% -DGDAL_LIBRARY=%SDK_LIB%/gdal_i.lib -DLIBXML2_INCLUDE_DIR=%SDK_INC%/libxml -DLIBXML2_LIBRARIES=%SDK_LIB%/libxml2.lib -DGIF_INCLUDE_DIR=%SDK_INC% -DGIF_LIBRARY=%SDK_LIB%/giflib.lib -DWITH_CURL=1 -DCURL_INCLUDE_DIR=%SDK_INC% -DCURL_LIBRARY=%SDK_LIB%/libcurl_imp.lib -DMS_EXTERNAL_LIBS=wsock32.lib -DWITH_SOS=1 -DWITH_CLIENT_WFS=1 -DWITH_CLIENT_WMS=1 -DSVG_INCLUDE_DIR=%SDK_INC% -DSVG_LIBRARY=%SDK_LIB%/libsvg.lib -DSVGCAIRO_INCLUDE_DIR=%SDK_INC% -DSVGCAIRO_LIBRARY=%SDK_LIB%/libsvg-cairo.lib -DWITH_SVGCAIRO=1 -DREGEX_DIR=%REGEX_DIR% -DWITH_POINT_Z_M=1 -DWITH_KML=1 -DWITH_THREAD_SAFETY=1 -DSWIG_EXECUTABLE=%SWIG_EXECUTABLE% -DWITH_PYTHON=1 -DPYTHON_EXECUTABLE=%PYTHON_EXECUTABLE% -DWITH_CSHARP=1 -DWITH_PROTOBUFC=0
   - cmake --build . --config Release
 
 before_test:
   - "%PYTHON_EXECUTABLE% -m pip install --upgrade pip"
-  - cd %APPVEYOR_BUILD_FOLDER%\mapscript\python
+  - cd %APPVEYOR_BUILD_FOLDER%/mapscript/python
   - "%PYTHON_EXECUTABLE% -m pip install -r requirements-dev.txt"
 
 test_script:
-  - set PATH=%APPVEYOR_BUILD_FOLDER%\build\Release;%APPVEYOR_BUILD_FOLDER%\sdk\%SDK%\bin;%PATH%
-  - set PROJ_LIB=%APPVEYOR_BUILD_FOLDER%\sdk\%SDK%\bin\proj\SHARE
-  - set PYTHONPATH=%APPVEYOR_BUILD_FOLDER%\build\mapscript\python\Release;%APPVEYOR_BUILD_FOLDER%\build\mapscript\python
-  - cd %APPVEYOR_BUILD_FOLDER%\mapscript\python
+  - set PATH=%APPVEYOR_BUILD_FOLDER%/build/Release;%APPVEYOR_BUILD_FOLDER%/sdk/%SDK%/bin;%PATH%
+  - set PROJ_LIB=%APPVEYOR_BUILD_FOLDER%/sdk/%SDK%/bin/proj/SHARE
+  - set PYTHONPATH=%APPVEYOR_BUILD_FOLDER%/build/mapscript/python/Release;%APPVEYOR_BUILD_FOLDER%/build/mapscript/python
+  - cd %APPVEYOR_BUILD_FOLDER%/mapscript/python
   - "%PYTHON_EXECUTABLE% -m pytest --ignore=tests/cases/fonttest.py --ignore=tests/cases/hashtest.py --ignore=tests/cases/pgtest.py --ignore=tests/cases/threadtest.py tests/cases"
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
 shallow_clone: true
 
 build_script:
-  - set "APPVEYOR_BUILD_FOLDER=%APPVEYOR_BUILD_FOLDER:\=/%"
+  - set "BUILD_FOLDER=%APPVEYOR_BUILD_FOLDER:\=/%"
   - if "%platform%" == "x64" SET VS_FULL=%VS_VERSION% Win64
   - if "%platform%" == "x86" SET VS_FULL=%VS_VERSION%
   - if "%platform%" == "x86" SET SDK=release-1911
@@ -28,17 +28,15 @@ build_script:
   - cd sdk
   - appveyor DownloadFile "%SDK_URL%"
   - 7z x "%SDK_ZIP%" > nul
-  - cd %SDK%
-  - cd ..
-  - cd ..
-  - set SDK_PREFIX=%CD%/sdk/%SDK%
-  - set SDK_INC=%CD%/sdk/%SDK%/include
-  - set SDK_LIB=%CD%/sdk/%SDK%/lib
-  - set SDK_BIN=%CD%/sdk/%SDK%/bin
-  - set SWIG_EXECUTABLE=%CD%/sdk/SWIG-1.3.39/swig.exe
-  - set REGEX_DIR=%CD%/sdk/regex-0.12
+  - set SDK_PREFIX=%BUILD_FOLDER%/sdk/%SDK%
+  - set SDK_INC=%BUILD_FOLDER%/sdk/%SDK%/include
+  - set SDK_LIB=%BUILD_FOLDER%/sdk/%SDK%/lib
+  - set SDK_BIN=%BUILD_FOLDER%/sdk/%SDK%/bin
+  - set SWIG_EXECUTABLE=%BUILD_FOLDER%/sdk/SWIG-1.3.39/swig.exe
+  - set REGEX_DIR=%BUILD_FOLDER%/sdk/regex-0.12
   - if "%platform%" == "x86" SET PYTHON_EXECUTABLE=c:/python27/python.exe
   - if "%platform%" == "x64" SET PYTHON_EXECUTABLE=c:/python27-x64/python.exe
+  - cd %BUILD_FOLDER%  
   - mkdir build
   - cd build
   - cmake -G "%VS_FULL%" .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%SDK_PREFIX% -DFREETYPE_INCLUDE_DIR_freetype2=%SDK_INC%/freetype -DFREETYPE_INCLUDE_DIR_ft2build=%SDK_INC%/freetype -DFREETYPE_LIBRARY=%SDK_LIB%/freetype.lib -DZLIB_INCLUDE_DIR=%SDK_INC% -DZLIB_LIBRARY=%SDK_LIB%/zlib.lib -DPNG_PNG_INCLUDE_DIR=%SDK_INC% -DPNG_LIBRARY=%SDK_LIB%/libpng.lib -DPNG_LIBRARIES=%SDK_LIB%/libpng.lib -DJPEG_INCLUDE_DIR=%SDK_INC% -DJPEG_LIBRARY=%SDK_LIB%/libjpeg.lib -DWITH_PROJ=1 -DPROJ_INCLUDE_DIR=%SDK_INC% -DPROJ_LIBRARY=%SDK_LIB%/proj_i.lib -DFRIBIDI_INCLUDE_DIR=%SDK_INC% -DFRIBIDI_LIBRARY=%SDK_LIB%/fribidi.lib -DHARFBUZZ_INCLUDE_DIR=%SDK_INC%/harfbuzz -DHARFBUZZ_LIBRARY=%SDK_LIB%/harfbuzz.lib -DICONV_INCLUDE_DIR=%SDK_INC% -DICONV_LIBRARY=%SDK_LIB%/iconv.lib -DICONV_DLL=%SDK_BIN%/iconv.dll -DCAIRO_INCLUDE_DIR=%SDK_INC% -DCAIRO_LIBRARY=%SDK_LIB%/cairo.lib -DFCGI_INCLUDE_DIR=%SDK_INC% -DFCGI_LIBRARY=%SDK_LIB%/libfcgi.lib -DGEOS_INCLUDE_DIR=%SDK_INC% -DGEOS_LIBRARY=%SDK_LIB%/geos_c.lib -DPOSTGRESQL_INCLUDE_DIR=%SDK_INC% -DPOSTGRESQL_LIBRARY=%SDK_LIB%/libpqdll.lib -DGDAL_INCLUDE_DIR=%SDK_INC% -DGDAL_LIBRARY=%SDK_LIB%/gdal_i.lib -DLIBXML2_INCLUDE_DIR=%SDK_INC%/libxml -DLIBXML2_LIBRARIES=%SDK_LIB%/libxml2.lib -DGIF_INCLUDE_DIR=%SDK_INC% -DGIF_LIBRARY=%SDK_LIB%/giflib.lib -DWITH_CURL=1 -DCURL_INCLUDE_DIR=%SDK_INC% -DCURL_LIBRARY=%SDK_LIB%/libcurl_imp.lib -DMS_EXTERNAL_LIBS=wsock32.lib -DWITH_SOS=1 -DWITH_CLIENT_WFS=1 -DWITH_CLIENT_WMS=1 -DSVG_INCLUDE_DIR=%SDK_INC% -DSVG_LIBRARY=%SDK_LIB%/libsvg.lib -DSVGCAIRO_INCLUDE_DIR=%SDK_INC% -DSVGCAIRO_LIBRARY=%SDK_LIB%/libsvg-cairo.lib -DWITH_SVGCAIRO=1 -DREGEX_DIR=%REGEX_DIR% -DWITH_POINT_Z_M=1 -DWITH_KML=1 -DWITH_THREAD_SAFETY=1 -DSWIG_EXECUTABLE=%SWIG_EXECUTABLE% -DWITH_PYTHON=1 -DPYTHON_EXECUTABLE=%PYTHON_EXECUTABLE% -DWITH_CSHARP=1 -DWITH_PROTOBUFC=0
@@ -46,14 +44,14 @@ build_script:
 
 before_test:
   - "%PYTHON_EXECUTABLE% -m pip install --upgrade pip"
-  - cd %APPVEYOR_BUILD_FOLDER%/mapscript/python
+  - cd %BUILD_FOLDER%/mapscript/python
   - "%PYTHON_EXECUTABLE% -m pip install -r requirements-dev.txt"
 
 test_script:
-  - set PATH=%APPVEYOR_BUILD_FOLDER%/build/Release;%APPVEYOR_BUILD_FOLDER%/sdk/%SDK%/bin;%PATH%
-  - set PROJ_LIB=%APPVEYOR_BUILD_FOLDER%/sdk/%SDK%/bin/proj/SHARE
-  - set PYTHONPATH=%APPVEYOR_BUILD_FOLDER%/build/mapscript/python/Release;%APPVEYOR_BUILD_FOLDER%/build/mapscript/python
-  - cd %APPVEYOR_BUILD_FOLDER%/mapscript/python
+  - set PATH=%BUILD_FOLDER%/build/Release;%BUILD_FOLDER%/sdk/%SDK%/bin;%PATH%
+  - set PROJ_LIB=%BUILD_FOLDER%/sdk/%SDK%/bin/proj/SHARE
+  - set PYTHONPATH=%BUILD_FOLDER%/build/mapscript/python/Release;%BUILD_FOLDER%/build/mapscript/python
+  - cd %BUILD_FOLDER%/mapscript/python
   - "%PYTHON_EXECUTABLE% -m pytest --ignore=tests/cases/fonttest.py --ignore=tests/cases/hashtest.py --ignore=tests/cases/pgtest.py --ignore=tests/cases/threadtest.py tests/cases"
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ environment:
 shallow_clone: true
 
 build_script:
+  - set "APPVEYOR_BUILD_FOLDER=%APPVEYOR_BUILD_FOLDER:\=/%"
   - if "%platform%" == "x64" SET VS_FULL=%VS_VERSION% Win64
   - if "%platform%" == "x86" SET VS_FULL=%VS_VERSION%
   - if "%platform%" == "x86" SET SDK=release-1911


### PR DESCRIPTION
This pull request replaces all backslashes in paths with forward slashes to stop current CMake errors in Appveyor such as:

```
CMake Warning (dev) at CMakeLists.txt:61 (target_link_libraries):
  Syntax error in cmake code at
    C:/projects/mapserver/CMakeLists.txt:61
  when parsing string
    C:\projects\mapserver\sdk\release-1911-x64\lib\libxml2.lib
  Invalid escape sequence \p
```

For example see a previous build log at https://ci.appveyor.com/project/MapServer/mapserver/build/1.0.767/job/0y3wh6bbf2we3g4d?fullLog=true which contains 4 of these errors. 

This may also be the reason for the issue with the libpng issue which required ```copy libpng.lib libpng.lib.lib``` - as \l is a special character. This additional step has been removed and the build is still successful. 
