### PR TITLE
Remove -beta2 version suffix.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ include(CheckCSourceCompiles)
 set (MapServer_VERSION_MAJOR 7)
 set (MapServer_VERSION_MINOR 2)
 set (MapServer_VERSION_REVISION 0)
-set (MapServer_VERSION_SUFFIX "-beta2")
+set (MapServer_VERSION_SUFFIX "")
 
 set(TARGET_VERSION_MAJOR ${MapServer_VERSION_MAJOR})
 set(TARGET_VERSION_MINOR ${MapServer_VERSION_MINOR})


### PR DESCRIPTION
The `-beta2` suffix is still present in the MapServer 7.2.0 release.