### PR TITLE
Fix Python MapScript Rebuilding

### DIFF
--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -30,10 +30,10 @@
 ============================================================================
 */
 
-#ifdef SWIGPHP
-%module mapscriptng
-#else
+#ifndef SWIGPHPNG
 %module mapscript
+#else
+%module mapscriptng
 #endif
 
 #ifdef SWIGCSHARP


### PR DESCRIPTION
Prevent Python mapscript from rebuilding every time due to possible CMake/SWIG bug. See #5708 