### PR TITLE
mapscript_csharp compilable on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ nbproject
 tags
 tests/map.png
 .vagrant
-
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ before_install:
   - sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
   - sudo apt-get update
   - sudo apt-get install --allow-unauthenticated protobuf-c-compiler libprotobuf-c0-dev bison flex python-lxml libfribidi-dev swig cmake librsvg2-dev colordiff libpq-dev libpng12-dev libjpeg-dev libgif-dev libgeos-dev libgd2-xpm-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal1-dev libproj-dev libxml2-dev python-dev libexempi-dev lcov lftp postgis libharfbuzz-dev gdal-bin
+  - sudo apt-get install --allow-unauthenticated libmono-system-drawing4.0-cil mono-mcs
   - sudo apt-get install --allow-unauthenticated php5-dev || sudo apt-get install --allow-unauthenticated php7-dev
   - sudo pip install git+git://github.com/tbonfort/cpp-coveralls.git@extensions
   - cd msautotest

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,13 @@ AUTOTEST_OPTS=-strict -q
 PHP_MAPSCRIPT=build/mapscript/php/php_mapscript.so
 PYTHON_MAPSCRIPT_PATH=build/mapscript/python
 JAVA_MAPSCRIPT_PATH=build/mapscript/java
+CSHARP_MAPSCRIPT_PATH=build/mapscript/csharp
 BUILDPATH=../../build
 FLEX=flex
 YACC=yacc
 CMAKEFLAGS=-DCMAKE_C_FLAGS="--coverage" -DCMAKE_CXX_FLAGS="--coverage" \
 			  -DCMAKE_SHARED_LINKER_FLAGS="-lgcov" -DWITH_CLIENT_WMS=1 \
-			  -DWITH_CLIENT_WFS=1 -DWITH_KML=1 -DWITH_SOS=1 -DWITH_PHP=1 \
+			  -DWITH_CLIENT_WFS=1 -DWITH_KML=1 -DWITH_SOS=1 -DWITH_CSHARP=1 -DWITH_PHP=1 \
 			  -DWITH_PYTHON=1 -DWITH_JAVA=1 -DWITH_THREAD_SAFETY=1 -DWITH_FRIBIDI=1 -DWITH_FCGI=0 -DWITH_EXEMPI=1 \
 			  -DCMAKE_BUILD_TYPE=Release -DWITH_RSVG=1 -DWITH_CURL=1 -DWITH_HARFBUZZ=1 -DWITH_POINT_Z_M=1
 all: cmakebuild
@@ -46,10 +47,14 @@ php-testcase:
 java-testcase:
 	test -d "$(JAVA_MAPSCRIPT_PATH)" && (export JAVA_MAPSCRIPT_SO="../../$(JAVA_MAPSCRIPT_PATH)" && cd mapscript/java && ./run_test.sh)
 
+csharp-testcase:
+	test -d "$(CSHARP_MAPSCRIPT_PATH)" && (export CSHARP_MAPSCRIPT_SO="../../$(CSHARP_MAPSCRIPT_PATH)" && cd mapscript/csharp && ./run_test.sh)
+
 test:  cmakebuild
 	@$(MAKE) $(MFLAGS)	wxs-testcase renderers-testcase misc-testcase gdal-testcase query-testcase mspython-testcase
 	@./print-test-results.sh
 	@$(MAKE) $(MFLAGS)	php-testcase
+	@$(MAKE) $(MFLAGS)	csharp-testcase
 
 
 lexer: maplexer.c

--- a/mapscript/csharp/CMakeLists.txt
+++ b/mapscript/csharp/CMakeLists.txt
@@ -1,7 +1,7 @@
 FIND_PACKAGE(SWIG REQUIRED)
 INCLUDE(${SWIG_USE_FILE})
 
-FIND_PROGRAM (CSHARP_COMPILER NAMES csc gmcs gmcs2)
+FIND_PROGRAM (CSHARP_COMPILER NAMES csc mcs gmcs gmcs2)
 
 IF (CSHARP_COMPILER)
 	MESSAGE(STATUS "Found CSharp compiler: ${CSHARP_COMPILER}")
