### PR TITLE
Change URL to OpenLayers to be protocol relative

### DIFF
--- a/maptemplate.c
+++ b/maptemplate.c
@@ -43,7 +43,7 @@
 static inline void IGUR_sizet(size_t ignored) { (void)ignored; }  /* Ignore GCC Unused Result */
 static inline void IGUR_voidp(void* ignored) { (void)ignored; }  /* Ignore GCC Unused Result */
 
-static char *olUrl = "http://www.mapserver.org/lib/OpenLayers-ms60.js";
+static char *olUrl = "//www.mapserver.org/lib/OpenLayers-ms60.js";
 static char *olTemplate = \
                           "<html>\n"
                           "<head>\n"


### PR DESCRIPTION
There is a built-in OpenLayers viewer in Mapserver which uses http://www.mapserver.org/lib/OpenLayers-ms60.js as URL to OpenLayer.
I was able to use this over https only if i tell my browser to allow mixed-content.

This patch changes the url to be a protocol relative URL. This causes Firefox to use https even if i call the viewer via http.
I tested and it works a little bit better now, because there are still http://-urls to the images in OpenLayers-ms60.js:

![grafik](https://user-images.githubusercontent.com/23343388/46879521-95240b00-ce46-11e8-9878-c707fdd9d312.png)

![grafik](https://user-images.githubusercontent.com/23343388/46879535-9b19ec00-ce46-11e8-90cb-f93af8d076fb.png) (in german, sorry)


If you merge this and anyone changes OpenLayers-ms60.js on your homepage to do the same, users can use the built-in OpenLayers viewer over https out-of-the box.

Thank you.

Alex