### PR TITLE
MSSQL2008: deal with termination '$' at end of regular expression. Follow-up of eea166a5157d4742b617cd7561c62cd2df5c8f5c (refs #5825)

### DIFF
--- a/mapmssql2008.c
+++ b/mapmssql2008.c
@@ -2988,6 +2988,8 @@ int process_node(layerObj* layer, expressionObj *filter)
           i++;
           continue;
         }
+        if( c == '$' && c_next == 0 && strtmpl[0] == '^' )
+          break;
 
         if (c == '\\') {
           i++;


### PR DESCRIPTION
@geographika I believe this should do it, but couldn't test. I'd appreciate if you could report if it solves your issue

We should probably add mssql tests in msautotest. Relevant snippets from GDAL autotest suite: https://github.com/OSGeo/gdal/blob/master/gdal/ci/travis/ubuntu_1604/before_install.sh#L10 and https://github.com/OSGeo/gdal/blob/master/gdal/ci/travis/ubuntu_1604/before_install.sh#L46