### PR TITLE
Python MapScript install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ endif(MapServer_IS_DEV_VERSION)
 MATH(EXPR MapServer_VERSION_NUM "${MapServer_VERSION_MAJOR}*10000+${MapServer_VERSION_MINOR}*100+${MapServer_VERSION_REVISION}")
 
 SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
+
+# Add custom function to check Python modules are installed
+include(FindPythonModule)
+
 if (APPLE)
   set(CMAKE_FIND_FRAMEWORK "LAST")
 endif (APPLE)

--- a/cmake/FindPythonModule.cmake
+++ b/cmake/FindPythonModule.cmake
@@ -1,0 +1,24 @@
+# Find if a Python module is installed
+# Found at http://www.cmake.org/pipermail/cmake/2011-January/041666.html
+# To use do: find_python_module(PyQt4 REQUIRED)
+function(find_python_module module)
+	string(TOUPPER ${module} module_upper)
+	if(NOT PY_${module_upper})
+		if(ARGC GREATER 1 AND ARGV1 STREQUAL "REQUIRED")
+			set(${module}_FIND_REQUIRED TRUE)
+		endif()
+		# A module's location is usually a directory, but for binary modules
+		# it's a .so file.
+		execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" 
+			"import re, ${module}; print(re.compile('/__init__.py.*').sub('',${module}.__file__))"
+			RESULT_VARIABLE _${module}_status 
+			OUTPUT_VARIABLE _${module}_location
+			ERROR_QUIET 
+			OUTPUT_STRIP_TRAILING_WHITESPACE)
+		if(NOT _${module}_status)
+			set(PY_${module_upper} ${_${module}_location} CACHE STRING 
+				"Location of Python module ${module}")
+		endif(NOT _${module}_status)
+	endif(NOT PY_${module_upper})
+	find_package_handle_standard_args(PY_${module} DEFAULT_MSG PY_${module_upper})
+endfunction(find_python_module)

--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -30,10 +30,9 @@
 ============================================================================
 */
 
+%module mapscript
 #ifdef SWIGPHP
 %module mapscriptng
-#else
-%module mapscript
 #endif
 
 #ifdef SWIGCSHARP

--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -30,8 +30,9 @@
 ============================================================================
 */
 
+#ifndef SWIGPHPNG
 %module mapscript
-#ifdef SWIGPHP
+#else
 %module mapscriptng
 #endif
 

--- a/mapscript/python/CMakeLists.txt
+++ b/mapscript/python/CMakeLists.txt
@@ -44,8 +44,6 @@ swig_link_libraries(pythonmapscript ${PYTHON_LIBRARIES} ${MAPSERVER_LIBMAPSERVER
 set_target_properties(${SWIG_MODULE_pythonmapscript_REAL_NAME} PROPERTIES PREFIX "")
 set_target_properties(${SWIG_MODULE_pythonmapscript_REAL_NAME} PROPERTIES OUTPUT_NAME _mapscript)
 
-execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(True))" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
-
 set(SETUP_PY_IN "${PROJECT_SOURCE_DIR}/mapscript/python/setup.py.in")
 set(SETUP_PY_TEMP "${CMAKE_CURRENT_BINARY_DIR}/setup.py.temp")
 
@@ -139,38 +137,26 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/mapscript/python/examples" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/examples
 )
 
