### PR TITLE
GML:Name is now encoded in WMS GetFeatureInfo (fixes #5361)

### DIFF
--- a/mapgml.c
+++ b/mapgml.c
@@ -1455,7 +1455,7 @@ int msGMLWriteQuery(mapObj *map, char *filename, const char *namespaces)
 
       value = (char *) msOWSLookupMetadata(&(lp->metadata), "OM", "title");
       if (value) {
-        msOWSPrintMetadata(stream, &(lp->metadata), namespaces, "title", OWS_NOERR, "\t<gml:name>%s</gml:name>\n", value);
+        msOWSPrintEncodeMetadata(stream, &(lp->metadata), namespaces, "title", OWS_NOERR, "\t<gml:name>%s</gml:name>\n", value);
       }
 
       geomtype = msOWSLookupMetadata(&(lp->metadata), "OFG", "geomtype");

--- a/msautotest/wxs/expected/wms_getfeatureinfo_encoding.xml
+++ b/msautotest/wxs/expected/wms_getfeatureinfo_encoding.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<msGMLOutput 
+	 xmlns:gml="http://www.opengis.net/gml"
+	 xmlns:xlink="http://www.w3.org/1999/xlink"
+	 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<encoding_layer_layer>
+	<gml:name>encoding test &amp; &lt;&gt; </gml:name>
+		<encoding_layer_feature>
+			<gml:boundedBy>
+				<gml:Box srsName="EPSG:3857">
+					<gml:coordinates>-10.000000,-10.000000 10.000000,10.000000</gml:coordinates>
+				</gml:Box>
+			</gml:boundedBy>
+		</encoding_layer_feature>
+	</encoding_layer_layer>
+</msGMLOutput>

--- a/msautotest/wxs/wms_getfeatureinfo_encoding.map
+++ b/msautotest/wxs/wms_getfeatureinfo_encoding.map
@@ -1,0 +1,63 @@
+#
+# Test WMS GetfeatureInfo encoding
+#
+# REQUIRES: SUPPORTS=WMS
+# 
+# Check that WMS GetFeatureInfo response in GML format are encoded
+# RUN_PARMS: wms_getfeatureinfo_encoding.xml [MAPSERV] "QUERY_STRING=map=[MAPFILE]&service=WMS&request=GetFeatureInfo&version=1.3.0&CRS=EPSG:3857&width=200&height=200&layers=encoding_layer&bbox=-20,-20,20,20&format=image/png&query_layers=encoding_layer&i=100&j=100&&info_format=gml" > [RESULT_DEMIME]
+
+MAP
+    IMAGETYPE png
+
+    SIZE 100 100
+    EXTENT -20 -20 20 20
+    IMAGECOLOR '#ffffff'
+    WEB
+        METADATA
+            "ows_enable_request" "*"
+            "ows_srs" "EPSG:3857 EPSG:900913 EPSG:4326"
+            "ows_title" "WMS Getfeatureinfo encoding test"
+            "wms_getfeatureinfo_formatlist" "gml"
+            "wms_onlineresource" "http://localhost/cgi-bin/mapserv?map=mymap.map"
+        END
+        IMAGEPATH '/tmp/ms_tmp/'
+        IMAGEURL '/ms_tmp/'
+    END
+    PROJECTION
+        "init=epsg:3857"
+    END
+
+    LAYER
+        NAME "encoding_layer"
+        TYPE POLYGON
+        STATUS DEFAULT
+        PROJECTION
+            'init=epsg:3857'
+        END
+        METADATA
+            "wms_title" "encoding test & <> "
+            "ows_srs" "EPSG:3857 EPSG:900913 EPSG:4326"
+        END
+        TEMPLATE 'blank.html'
+
+        FEATURE
+            POINTS
+                -10 -10
+                -10  10
+                 10  10
+                 10 -10
+                -10 -10
+            END
+            TEXT "Polygon"
+        END
+
+        CLASS
+            NAME 'class'
+
+            STYLE
+                COLOR '#ff0000'
+            END
+        END
+    END
+
+END


### PR DESCRIPTION
This will fix #5361.