### PR TITLE
allow NDEBUG to work for both set/unset cases

### DIFF
--- a/mapdrawgdal.c
+++ b/mapdrawgdal.c
@@ -86,7 +86,7 @@ int msDrawRasterLayerGDAL(mapObj *map, layerObj *layer, imageObj *image,
 {
   int i,j, k; /* loop counters */
   int cmap[MAXCOLORS];
-#ifndef NDEBUG
+#if !defined(NDEBUG)
   int cmap_set = FALSE;
 #endif
   unsigned char rb_cmap[4][MAXCOLORS];
@@ -521,7 +521,7 @@ int msDrawRasterLayerGDAL(mapObj *map, layerObj *layer, imageObj *image,
     const char* pszRangeColorspace = msLayerGetProcessingKey( layer, "RANGE_COLORSPACE" );
     colorspace iRangeColorspace;
 
-#ifndef NDEBUG
+#if !defined(NDEBUG)
     cmap_set = TRUE;
 #endif
 
@@ -605,7 +605,7 @@ int msDrawRasterLayerGDAL(mapObj *map, layerObj *layer, imageObj *image,
     }
   } else if( hBand2 == NULL && hColorMap != NULL && rb->type == MS_BUFFER_BYTE_RGBA ) {
     int color_count;
-#ifndef NDEBUG
+#if !defined(NDEBUG)
     cmap_set = TRUE;
 #endif
 

--- a/mapserv.c
+++ b/mapserv.c
@@ -52,7 +52,7 @@ void msCleanupOnSignal( int nInData )
   /* from within the signal handler on Unix.  So we force output through */
   /* normal stdio functions. */
   msIO_installHandlers( NULL, NULL, NULL );
-#ifndef NDEBUG
+#if !defined(NDEBUG)
   msIO_fprintf( stderr, "In msCleanupOnSignal.\n" );
 #endif
   msCleanup();

--- a/maputil.c
+++ b/maputil.c
@@ -1934,7 +1934,7 @@ int msSetup()
 
 /* This is intended to be a function to cleanup anything that "hangs around"
    when all maps are destroyed, like Registered GDAL drivers, and so forth. */
-#ifndef NDEBUG
+#if !defined(NDEBUG)
 #if defined(USE_LIBXML2)
 #include "maplibxml2.h"
 #endif
@@ -1972,7 +1972,7 @@ void msCleanup()
 #endif
 
 /* make valgrind happy on debug code */
-#ifndef NDEBUG
+#if !defined(NDEBUG)
 #ifdef USE_CAIRO
   msCairoCleanup();
 #endif


### PR DESCRIPTION
When `-DNDEBUG` is set, the opposite happens with the code checks of `ifndef`.  This change should allow `NDEBUG` to properly function when it is both set and unset.