-# set(mapscript_files $<TARGET_FILE:${SWIG_MODULE_pythonmapscript_REAL_NAME}> $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/mapscript.py)
-# install(FILES ${mapscript_files} DESTINATION ${PYTHON_SITE_PACKAGES})
-
-
-    
 install(  
   CODE "
-  
-  if(DEFINED ENV{DESTDIR})
-    SET(PYTHON_ROOT \$ENV{DESTDIR}\)
-  else()
-    SET(PYTHON_ROOT \"${PYTHON_SITE_PACKAGES}\")
-  endif()
+    if(DEFINED ENV{DESTDIR})
+      SET(PYTHON_ROOT \"--root=\$ENV{DESTDIR}\")
+      SET(ENV{PYTHONPATH} \$ENV{DESTDIR}:\$ENV{PYTHONPATH})
+    endif()
 
-  if(DEFINED CMAKE_INSTALL_PREFIX)
-    SET(PYTHON_INSTALL_LIB \${CMAKE_INSTALL_PREFIX})
-  else()
-    SET(PYTHON_INSTALL_LIB \${PYTHON_SITE_PACKAGES}\)
-  endif()
+    if(DEFINED CMAKE_INSTALL_PREFIX)
+      SET(PYTHON_INSTALL_LIB \"--install-lib=\${CMAKE_INSTALL_PREFIX}\")
+      SET(ENV{PYTHONPATH} \${CMAKE_INSTALL_PREFIX}:\$ENV{PYTHONPATH})
+    endif()
 
-  if(NOT WIN32)
-    SET(ENV{PYTHONPATH} \${PYTHON_ROOT}:\$ENV{PYTHONPATH})
-  endif()
-
-  execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} setup.py install --root=\${PYTHON_ROOT} --install-lib=\${PYTHON_INSTALL_LIB}
-    WORKING_DIRECTORY ${OUTPUT_FOLDER}
-  )
-")
+    execute_process(
+      COMMAND ${PYTHON_EXECUTABLE} setup.py install \${PYTHON_ROOT} \${PYTHON_INSTALL_LIB}
+      WORKING_DIRECTORY ${OUTPUT_FOLDER}
+    )
+  "
+)
 
 message(STATUS "CMake Version: ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}")
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Python MapScript output directory: ${OUTPUT_FOLDER}")
 message(STATUS "Python Executable: ${PYTHON_EXECUTABLE}")
-message(STATUS "Python Site Packages: ${PYTHON_SITE_PACKAGES}")

--- a/mapscript/python/CMakeLists.txt
+++ b/mapscript/python/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(SWIG REQUIRED)
 include(${SWIG_USE_FILE})
 find_package(PythonInterp)
+find_python_module(setuptools REQUIRED)
 
 # Python library/header finding doesn't seem to honor the python
 # interpreter that was found beforehand, and defaults to the system

--- a/mapscript/python/CMakeLists.txt
+++ b/mapscript/python/CMakeLists.txt
@@ -55,6 +55,7 @@ file(READ ${SETUP_PY_TEMP} SETUP_CONTENT)
 
 file(GENERATE OUTPUT $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/setup.py INPUT ${SETUP_PY_TEMP})
 
+# following not needed?
 set(BUILD_TIMESTAMP "${CMAKE_CURRENT_BINARY_DIR}/build/timestamp")
 set(TESTS_FOLDER ${PROJECT_SOURCE_DIR}/mapscript/python/tests/cases)
 
@@ -108,17 +109,9 @@ add_custom_command(
     DEPENDS mapscriptlinting.stamp
     OUTPUT mapscriptwheel.stamp
     WORKING_DIRECTORY ${OUTPUT_FOLDER}
-    COMMENT "Copying files required to build Mapscript"
-    COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/mapscript/python/mapscript/__init__.py" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/__init__.py
-    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/mapscript.py" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/mapscript.py
-    COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${SWIG_MODULE_pythonmapscript_REAL_NAME}>" "$<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/$<TARGET_FILE_NAME:${SWIG_MODULE_pythonmapscript_REAL_NAME}>"
-    COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/mapscript/python/README.rst" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/README.rst
-    COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/mapscript/python/tests/cases" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/tests
     # now check the Python test code with flake8
     COMMENT "Linting test code files"
     COMMAND ${PYTHON_VENV_SCRIPTS}/flake8 $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/tests --max-line-length=120
-    COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/tests" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/tests/data
-    COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/mapscript/python/examples" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/examples
     COMMENT "Building the mapscript Python wheel"
     COMMAND ${PYTHON_VENV_SCRIPTS}/python setup.py bdist_wheel
 )
@@ -131,8 +124,29 @@ add_custom_command(
     COMMAND ${PYTHON_VENV_SCRIPTS}/pytest --pyargs mapscript.tests
 )
 
-set(mapscript_files $<TARGET_FILE:${SWIG_MODULE_pythonmapscript_REAL_NAME}> $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/mapscript.py)
-install(FILES ${mapscript_files} DESTINATION ${PYTHON_SITE_PACKAGES})
+add_custom_command(
+  TARGET _pythonmapscript
+  WORKING_DIRECTORY ${OUTPUT_FOLDER}
+  POST_BUILD
+  COMMENT "Copying files required to build Mapscript"
+  COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/mapscript/python/mapscript/__init__.py" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/__init__.py
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/mapscript.py" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/mapscript.py
+  COMMAND ${CMAKE_COMMAND} -E copy "$<TARGET_FILE:${SWIG_MODULE_pythonmapscript_REAL_NAME}>" "$<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/$<TARGET_FILE_NAME:${SWIG_MODULE_pythonmapscript_REAL_NAME}>"
+  COMMAND ${CMAKE_COMMAND} -E copy "${PROJECT_SOURCE_DIR}/mapscript/python/README.rst" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/README.rst
+  COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/mapscript/python/tests/cases" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/tests
+  COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/tests" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/tests/data
+  COMMAND ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/mapscript/python/examples" $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/examples
+)
+
+# set(mapscript_files $<TARGET_FILE:${SWIG_MODULE_pythonmapscript_REAL_NAME}> $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/mapscript.py)
+# install(FILES ${mapscript_files} DESTINATION ${PYTHON_SITE_PACKAGES})
+
+install(CODE "
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} setup.py install
+    WORKING_DIRECTORY ${OUTPUT_FOLDER}
+  )
+")
 
 message(STATUS "CMake version: ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}")
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")

