### PR TITLE
Make Travis stop building with php 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: trusty
 language: php
 php:
-  - 5.5
   - 5.6
 
 env:


### PR DESCRIPTION
Make Travis stop building with PHP-5.5 (not supported any more. see http://php.net/supported-versions.php)