### PR TITLE
Silently ignore WMS filter if the provided value is empty

### DIFF
--- a/mapwms.c
+++ b/mapwms.c
@@ -323,7 +323,12 @@ int msWMSApplyFilter(mapObj *map, int version, const char *filter,
   char **paszFilters = NULL;
   FilterEncodingNode *psNode = NULL;
 
-  if (!map || !filter || strlen(filter)==0)
+  // Empty filter should be ignored
+  if (!filter || strlen(filter) == 0)
+    return MS_SUCCESS;
+  
+
+  if (!map)
     return MS_FAILURE;  
 
   /* Count number of requested layers 
@@ -360,7 +365,7 @@ int msWMSApplyFilter(mapObj *map, int version, const char *filter,
   }
 
   if (numlayers != numfilters) {
-    msSetError(MS_WFSERR, "Wrong number of filter elements, one filter must be specified for each requested layer.",
+    msSetError(MS_WMSERR, "Wrong number of filter elements, one filter must be specified for each requested layer.",
 	       "msWMSApplyFilter" );
     return msWMSException(map, version, "InvalidParameterValue", wms_exception_format);
   }
@@ -454,7 +459,7 @@ int msWMSApplyFilter(mapObj *map, int version, const char *filter,
       errorObj* ms_error = msGetErrorObj();
 
       if(ms_error->code != MS_NOTFOUND) {
-	msSetError(MS_WFSERR, "FLTApplyFilterToLayer() failed", "msWFSGetFeature()");
+	msSetError(MS_WMSERR, "FLTApplyFilterToLayer() failed", "msWFSGetFeature()");
 	FLTFreeFilterEncodingNode( psNode );
 	return msWMSException(map, version, "InvalidParameterValue", wms_exception_format);
       }

--- a/mapwms.c
+++ b/mapwms.c
@@ -326,7 +326,6 @@ int msWMSApplyFilter(mapObj *map, int version, const char *filter,
   // Empty filter should be ignored
   if (!filter || strlen(filter) == 0)
     return MS_SUCCESS;
-  
 
   if (!map)
     return MS_FAILURE;  
@@ -459,7 +458,7 @@ int msWMSApplyFilter(mapObj *map, int version, const char *filter,
       errorObj* ms_error = msGetErrorObj();
 
       if(ms_error->code != MS_NOTFOUND) {
-	msSetError(MS_WMSERR, "FLTApplyFilterToLayer() failed", "msWFSGetFeature()");
+	msSetError(MS_WMSERR, "FLTApplyFilterToLayer() failed", "msWMSApplyFilter()");
 	FLTFreeFilterEncodingNode( psNode );
 	return msWMSException(map, version, "InvalidParameterValue", wms_exception_format);
       }


### PR DESCRIPTION
New pull request targeting branch-7-2 instead of master.

If the WMS filter parameter is empty (e.g. FILTER=) you will get a 500 error. This pull request changes this behavior so that it will instead ignore empty filters.

See discussion in #5597 for more details.