### PR TITLE
Add 'DEBUG 3' on failing msautotests

### DIFF
--- a/msautotest/misc/ogr_empty_geojson.map
+++ b/msautotest/misc/ogr_empty_geojson.map
@@ -34,6 +34,7 @@ MAP
     END
 
     LAYER
+        DEBUG 3
         NAME "geojson"
         TYPE POLYGON
         STATUS DEFAULT

--- a/msautotest/wxs/wfs_200.map
+++ b/msautotest/wxs/wfs_200.map
@@ -323,6 +323,7 @@ END
 
 
 LAYER
+  DEBUG 3
   NAME province
   DATA province
   METADATA

--- a/msautotest/wxs/wfs_200_allgeoms.map
+++ b/msautotest/wxs/wfs_200_allgeoms.map
@@ -135,6 +135,7 @@ PROJECTION
 END
 
 LAYER
+  DEBUG 3
   NAME "point"
   DATA "point"
   TOLERANCE 50
@@ -153,6 +154,7 @@ LAYER
 END # Layer
 
 LAYER
+  DEBUG 3
   NAME "multipoint"
   DATA "multipoint"
   METADATA
@@ -169,6 +171,7 @@ LAYER
 END # Layer
 
 LAYER
+  DEBUG 3
   NAME "linestring"
   DATA "linestring"
   METADATA

--- a/msautotest/wxs/wfs_200_cite.map
+++ b/msautotest/wxs/wfs_200_cite.map
@@ -93,6 +93,7 @@ END
 
 
 LAYER
+  DEBUG 3
   NAME province
   CONNECTIONTYPE OGR
   CONNECTION "data/province.shp"

--- a/msautotest/wxs/wfs_200_cite_postgis.map
+++ b/msautotest/wxs/wfs_200_cite_postgis.map
@@ -83,6 +83,7 @@ END
 
 
 LAYER
+  DEBUG 3
   NAME province
   INCLUDE "postgis.include"
   DATA "the_geom from (select * from province order by gid) as foo using unique gid using srid=3978"

--- a/msautotest/wxs/wfs_200_low_wfsmaxfeatures_no_compute_number_matched.map
+++ b/msautotest/wxs/wfs_200_low_wfsmaxfeatures_no_compute_number_matched.map
@@ -72,6 +72,7 @@ END
 
 
 LAYER
+  DEBUG 3
   NAME province
   DATA province
   METADATA

--- a/msautotest/wxs/wfs_filter.map
+++ b/msautotest/wxs/wfs_filter.map
@@ -249,6 +249,7 @@ END
 
 
 LAYER
+  DEBUG 3
   NAME province
   DATA province
   METADATA
@@ -300,6 +301,7 @@ END # Layer
 
 
 LAYER
+  DEBUG 3
   NAME popplace
   DATA popplace
   METADATA

--- a/msautotest/wxs/wfs_filter_ogr.map
+++ b/msautotest/wxs/wfs_filter_ogr.map
@@ -177,6 +177,7 @@ END
 
 
 LAYER
+  DEBUG 3
   NAME province
   CONNECTIONTYPE OGR
   CONNECTION "province.shp"
@@ -204,6 +205,7 @@ END # Layer
 
 
 LAYER
+  DEBUG 3
   NAME popplace
   CONNECTIONTYPE OGR
   CONNECTION "popplace.shp"

--- a/msautotest/wxs/wfs_filter_postgis.map
+++ b/msautotest/wxs/wfs_filter_postgis.map
@@ -194,6 +194,7 @@ END
 
 
 LAYER
+  DEBUG 3
   NAME province
   INCLUDE "postgis.include"
   DATA "the_geom from (select * from province order by gid) as foo using srid=3978 using unique gid"
@@ -219,6 +220,7 @@ LAYER
 END # Layer
 
 LAYER
+  DEBUG 3
   NAME popplace
   INCLUDE "postgis.include"
   DATA "the_geom from (select * from popplace order by gid) as foo using srid=3978 using unique gid"

--- a/msautotest/wxs/wfs_filter_projmeter.map
+++ b/msautotest/wxs/wfs_filter_projmeter.map
@@ -98,6 +98,7 @@ END
 
 
 LAYER
+  DEBUG 3
   NAME province
   DATA province
   METADATA
@@ -149,6 +150,7 @@ END # Layer
 
 
 LAYER
+  DEBUG 3
   NAME popplace
   DATA popplace
   METADATA

--- a/msautotest/wxs/wfs_ogr_native_sql.map
+++ b/msautotest/wxs/wfs_ogr_native_sql.map
@@ -131,6 +131,7 @@ END
 #
 
 LAYER
+  DEBUG 3
   NAME towns
   DATA towns
   CONNECTIONTYPE OGR
@@ -309,6 +310,7 @@ LAYER
 END # Layer
 
 LAYER
+  DEBUG 3
   NAME select_zero_feature
   DATA "SELECT * FROM towns WHERE 0"
   CONNECTIONTYPE OGR

--- a/msautotest/wxs/wfs_ogr_no_native_sql.map
+++ b/msautotest/wxs/wfs_ogr_no_native_sql.map
@@ -97,6 +97,7 @@ END
 #
 
 LAYER
+  DEBUG 3
   NAME towns
   DATA towns
   CONNECTIONTYPE OGR

--- a/msautotest/wxs/wfs_time.map
+++ b/msautotest/wxs/wfs_time.map
@@ -71,6 +71,7 @@ END
 #
 
 LAYER
+  DEBUG 3
   NAME time
   DATA pattern1
   METADATA

--- a/msautotest/wxs/wfs_time_ogr.map
+++ b/msautotest/wxs/wfs_time_ogr.map
@@ -70,6 +70,7 @@ END
 #
 
 LAYER
+  DEBUG 3
   NAME time
   CONNECTIONTYPE OGR
   CONNECTION "data/pattern1.shp"

--- a/msautotest/wxs/wfs_time_postgis.map
+++ b/msautotest/wxs/wfs_time_postgis.map
@@ -76,6 +76,7 @@ END
 #
 
 LAYER
+  DEBUG 3
   NAME time
   INCLUDE "postgis.include"
   DATA "the_geom from (select * from pattern1 order by gid) as foo using unique gid using srid=4326"

--- a/msautotest/wxs/wms_inspire.map
+++ b/msautotest/wxs/wms_inspire.map
@@ -255,6 +255,7 @@ MAP
     #
 
     LAYER
+        DEBUG 3
         NAME TN.CommonTransportElements
         METADATA
             "wms_title" "TN.CommonTransportElements"

--- a/msautotest/wxs/wms_raster.map
+++ b/msautotest/wxs/wms_raster.map
@@ -86,6 +86,7 @@ END
 #
 
 LAYER
+  DEBUG 3
   NAME road
   DATA toronto.tif
   METADATA


### PR DESCRIPTION
Following #5707, some msautotests failed. These tests expected error messages that were filtered out by said PR. The proposed update increases the debug level to 3 on impacted layers in msautotests, so that expected error messages are produced.