### PR TITLE
mapogcsld: fix potential overflow when writing hexcolor 

### DIFF
--- a/mapogcsld.c
+++ b/mapogcsld.c
@@ -4013,7 +4013,7 @@ char *msSLDGenerateTextSLD(classObj *psClass, layerObj *psLayer, int nVersion)
       snprintf(szTmp, sizeof(szTmp), "<%sFill>\n", sNameSpace );
       pszSLD = msStringConcatenate(pszSLD, szTmp);
 
-      sprintf(szHexColor,"%02x%02x%02x",nColorRed,
+      sprintf(szHexColor,"%02hhx%02hhx%02hhx",nColorRed,
               nColorGreen, nColorBlue);
 
       snprintf(szTmp, sizeof(szTmp),


### PR DESCRIPTION
Fix potential overflow when writing hexcolor in the unlikely case color components are bigger than 255. Just keeping the compiler happy.