@@ -25,6 +25,8 @@ if (WIN32)
   if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo") 
       set(PLATFORM_TARGET ${PLATFORM_TARGET} /debug:full)
   endif (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+else()
+	set (KEYFILE_SPEC -keyfile:${PROJECT_SOURCE_DIR}/mapscript/csharp/mapscript.snk)
 endif(WIN32)
 
 MARK_AS_ADVANCED(CSHARP_COMPILER)
@@ -33,15 +35,24 @@ include_directories(${PROJECT_SOURCE_DIR}/mapscript/swiginc)
 include_directories(${PROJECT_SOURCE_DIR}/mapscript/)
 include_directories(${PROJECT_SOURCE_DIR}/mapscript/csharp)
 SET (CMAKE_SWIG_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}")
-SET( CMAKE_SWIG_FLAGS -namespace OSGeo.MapServer ${MAPSERVER_COMPILE_DEFINITIONS} -DWIN32)
-SWIG_ADD_MODULE(mapscript csharp ../mapscript.i)
+SET( CMAKE_SWIG_FLAGS -namespace OSGeo.MapServer ${MAPSERVER_COMPILE_DEFINITIONS})
+if (${CMAKE_VERSION} VERSION_LESS "3.8.0")
+	SWIG_ADD_MODULE(mapscript csharp ../mapscript.i)
+else()
+	SWIG_ADD_LIBRARY(mapscript LANGUAGE csharp SOURCES ../mapscript.i)
+endif()
+
 
 set_target_properties(mapscript PROPERTIES OUTPUT_NAME "mapscript")
 
 SWIG_LINK_LIBRARIES(mapscript ${MAPSERVER_LIBMAPSERVER})
 
 
-ADD_CUSTOM_COMMAND(TARGET mapscript
+
+
+if (WIN32)
+
+	ADD_CUSTOM_COMMAND(TARGET mapscript
                       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                       POST_BUILD
 					  COMMAND set MAPSCRIPT_SNK=${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\mapscript.snk          
@@ -61,5 +72,29 @@ ADD_CUSTOM_COMMAND(TARGET mapscript
 					  #COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /lib:C:\Windows\Microsoft.NET\Framework\v4.0.30319\WPF /r:mapscript_csharp.dll /r:System.Xaml.dll /r:WindowsBase.dll /r:PresentationCore.dll /out:drawmapWPF.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapWPF.cs
                       COMMENT "Compiling c# source files"
                       )
+else()
+	ADD_CUSTOM_COMMAND(TARGET mapscript
+			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+			POST_BUILD
+			#COMMAND set MAPSCRIPT_SNK=${PROJECT_SOURCE_DIR}/mapscript/csharp/mapscript.snk
+			#COMMAND set MAPSCRIPT_SNK=%MAPSCRIPT_SNK:/=\\%
+			COMMAND cp -f ${PROJECT_SOURCE_DIR}/mapscript/csharp/mapscript.snk ./
+			COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -target:library -out:mapscript_csharp.dll ${KEYFILE_SPEC} *.cs ${PROJECT_SOURCE_DIR}/mapscript/csharp/config/AssemblyInfo.cs
+			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:shpdump.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\shpdump.cs
+			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:drawmap.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmap.cs
+			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:shapeinfo.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\shapeinfo.cs
+			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:drawquery.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawquery.cs
+			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:getbytes.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\getbytes.cs
+			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:HTMLtemplate.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\HTMLtemplate.cs
+			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:RFC24.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\RFC24.cs
+			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:drawmapDirect.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapDirect.cs
+			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:drawmapDirectPrint.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapDirectPrint.cs
+			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:drawmapGDIPlus.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapGDIPlus.cs
+			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /lib:C:\Windows\Microsoft.NET\Framework\v4.0.30319\WPF /r:mapscript_csharp.dll /r:System.Xaml.dll /r:WindowsBase.dll /r:PresentationCore.dll /out:drawmapWPF.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapWPF.cs
+			COMMENT "Compiling c# source files"
+			)
+endif()
 
+#get_target_property(LOC_MAPSCRIPT_LIB ${SWIG_MODULE_csharpmapscript_REAL_NAME} LOCATION)
+#install(FILES ${LOC_MAPSCRIPT_LIB} DESTINATION lib)
 

--- a/mapscript/csharp/CMakeLists.txt
+++ b/mapscript/csharp/CMakeLists.txt
@@ -53,48 +53,44 @@ SWIG_LINK_LIBRARIES(mapscript ${MAPSERVER_LIBMAPSERVER})
 if (WIN32)
 
 	ADD_CUSTOM_COMMAND(TARGET mapscript
-                      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                      POST_BUILD
-					  COMMAND set MAPSCRIPT_SNK=${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\mapscript.snk          
-					  COMMAND set MAPSCRIPT_SNK=%MAPSCRIPT_SNK:/=\\%          
-					  COMMAND copy /Y \"%MAPSCRIPT_SNK%\"
-					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /t:library /out:mapscript_csharp.dll ${KEYFILE_SPEC} *.cs ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\config\\AssemblyInfo.cs
-					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:shpdump.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\shpdump.cs
-					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:drawmap.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmap.cs
-					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:shapeinfo.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\shapeinfo.cs
-					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:drawquery.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawquery.cs
-					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:getbytes.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\getbytes.cs
-					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:HTMLtemplate.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\HTMLtemplate.cs
-					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:RFC24.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\RFC24.cs
-					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:drawmapDirect.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapDirect.cs
-					  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:drawmapDirectPrint.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapDirectPrint.cs
-                      COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:drawmapGDIPlus.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapGDIPlus.cs
-					  #COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /lib:C:\Windows\Microsoft.NET\Framework\v4.0.30319\WPF /r:mapscript_csharp.dll /r:System.Xaml.dll /r:WindowsBase.dll /r:PresentationCore.dll /out:drawmapWPF.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapWPF.cs
-                      COMMENT "Compiling c# source files"
-                      )
+						  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+						  POST_BUILD
+						  COMMAND set MAPSCRIPT_SNK=${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\mapscript.snk
+						  COMMAND set MAPSCRIPT_SNK=%MAPSCRIPT_SNK:/=\\%
+						  COMMAND copy /Y \"%MAPSCRIPT_SNK%\"
+						  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /t:library /out:mapscript_csharp.dll ${KEYFILE_SPEC} *.cs ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\config\\AssemblyInfo.cs
+						  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:shpdump.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\shpdump.cs
+						  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:drawmap.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmap.cs
+						  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:shapeinfo.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\shapeinfo.cs
+						  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:drawquery.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawquery.cs
+						  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:getbytes.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\getbytes.cs
+						  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:HTMLtemplate.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\HTMLtemplate.cs
+						  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:RFC24.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\RFC24.cs
+						  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:drawmapDirect.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapDirect.cs
+						  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:drawmapDirectPrint.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapDirectPrint.cs
+						  COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:drawmapGDIPlus.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapGDIPlus.cs
+						  #COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /lib:C:\Windows\Microsoft.NET\Framework\v4.0.30319\WPF /r:mapscript_csharp.dll /r:System.Xaml.dll /r:WindowsBase.dll /r:PresentationCore.dll /out:drawmapWPF.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapWPF.cs
+						  COMMENT "Compiling c# source files"
+						  )
 else()
 	ADD_CUSTOM_COMMAND(TARGET mapscript
-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-			POST_BUILD
-			#COMMAND set MAPSCRIPT_SNK=${PROJECT_SOURCE_DIR}/mapscript/csharp/mapscript.snk
-			#COMMAND set MAPSCRIPT_SNK=%MAPSCRIPT_SNK:/=\\%
-			COMMAND cp -f ${PROJECT_SOURCE_DIR}/mapscript/csharp/mapscript.snk ./
-			COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -target:library -out:mapscript_csharp.dll ${KEYFILE_SPEC} *.cs ${PROJECT_SOURCE_DIR}/mapscript/csharp/config/AssemblyInfo.cs
-			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:shpdump.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\shpdump.cs
-			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:drawmap.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmap.cs
-			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:shapeinfo.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\shapeinfo.cs
-			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:drawquery.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawquery.cs
-			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:getbytes.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\getbytes.cs
-			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:HTMLtemplate.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\HTMLtemplate.cs
-			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /out:RFC24.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\RFC24.cs
-			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:drawmapDirect.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapDirect.cs
-			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:drawmapDirectPrint.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapDirectPrint.cs
-			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /r:mapscript_csharp.dll /r:System.Drawing.dll /out:drawmapGDIPlus.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapGDIPlus.cs
-			#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /lib:C:\Windows\Microsoft.NET\Framework\v4.0.30319\WPF /r:mapscript_csharp.dll /r:System.Xaml.dll /r:WindowsBase.dll /r:PresentationCore.dll /out:drawmapWPF.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapWPF.cs
-			COMMENT "Compiling c# source files"
-			)
+						WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+						POST_BUILD
+						COMMAND cp -f ${PROJECT_SOURCE_DIR}/mapscript/csharp/mapscript.snk ./
+						COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -target:library -out:mapscript_csharp.dll ${KEYFILE_SPEC} *.cs ${PROJECT_SOURCE_DIR}/mapscript/csharp/config/AssemblyInfo.cs
+						COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -reference:mapscript_csharp.dll -out:shpdump.exe ${PROJECT_SOURCE_DIR}/mapscript/csharp/examples/shpdump.cs
+						COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -reference:mapscript_csharp.dll -out:drawmap.exe ${PROJECT_SOURCE_DIR}/mapscript/csharp/examples/drawmap.cs
+						COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -reference:mapscript_csharp.dll -out:shapeinfo.exe ${PROJECT_SOURCE_DIR}/mapscript/csharp/examples/shapeinfo.cs
+						COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -reference:mapscript_csharp.dll -out:drawquery.exe ${PROJECT_SOURCE_DIR}/mapscript/csharp/examples/drawquery.cs
+						COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -reference:mapscript_csharp.dll -reference:System.Drawing.dll -out:getbytes.exe ${PROJECT_SOURCE_DIR}/mapscript/csharp/examples/getbytes.cs
+						COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -reference:mapscript_csharp.dll -out:HTMLtemplate.exe ${PROJECT_SOURCE_DIR}/mapscript/csharp/examples/HTMLtemplate.cs
+						COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -reference:mapscript_csharp.dll -out:RFC24.exe ${PROJECT_SOURCE_DIR}/mapscript/csharp/examples/RFC24.cs
+						COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -reference:mapscript_csharp.dll -reference:System.Drawing.dll -out:drawmapDirect.exe ${PROJECT_SOURCE_DIR}/mapscript/csharp/examples/drawmapDirect.cs
+						COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -reference:mapscript_csharp.dll -reference:System.Drawing.dll -out:drawmapDirectPrint.exe ${PROJECT_SOURCE_DIR}/mapscript/csharp/examples/drawmapDirectPrint.cs
+						COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} -reference:mapscript_csharp.dll -reference:System.Drawing.dll -out:drawmapGDIPlus.exe ${PROJECT_SOURCE_DIR}/mapscript/csharp/examples/drawmapGDIPlus.cs
+						#COMMAND ${CSHARP_COMPILER} ${PLATFORM_TARGET} /lib:C:\Windows\Microsoft.NET\Framework\v4.0.30319\WPF /r:mapscript_csharp.dll /r:System.Xaml.dll /r:WindowsBase.dll /r:PresentationCore.dll /out:drawmapWPF.exe ${PROJECT_SOURCE_DIR}\\mapscript\\csharp\\examples\\drawmapWPF.cs
+						COMMENT "Compiling c# source files"
+						)
 endif()
 
-#get_target_property(LOC_MAPSCRIPT_LIB ${SWIG_MODULE_csharpmapscript_REAL_NAME} LOCATION)
-#install(FILES ${LOC_MAPSCRIPT_LIB} DESTINATION lib)
 

--- a/mapscript/csharp/CMakeLists.txt
+++ b/mapscript/csharp/CMakeLists.txt
@@ -42,8 +42,11 @@ else()
 	SWIG_ADD_LIBRARY(mapscript LANGUAGE csharp SOURCES ../mapscript.i)
 endif()
 
-
-set_target_properties(mapscript PROPERTIES OUTPUT_NAME "mapscript")
+if (WIN32)
+	set_target_properties(mapscript PROPERTIES OUTPUT_NAME "mapscript")
+else()
+	set_target_properties(mapscript PROPERTIES OUTPUT_NAME "libmapscript")
+endif()
 
 SWIG_LINK_LIBRARIES(mapscript ${MAPSERVER_LIBMAPSERVER})
 

--- a/mapscript/csharp/csmodule.i
+++ b/mapscript/csharp/csmodule.i
@@ -126,7 +126,7 @@ inner exceptions. Otherwise the exception message will be concatenated*/
  *****************************************************************************/
  
 %pragma(csharp) imclasscode=%{
-  public class StringArrayMarshal : System.IDisposable {
+public class StringArrayMarshal : global::System.IDisposable {
     public readonly System.IntPtr[] _ar;
     public StringArrayMarshal(string[] ar) {
       _ar = new System.IntPtr[ar.Length];
@@ -208,8 +208,8 @@ inner exceptions. Otherwise the exception message will be concatenated*/
 
 %typemap(csvarout, excode=SWIGEXCODE2) outputFormatObj** %{
     get {
-	  System.IntPtr cPtr = $imcall;
-	  System.IntPtr objPtr;
+      System.IntPtr cPtr = $imcall;
+      System.IntPtr objPtr;
       outputFormatObj[] ret = new outputFormatObj[this.numoutputformats];
       for(int cx = 0; cx < this.numoutputformats; cx++) {
           objPtr = System.Runtime.InteropServices.Marshal.ReadIntPtr(cPtr, cx * System.Runtime.InteropServices.Marshal.SizeOf(typeof(System.IntPtr)));
@@ -313,7 +313,7 @@ static SWIG_CSharpByteArrayHelperCallback SWIG_csharp_bytearray_callback = NULL;
 %csmethodmodifiers processLegendTemplate "private";
 %csmethodmodifiers processQueryTemplate "private";
 
-%typemap(csinterfaces) mapObj "System.IDisposable, System.Runtime.Serialization.ISerializable"; 
+%typemap(csinterfaces) mapObj "System.IDisposable, System.Runtime.Serialization.ISerializable";
 %typemap(csattributes) mapObj  "[Serializable]"
 %typemap(cscode) mapObj, struct mapObj %{  
   public string processTemplate(int bGenerateImages, string[] names, string[] values)
@@ -393,7 +393,7 @@ static SWIG_CSharpByteArrayHelperCallback SWIG_csharp_bytearray_callback = NULL;
 		}
 	}
 	protected static SWIGByteArrayHelper bytearrayHelper = new SWIGByteArrayHelper();
-	[System.ThreadStatic] 
+	[System.ThreadStatic]
 	private static byte[] arraybuffer;
 
 	internal static byte[] GetBytes()
@@ -424,7 +424,7 @@ DllExport void SWIGSTDCALL SWIGRegisterByteArrayCallback_$module(SWIG_CSharpByte
 %typemap(csin) (double pattern[ANY]) "$csinput"
 %typemap(csvarout, excode=SWIGEXCODE2) (double pattern[ANY]) %{
     get {
-        System.IntPtr cPtr = $imcall;
+      System.IntPtr cPtr = $imcall;
       double[] ret = new double[patternlength];
       if (patternlength > 0) {       
 	        System.Runtime.InteropServices.Marshal.Copy(cPtr, ret, 0, patternlength);
@@ -433,7 +433,7 @@ DllExport void SWIGSTDCALL SWIGRegisterByteArrayCallback_$module(SWIG_CSharpByte
       return ret;
     } 
     set {
-        System.IntPtr cPtr = $imcall;
+      System.IntPtr cPtr = $imcall;
       if (value.Length > 0) {       
 	        System.Runtime.InteropServices.Marshal.Copy(value, 0, cPtr, value.Length);
       }
@@ -450,8 +450,8 @@ DllExport void SWIGSTDCALL SWIGRegisterByteArrayCallback_$module(SWIG_CSharpByte
 %typemap(csin) (int *panIndexes)  "$csinput"
 
 /* Typemaps for device handle */
-%typemap(imtype) (void* device)  %{ System.IntPtr%}
-%typemap(cstype) (void* device) %{ System.IntPtr%}
+%typemap(imtype) (void* device)  %{System.IntPtr%}
+%typemap(cstype) (void* device) %{System.IntPtr%}
 %typemap(in) (void* device) %{ $1 = ($1_ltype)$input; %}
 %typemap(csin) (void* device)  "$csinput"
 

--- a/mapscript/csharp/run_test.sh
+++ b/mapscript/csharp/run_test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -ex
+cd ${CSHARP_MAPSCRIPT_SO}
+echo .: Testing shpdump.exe :.
+mono shpdump.exe ../../../tests/point.shp
+echo .: Testing drawmap.exe :.
+mono drawmap.exe ../../../tests/test.map ./map.png
+echo .: Testing shapeinfo.exe :.
+mono shapeinfo.exe ../../../tests/point.shp
+echo .: Testing getbytes.exe :.
+mono getbytes.exe ../../../tests/test.map test_csharp2.png
+echo .: Testing RFC24.exe :.
+mono RFC24.exe ../../../tests/test.map

--- a/mapscript/csharp/swig_csharp_extensions.i
+++ b/mapscript/csharp/swig_csharp_extensions.i
@@ -31,8 +31,6 @@
 
 // Ensure the class is not marked BeforeFieldInit causing memory corruption with CLR4 
 %pragma(csharp) imclasscode=%{
-  //static $imclassname() {
-  //}
 
   public class UTF8Marshaler : System.Runtime.InteropServices.ICustomMarshaler {
     static UTF8Marshaler static_instance;
@@ -45,12 +43,12 @@
                    "UTF8Marshaler must be used on a string.");
 
         // not null terminated
-        byte[] strbuf = System.Text.Encoding.UTF8.GetBytes((string)managedObj); 
+        byte[] strbuf = System.Text.Encoding.UTF8.GetBytes((string)managedObj);
         System.IntPtr buffer = System.Runtime.InteropServices.Marshal.AllocHGlobal(strbuf.Length + 1);
         System.Runtime.InteropServices.Marshal.Copy(strbuf, 0, buffer, strbuf.Length);
 
         // write the terminating null
-        System.Runtime.InteropServices.Marshal.WriteByte(buffer, strbuf.Length, 0); 
+        System.Runtime.InteropServices.Marshal.WriteByte(buffer, strbuf.Length, 0);
         return buffer;
     }
 
@@ -62,7 +60,7 @@
     }
 
     public void CleanUpNativeData(System.IntPtr pNativeData) {
-        System.Runtime.InteropServices.Marshal.FreeHGlobal(pNativeData);            
+        System.Runtime.InteropServices.Marshal.FreeHGlobal(pNativeData);
     }
 
     public void CleanUpManagedData(object managedObj) {
@@ -81,8 +79,8 @@
   }
 %}
 
-%typemap(imtype, inattributes="[System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]", 
-  outattributes="[return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]") 
+%typemap(imtype, inattributes="[System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]",
+  outattributes="[return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(UTF8Marshaler))]")
   char *, char *&, char[ANY], char[]   "string"
 
 %typemap(csout, excode=SWIGEXCODE) SWIGTYPE {
@@ -267,7 +265,7 @@
 
 %pragma(csharp) modulecode=%{
   /* %pragma(csharp) modulecode */
-  internal class $moduleObject : System.IDisposable {
+  internal class $moduleObject : global::System.IDisposable {
 	public virtual void Dispose() {
       
     }


### PR DESCRIPTION
In reference to
http://osgeo-org.1560.x6.nabble.com/csharp-mapscript-dotnet-core-on-Linux-td5391329.html
and
#5728

##sample usage:
$ mkdir build
$ cd build
$ cmake -DCMAKE_INSTALL_PREFIX=/opt
-DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu:/usr/share/postgresql/10:/usr/local:/opt
-DWITH_CLIENT_WFS=ON
-DWITH_CLIENT_WMS=ON
-DWITH_CURL=ON
-DWITH_SOS=ON
-DWITH_PHP=OFF
-DWITH_PERL=OFF
-DWITH_RUBY=OFF
-DWITH_JAVA=OFF
-DWITH_CSHARP=ON
-DWITH_PYTHON=OFF
-DWITH_SVGCAIRO=OFF
-DWITH_ORACLESPATIAL=OFF
-DWITH_MSSQL2008=OFF
../ >../configure.out.txt
$ make mapscript