### PR TITLE
emit only required formats for WMS links in ISO metadata (#5667)

### DIFF
--- a/mapmetadata.c
+++ b/mapmetadata.c
@@ -604,9 +604,7 @@ xmlNodePtr _msMetadataGetDistributionInfo(xmlNsPtr namespace, mapObj *map, layer
 
   /* WMS */
   xmlAddChild(psDTONode, _msMetadataGetOnline(namespace, layer, "M", "image/png", "PNG Format", url));
-
   xmlAddChild(psDTONode, _msMetadataGetOnline(namespace, layer, "M", "image/jpeg", "JPEG Format", url));
-  xmlAddChild(psDTONode, _msMetadataGetOnline(namespace, layer, "M", "image/gif", "GIF Format", url));
 
   /* WCS */
   if (layer->type == MS_LAYER_RASTER) {

--- a/msautotest/wxs/expected/ows_metadata_layer_raster.xml
+++ b/msautotest/wxs/expected/ows_metadata_layer_raster.xml
@@ -256,22 +256,6 @@ Content-type: text/xml
           <gmd:onLine>
             <gmd:CI_OnlineResource>
               <gmd:linkage>
-                <gmd:URL>http://localhost/ows?service=WMS&amp;version=1.3.0&amp;request=GetMap&amp;width=500&amp;height=300&amp;styles=&amp;layers=toronto&amp;format=image/gif&amp;crs=EPSG:32611&amp;bbox=4945950.00000,456800.00000,4957150.00000,469300.00000</gmd:URL>
-              </gmd:linkage>
-              <gmd:protocol>
-                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
-              </gmd:protocol>
-              <gmd:name>
-                <gco:CharacterString>toronto</gco:CharacterString>
-              </gmd:name>
-              <gmd:description>
-                <gco:CharacterString>GIF Format</gco:CharacterString>
-              </gmd:description>
-            </gmd:CI_OnlineResource>
-          </gmd:onLine>
-          <gmd:onLine>
-            <gmd:CI_OnlineResource>
-              <gmd:linkage>
                 <gmd:URL>http://localhost/ows?service=WCS&amp;version=2.0.1&amp;request=GetCoverage&amp;coverageid=toronto&amp;format=image/tiff</gmd:URL>
               </gmd:linkage>
               <gmd:protocol>

--- a/msautotest/wxs/expected/ows_metadata_layer_vector.xml
+++ b/msautotest/wxs/expected/ows_metadata_layer_vector.xml
@@ -258,22 +258,6 @@ Content-type: text/xml
           <gmd:onLine>
             <gmd:CI_OnlineResource>
               <gmd:linkage>
-                <gmd:URL>http://localhost/ows?service=WMS&amp;version=1.3.0&amp;request=GetMap&amp;width=500&amp;height=300&amp;styles=&amp;layers=province&amp;format=image/gif&amp;crs=&amp;bbox=-76361.77343,2253355.75000,515489.03125,2747648.50000</gmd:URL>
-              </gmd:linkage>
-              <gmd:protocol>
-                <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
-              </gmd:protocol>
-              <gmd:name>
-                <gco:CharacterString>province</gco:CharacterString>
-              </gmd:name>
-              <gmd:description>
-                <gco:CharacterString>GIF Format</gco:CharacterString>
-              </gmd:description>
-            </gmd:CI_OnlineResource>
-          </gmd:onLine>
-          <gmd:onLine>
-            <gmd:CI_OnlineResource>
-              <gmd:linkage>
                 <gmd:URL>http://localhost/ows?service=WFS&amp;version=1.1.0&amp;request=GetFeature&amp;typename=province&amp;outputformat=GML2</gmd:URL>
               </gmd:linkage>
               <gmd:protocol>


### PR DESCRIPTION
Fixes #5667 