### PR TITLE
Hide MSVC compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -902,6 +902,7 @@ endif(UNIX)
 
 if (WIN32)
 ms_link_libraries( ${MS_EXTERNAL_LIBS} ws2_32.lib)
+    set_target_properties(mapserver PROPERTIES COMPILE_FLAGS "/wd4267 /wd4244 /wd4018")
 endif (WIN32)
 
 configure_file (


### PR DESCRIPTION
See #5700 - this hides the most frequent lower level warnings, so more significant issues can be addressed. 
It brings the warnings down from ~830 to ~50. 