--- a/mapscript/python/CMakeLists.txt
+++ b/mapscript/python/CMakeLists.txt
@@ -7,8 +7,10 @@ find_python_module(setuptools REQUIRED)
 # interpreter that was found beforehand, and defaults to the system
 # python. We first try to find python.h and libpython.so ourselves
 # from the hints given by distutils and sys
-execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_inc; print(get_python_inc(True))" OUTPUT_VARIABLE PYTHON_INC OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "import sys; print(sys.prefix)" OUTPUT_VARIABLE PYTHON_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_inc; print(get_python_inc(True))" OUTPUT_VARIABLE PYTHON_INC OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "import sys; print(sys.prefix)" OUTPUT_VARIABLE PYTHON_PREFIX OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process (COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(True))" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 find_path(PYTHON_INCLUDE_PATH Python.h
   HINTS ${PYTHON_INC}
@@ -139,18 +141,19 @@ add_custom_command(
 
 install(  
   CODE "
+  
+    SET(ENV{PYTHONPATH} \${PYTHON_SITE_PACKAGES}:\$ENV{PYTHONPATH})
+      
     if(DEFINED ENV{DESTDIR})
       SET(PYTHON_ROOT \"--root=\$ENV{DESTDIR}\")
-      SET(ENV{PYTHONPATH} \$ENV{DESTDIR}:\$ENV{PYTHONPATH})
     endif()
-
+  
     if(DEFINED CMAKE_INSTALL_PREFIX)
-      SET(PYTHON_INSTALL_LIB \"--install-lib=\${CMAKE_INSTALL_PREFIX}\")
-      SET(ENV{PYTHONPATH} \${CMAKE_INSTALL_PREFIX}:\$ENV{PYTHONPATH})
+      SET(PYTHON_PREFIX \"--prefix=\${CMAKE_INSTALL_PREFIX}\")
     endif()
 
     execute_process(
-      COMMAND ${PYTHON_EXECUTABLE} setup.py install \${PYTHON_ROOT} \${PYTHON_INSTALL_LIB}
+      COMMAND ${PYTHON_EXECUTABLE} setup.py install \${PYTHON_ROOT} \${PYTHON_PREFIX}
       WORKING_DIRECTORY ${OUTPUT_FOLDER}
     )
   "
@@ -160,3 +163,4 @@ message(STATUS "CMake Version: ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}")
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Python MapScript output directory: ${OUTPUT_FOLDER}")
 message(STATUS "Python Executable: ${PYTHON_EXECUTABLE}")
+message(STATUS "Python site packages: ${PYTHON_SITE_PACKAGES}")

--- a/mapscript/python/CMakeLists.txt
+++ b/mapscript/python/CMakeLists.txt
@@ -144,7 +144,7 @@ add_custom_command(
 
 install(CODE "
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} setup.py install
+    COMMAND ${PYTHON_EXECUTABLE} setup.py install --root=${PYTHON_SITE_PACKAGES} 
     WORKING_DIRECTORY ${OUTPUT_FOLDER}
   )
 ")

--- a/mapscript/python/CMakeLists.txt
+++ b/mapscript/python/CMakeLists.txt
@@ -142,15 +142,35 @@ add_custom_command(
 # set(mapscript_files $<TARGET_FILE:${SWIG_MODULE_pythonmapscript_REAL_NAME}> $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/mapscript.py)
 # install(FILES ${mapscript_files} DESTINATION ${PYTHON_SITE_PACKAGES})
 
-install(CODE "
+
+    
+install(  
+  CODE "
+  
+  if(DEFINED ENV{DESTDIR})
+    SET(PYTHON_ROOT \$ENV{DESTDIR}\)
+  else()
+    SET(PYTHON_ROOT \"${PYTHON_SITE_PACKAGES}\")
+  endif()
+
+  if(DEFINED CMAKE_INSTALL_PREFIX)
+    SET(PYTHON_INSTALL_LIB \${CMAKE_INSTALL_PREFIX})
+  else()
+    SET(PYTHON_INSTALL_LIB \${PYTHON_SITE_PACKAGES}\)
+  endif()
+
+  if(NOT WIN32)
+    SET(ENV{PYTHONPATH} \${PYTHON_ROOT}:\$ENV{PYTHONPATH})
+  endif()
+
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} setup.py install --root=${PYTHON_SITE_PACKAGES} 
+    COMMAND ${PYTHON_EXECUTABLE} setup.py install --root=\${PYTHON_ROOT} --install-lib=\${PYTHON_INSTALL_LIB}
     WORKING_DIRECTORY ${OUTPUT_FOLDER}
   )
 ")
 
-message(STATUS "CMake version: ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}")
-message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
+message(STATUS "CMake Version: ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}")
+message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Python MapScript output directory: ${OUTPUT_FOLDER}")
-message(STATUS "Python executable: ${PYTHON_EXECUTABLE}")
-message(STATUS "Python site packages: ${PYTHON_SITE_PACKAGES}")
+message(STATUS "Python Executable: ${PYTHON_EXECUTABLE}")
+message(STATUS "Python Site Packages: ${PYTHON_SITE_PACKAGES}")

--- a/mapscript/python/README.rst
+++ b/mapscript/python/README.rst
@@ -2,7 +2,7 @@ Python MapScript for MapServer 7.2.1 README
 ===========================================
 
 :Author: MapServer Team
-:Last Updated: 2018-10-12
+:Last Updated: 2018-11-28
 
 Introduction
 ------------
@@ -51,8 +51,8 @@ running correctly.
 ..
     py3 SWIG flag adds type annotations
 
-Installation
-------------
+Installation on Windows
+-----------------------
 
 To use mapscript you will need to add the MapServer binaries to your system path. 
 On Windows you can use the following, replacing ``C:\MapServer\bin`` with the location of your MapServer binaries. 
@@ -61,11 +61,11 @@ On Windows you can use the following, replacing ``C:\MapServer\bin`` with the lo
 
     SET PATH=C:\MapServer\bin;%PATH%
 
-Windows binary packages can be downloaded from `GIS Internals <https://www.gisinternals.com/stable.php>`. 
+Windows binary packages can be downloaded from `GIS Internals <https://www.gisinternals.com/stable.php>`_. 
 To ensure compatibility with the wheels, please use identical release packages, e.g. ``release-1911-x64-gdal-2-3-mapserver-7-2``
 for mapscript 7.2. 
 
-When using these packages the MapServer path will be similar to `C:\release-1911-x64-gdal-2-3-mapserver-7-2\bin`. 
+When using these packages the MapServer path will be similar to ``C:\release-1911-x64-gdal-2-3-mapserver-7-2\bin``. 
 
 Prior to installing mapscript it is recommended to update pip to the latest version with the following command:
 
@@ -106,6 +106,40 @@ If your version of mapscript does not match your version of MapServer you may in
     ImportError: DLL load failed: The specified module could not be found.
     ImportError: DLL load failed: The specified procedure could not be found.
 
+Installation on Unix
+--------------------
+
+For Unix users there are two approaches to installing mapscript. The first is to install the ``python-mapscript`` package using a package manager. For example on
+Ubuntu the following command can be used:
+
+.. code-block:: bat
+
+    sudo apt-get install python-mapscript
+
+The second approach is to build and install the Python mapscript module from source. Full details on compiling MapServer from source are detailed on the
+`Compiling on Unix <https://www.mapserver.org/installation/unix.html>`_ page. To make sure Python mapscript is built alongside MapServer the following flag needs to be set:
+
+.. code-block:: bat
+
+    -DWITH_PYTHON=ON
+
+To configure the path of the mapscript installation location ``-DCMAKE_INSTALL_PREFIX`` can be set, e.g. 
+
+.. code-block:: bat
+
+    sudo cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+
+When installing the `DESTDIR <https://cmake.org/cmake/help/latest/envvar/DESTDIR.html>`_ variable can be set (note ``DESTDIR`` is not used on Windows)
+to install mapscript to a non-default location. E.g.
+
+.. code-block:: bat
+
+    make install DESTDIR=/tmp
+
+In summary the ``install`` target runs the ``setup.py install`` command using custom paths (when set) similar to below:
+
+    python setup.py install --root=${DESTDIR} --prefix={CMAKE_INSTALL_PREFIX}
+
 Quickstart
 ----------
 
@@ -118,19 +152,19 @@ To open an existing Mapfile:
 
     >>> import mapscript
     >>> test_map = mapscript.mapObj(r"C:\Maps\mymap.map")
-    >>> e = test_map.extent
+    >>> extent = test_map.extent
 
 Create a layer from a string:
 
 .. code-block:: python
 
     >>> import mapscript
-    >>> lo = mapscript.fromstring("""LAYER NAME "test" TYPE POINT END""")
-    >>> lo
+    >>> layer = mapscript.fromstring("""LAYER NAME "test" TYPE POINT END""")
+    >>> layer
     <mapscript.layerObj; proxy of C layerObj instance at ...>
-    >>> lo.name
+    >>> layer.name
     'test'
-    >>> lo.type == mapscript.MS_LAYER_POINT
+    >>> layer.type == mapscript.MS_LAYER_POINT
     True
 
 Building the Mapscript Module
@@ -139,14 +173,14 @@ Building the Mapscript Module
 The mapscript module is built as part of the MapServer CMake build process. This is configured using the ``mapserver/mapscript/CMakeLists.txt`` file. 
 
 Before the switch to CMake MapServer mapscript was built using distutils and ``setup.py``. Now the ``setup.py.in`` file is used as a template that
-is filled with the MapServer version number and used to created wheel files for distribution. 
+is filled with the MapServer version number and used to created wheel files for distribution, or install mapscript directly on the build machine.  
 
 The build process works as follows. 
 
 + CMake runs SWIG. This uses the SWIG interface files to create a ``mapscriptPYTHON_wrap.c`` file, 
   and a ``mapscript.py`` file containing the Python wrapper to the mapscript binary module. 
 + CMake then uses the appropriate compiler on the system to compile the ``mapscriptPYTHON_wrap.c`` file into a Python binary module -
-  ``_mapscript.pyd`` file on Windows, and a ``_mapscript.so`` file on Windows. 
+  ``_mapscript.pyd`` file on Windows, and a ``_mapscript.so`` file on Unix. 
 
 ``CMakeLists.txt`` is configured with a ``pythonmapscript-wheel`` target that copies all the required files to the output build folder where they are then packaged
 into a Python wheel. The wheel can be built using the following command:


### PR DESCRIPTION
This pull request modifies how the `make install` command install the Python MapScript bindings. Currently CMake simply copies the _mapscript.so and mapscript.py files to `/usr/local/lib/python2.7/dist-packages/`

This update uses CMake to run `python setup.py install` if `make install` is run. This creates installation metadata and copies it to `/usr/local/lib/python2.7/dist-packages/mapscript-7.3.0-py2.7-linux-x86_64.egg/`

This should allow other applications that rely on MapScript to check if the dependency is already installed, and to allow MapScript to be listed and uninstalled using pip. It hopefully also helps with packaging Python MapScript in the future and addresses #5140. 

The new MapScript installation also includes the tests and examples within the MapScript module - the same as provided in the Python Wheels. 

An additional change is made to avoid `make install` rebuilding the Python MapScript module (see #5708), although it still needs to be reviewed to see if this causes issues with the PHPNG MapScript module. 