### PR TITLE
Use RST for ReadMe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,11 @@
+MapServer
+=========
+
+|Build Status|
+
 -------
 Summary
 -------
-
    
 MapServer is a system for developing web-based GIS applications. 
 The basic system consists of a CGI program that can be configured to 
@@ -28,9 +32,8 @@ Join the MapServer user mailing list online at:
 
  
 
------------
 Credits
------------
+-------
 
 MapServer was originally written by Stephen Lime. Major funding for development of 
 MapServer has been provided by NASA through cooperative argreements with 
@@ -61,9 +64,8 @@ Portions derived from Shapelib, Copyright 1995-1999 Frank Warmerdam.
 
 Supporting packages are covered by their own copyrights.
 
------------
 License
------------
+-------
 
 ::
 
@@ -89,3 +91,8 @@ License
   SOFTWARE.
 
 
+.. |Build Status| image:: https://travis-ci.org/mapserver/mapserver.svg?branch=master
+   :target: https://travis-ci.org/mapserver/mapserver
+
+.. |Appveyor Build Status| image:: https://ci.appveyor.com/api/projects/status/mk33l07478gfytwh?svg=true
+   :target: https://ci.appveyor.com/project/mapserver/mapserver


### PR DESCRIPTION
In preparation for the 7.2 release, would it be worthwhile changing the README to an RST file so it is nicely formatted on GitHub? You can see a preview at https://github.com/geographika/mapserver/tree/7-2-readme
As the default branch in GitHub will be 7.2 until the next major release I created the pull request against the 7.2 branch. I can make it against master if preferable. 

I added in the status button of the master build from Travis. 
I can also add in Appveyor, but it seems like you need to be an admin to see the URL for the badge. @sdlime - if you get a chance maybe you could add me as an admin to the Appveyor MapServer project, similar to MapCache?
