### PR TITLE
set required syntax statement for protobuf 3 (#5376)

### DIFF
--- a/renderers/mvt/vector_tile.proto
+++ b/renderers/mvt/vector_tile.proto
@@ -1,3 +1,6 @@
+//set statement to avoid warnings thrown in protobuf >= 3
+syntax = "proto2";
+
 package vector_tile;
 
 option optimize_for = LITE_RUNTIME;

--- a/renderers/mvt/vector_tile.proto
+++ b/renderers/mvt/vector_tile.proto
@@ -1,4 +1,4 @@
-//set statement to avoid warnings thrown in protobuf >= 3
+//set version statement to avoid warnings thrown in protobuf >= 3
 syntax = "proto2";
 
 package vector_tile;


### PR DESCRIPTION
This removes the warning thrown with protobuf 3, when compiling MapServer:
```
[libprotobuf WARNING D:\protobuf-3.6.1\src\google\protobuf\compiler\parser.cc:562] No syntax specified for the proto file: vector_tile.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
```