### PR TITLE
WMS: apply FILTER (RFC 118) vendor parameter after the CRS parameter is taken into account to avoid extent inconsistencies (found during refs #5658 investigation)

### DIFF
--- a/mapwms.c
+++ b/mapwms.c
@@ -1367,22 +1367,6 @@ int msWMSLoadGetMapParams(mapObj *map, int nVersion,
   }
 
   /*
-  ** Apply vendor-specific filter if specified
-  */
-  if (filter) {
-    if (sld_url || sld_body) {
-      msSetError(MS_WMSERR,
-                 "Vendor-specific FILTER parameter cannot be used with SLD or SLD_BODY.",
-                 "msWMSLoadGetMapParams()");
-      return msWMSException(map, nVersion, NULL, wms_exception_format);
-    }
-    
-    if (msWMSApplyFilter(map, nVersion, filter, need_axis_swap, wms_exception_format) == MS_FAILURE) {
-      return MS_FAILURE;/* msWMSException(map, nVersion, "InvalidFilterRequest"); */
-    }
-  }
-
-  /*
   ** If any select layers have a default time, we will apply the default
   ** time value even if no TIME request was in the url.
   */
@@ -1655,6 +1639,22 @@ this request. Check wms/ows_enable_request settings.",
     nTmp = GetMapserverUnitUsingProj(&(map->projection));
     if( nTmp != -1 ) {
       map->units = nTmp;
+    }
+  }
+
+  /*
+  ** Apply vendor-specific filter if specified
+  */
+  if (filter) {
+    if (sld_url || sld_body) {
+      msSetError(MS_WMSERR,
+                 "Vendor-specific FILTER parameter cannot be used with SLD or SLD_BODY.",
+                 "msWMSLoadGetMapParams()");
+      return msWMSException(map, nVersion, NULL, wms_exception_format);
+    }
+
+    if (msWMSApplyFilter(map, nVersion, filter, need_axis_swap, wms_exception_format) == MS_FAILURE) {
+      return MS_FAILURE;/* msWMSException(map, nVersion, "InvalidFilterRequest"); */
     }
   }
 


### PR DESCRIPTION
@dmorissette If you want to have a look at https://github.com/mapserver/mapserver/commit/f8ed7b23b64ebb436f81b31ee500737dd04cb28d that modifies a bit RFC118 related functionality. I observed that when the WMS request involves reprojection, msWMSApplyFilter() resulted in incorrect bounding box in the call chain because the map->projection wasn't yet set, but the overall request still worked, because the querymap rendering re-evaluated the request due to the resultcache being empty 