### PR TITLE
Update Projection WKT string

### DIFF
--- a/mapscript/python/tests/cases/map_test.py
+++ b/mapscript/python/tests/cases/map_test.py
@@ -289,8 +289,13 @@ class MapSizeTestCase(MapTestCase):
 
 class MapSetWKTTestCase(MapTestCase):
 
-    def xtestOGCWKT(self):
-        self.map.setWKTProjection('PROJCS["unnamed", PROJECTION["Albers_Conic_Equal_Area"], '
+    def testOGCWKT(self):
+        self.map.setWKTProjection('PROJCS["unnamed", ''GEOGCS["WGS 84", '
+                                  'DATUM["WGS_1984", '
+                                  'SPHEROID["WGS 84",6378137,298.257223563]], '
+                                  'PRIMEM["Greenwich",0], '
+                                  'UNIT["degree",0.0174532925199433]], '
+                                  'PROJECTION["Albers_Conic_Equal_Area"], '
                                   'PARAMETER["standard_parallel_1", 65], PARAMETER["standard_parallel_2", 55], '
                                   'PARAMETER["latitude_of_center", 0], PARAMETER["longitude_of_center", -153], '
                                   'PARAMETER["false_easting", -4943910.68], PARAMETER["false_northing", 0]]')

--- a/mapscript/python/tests/cases/map_test.py
+++ b/mapscript/python/tests/cases/map_test.py
@@ -290,8 +290,10 @@ class MapSizeTestCase(MapTestCase):
 class MapSetWKTTestCase(MapTestCase):
 
     def testOGCWKT(self):
-        self.map.setWKTProjection('''PROJCS["unnamed",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],
-                                     PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]],
+        self.map.setWKTProjection('''PROJCS["unnamed",GEOGCS["WGS 84",DATUM["WGS_1984",
+                                     SPHEROID["WGS 84",6378137,298.257223563]],
+                                     PRIMEM["Greenwich",0],
+                                     UNIT["Degree",0.0174532925199433]],
                                      PROJECTION["Albers_Conic_Equal_Area"],
                                      PARAMETER["standard_parallel_1", 65], PARAMETER["standard_parallel_2", 55],
                                      PARAMETER["latitude_of_center", 0], PARAMETER["longitude_of_center", -153],
@@ -302,7 +304,7 @@ class MapSetWKTTestCase(MapTestCase):
 
         assert proj4.find('+proj=aea') != -1
         assert proj4.find('+datum=WGS84') != -1
-        assert (mapscript.projectionObj(proj4)).getUnits() != mapscript.MS_DD
+        assert mapscript.projectionObj(proj4).getUnits() != mapscript.MS_DD
 
     def testESRIWKT(self):
         self.map.setWKTProjection('ESRI::PROJCS["Pulkovo_1995_GK_Zone_2", GEOGCS["GCS_Pulkovo_1995", '

--- a/mapscript/python/tests/cases/map_test.py
+++ b/mapscript/python/tests/cases/map_test.py
@@ -290,19 +290,18 @@ class MapSizeTestCase(MapTestCase):
 class MapSetWKTTestCase(MapTestCase):
 
     def testOGCWKT(self):
-        self.map.setWKTProjection('PROJCS["unnamed", ''GEOGCS["WGS 84", '
-                                  'DATUM["WGS_1984", '
-                                  'SPHEROID["WGS 84",6378137,298.257223563]], '
-                                  'PRIMEM["Greenwich",0], '
-                                  'UNIT["degree",0.0174532925199433]], '
-                                  'PROJECTION["Albers_Conic_Equal_Area"], '
-                                  'PARAMETER["standard_parallel_1", 65], PARAMETER["standard_parallel_2", 55], '
-                                  'PARAMETER["latitude_of_center", 0], PARAMETER["longitude_of_center", -153], '
-                                  'PARAMETER["false_easting", -4943910.68], PARAMETER["false_northing", 0]]')
+        self.map.setWKTProjection('''PROJCS["unnamed",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],
+                                     PRIMEM["Greenwich",0],UNIT["Degree",0.0174532925199433]],
+                                     PROJECTION["Albers_Conic_Equal_Area"],
+                                     PARAMETER["standard_parallel_1", 65], PARAMETER["standard_parallel_2", 55],
+                                     PARAMETER["latitude_of_center", 0], PARAMETER["longitude_of_center", -153],
+                                     PARAMETER["false_easting", -4943910.68], PARAMETER["false_northing", 0],
+                                     UNIT["metre",1.0]
+                                     ]''')
         proj4 = self.map.getProjection()
 
         assert proj4.find('+proj=aea') != -1
-        assert proj4.find('+ellps=WGS84') != -1
+        assert proj4.find('+datum=WGS84') != -1
         assert (mapscript.projectionObj(proj4)).getUnits() != mapscript.MS_DD
 
     def testESRIWKT(self):


### PR DESCRIPTION
To fix #5817

> the WKT string is invalid. It lacks a GEOGCS node. Previous versions of GDAL were too lax regarding this. You could instead use the following for example