### PR TITLE
Add sampling along diagonal for rectangle as polygon reprojection

### DIFF
--- a/mapproject.c
+++ b/mapproject.c
@@ -806,7 +806,7 @@ msProjectRectAsPolygon(projectionObj *in, projectionObj *out,
   lineObj  ring;
   /*  pointObj ringPoints[NUMBER_OF_SAMPLE_POINTS*4+4]; */
   pointObj *ringPoints;
-  int     ix, iy, ixy, sampleDiagonal, numPolyPoints;
+  int     ix, iy, ixy;
 
   double dx, dy;
 
@@ -859,9 +859,7 @@ msProjectRectAsPolygon(projectionObj *in, projectionObj *out,
   }
   
   /* If there is more than two sample points we will also get samples from the diagonal line */
-  sampleDiagonal = NUMBER_OF_SAMPLE_POINTS > 2 ? MS_TRUE : MS_FALSE;
-  numPolyPoints = sampleDiagonal ? NUMBER_OF_SAMPLE_POINTS*5+3 : NUMBER_OF_SAMPLE_POINTS*4+4;
-  ringPoints = (pointObj*) calloc(sizeof(pointObj),numPolyPoints);
+  ringPoints = (pointObj*) calloc(sizeof(pointObj),NUMBER_OF_SAMPLE_POINTS*5+3);
   ring.point = ringPoints;
   ring.numpoints = 0;
 
@@ -876,7 +874,7 @@ msProjectRectAsPolygon(projectionObj *in, projectionObj *out,
     }
   }
 
-  /* sample on along right side */
+  /* sample along right side */
   if(dy != 0) {
     for(iy = 1; iy <= NUMBER_OF_SAMPLE_POINTS; iy++ ) {
       ringPoints[ring.numpoints].x = rect->maxx;
@@ -903,7 +901,7 @@ msProjectRectAsPolygon(projectionObj *in, projectionObj *out,
   /* sample along diagonal line */
   /* This is done to handle cases where reprojection from world covering projection to one */
   /* which isn't could cause min and max values of the projected rectangle to be invalid */
-  if(dy != 0 && dx != 0 && sampleDiagonal) {
+  if(dy != 0 && dx != 0) {
     /* No need to compute corners as they've already been computed */
     for(ixy = NUMBER_OF_SAMPLE_POINTS-2; ixy >= 1; ixy-- ) {
       ringPoints[ring.numpoints].x = rect->minx + ixy * dx;


### PR DESCRIPTION
This pull request will solve reprojection issues in certain edge cases. 

### Issue
Not all geometries of the shapefile I was rendering appeared in the final image even though the extent cover all geometries. When I found the issue I had the following setup:
- Shapefile with data in EPSG:32633 projection
- WMS request with bounding box specified in EPSG:4326 projection
  - The following query string was used to debug the issue:
  ```QUERY_STRING=map=fylker.map&FORMAT=image%2Fpng&LAYERS=Fylker_Norge_flate&TRANSPARENT=TRUE&VERSION=1.3.0&EXCEPTIONS=INIMAGE&SERVICE=WMS&REQUEST=GetMap&STYLES=&CRS=EPSG%3A4326&BBOX=-90,-180,112.92325084041,22.92325084041&WIDTH=512&HEIGHT=512```

When the bounding box is reprojected (-90,-180,112.92325084041,22.92325084041) to EPSG:32633 the reprojected bounding box will not be correct, even with the current implementation which takes samples along the edges of the bounding box. To give an example, in the case described above the bottom left corner will have the following coordinates:

`500000.00       -9997964.94`

Using a sample in e.g. center of the bottom line of the rectangle will still give the same X value (500000.00) due to the Y value. 

### Proposed fix
The solution I propose is to sample the diagonal line in addition to the rectangle edges. In my case e.g. center point of the original bounding box would give a lower minimum X values than any of the samples along the edges.

This is how the resulting image looks before the fix:
![pre_fix](https://user-images.githubusercontent.com/2751905/55866190-1eab6000-5b80-11e9-9abe-1d6a8a51cbf7.png)
This is after the fix:
![post_fix](https://user-images.githubusercontent.com/2751905/55866191-1eab6000-5b80-11e9-9659-02b1ff26b34d.png)
In my case I had an issue with the min x value being too high of the reprojected bounding box even though it clearly shouldn't as I specify -180 deg in the request bounding box (which is in EPSG:4326).