### PR TITLE
Assorted set of compiler warning fixes, and remove need for DEBUG 3

### DIFF
--- a/mapmetadata.c
+++ b/mapmetadata.c
@@ -38,7 +38,8 @@
 /*      Create a gmd:name/gmd:CharacterString element pattern           */
 /************************************************************************/
 
-xmlNodePtr _msMetadataGetCharacterString(xmlNsPtr namespace, char *name, char *value) {
+static
+xmlNodePtr _msMetadataGetCharacterString(xmlNsPtr namespace, const char *name, const char *value) {
   xmlNsPtr psNsGco = NULL;
   xmlNodePtr psNode = NULL;
 
@@ -61,7 +62,8 @@ xmlNodePtr _msMetadataGetCharacterString(xmlNsPtr namespace, char *name, char *v
 /*      Create a gmd:name/gmd:URL element pattern                       */
 /************************************************************************/
 
-xmlNodePtr _msMetadataGetURL(xmlNsPtr namespace, char *name, char *value) {
+static
+xmlNodePtr _msMetadataGetURL(xmlNsPtr namespace, const char *name, const char *value) {
   xmlNsPtr psNsGco = NULL;
   xmlNodePtr psNode = NULL;
 
@@ -83,13 +85,14 @@ xmlNodePtr _msMetadataGetURL(xmlNsPtr namespace, char *name, char *value) {
 /*               Create a gmd:onLine element pattern                    */
 /************************************************************************/
 
-xmlNodePtr _msMetadataGetOnline(xmlNsPtr namespace, layerObj *layer, char *service, char *format, char *desc, char *url_in) {
+static
+xmlNodePtr _msMetadataGetOnline(xmlNsPtr namespace, layerObj *layer, const char *service, const char *format, const char *desc, const char *url_in) {
 
   int status;
   char *url = NULL;
   char buffer[32];
   char *epsg_str;
-  char *link_protocol;
+  const char *link_protocol = "unknown protocol";
 
   xmlNodePtr psNode = NULL;
   xmlNodePtr psORNode = NULL;
@@ -160,7 +163,8 @@ xmlNodePtr _msMetadataGetOnline(xmlNsPtr namespace, layerObj *layer, char *servi
 /*      Create a gmd:name/gmd:Integer element pattern                   */
 /************************************************************************/
 
-xmlNodePtr _msMetadataGetInteger(xmlNsPtr namespace, char *name, int value) {
+static
+xmlNodePtr _msMetadataGetInteger(xmlNsPtr namespace, const char *name, int value) {
   char buffer[8];
   xmlNsPtr psNsGco = NULL;
   xmlNodePtr psNode = NULL;
@@ -185,7 +189,8 @@ xmlNodePtr _msMetadataGetInteger(xmlNsPtr namespace, char *name, int value) {
 /*      Create a gmd:name/gmd:Decimal element pattern                   */
 /************************************************************************/
 
-xmlNodePtr _msMetadataGetDecimal(xmlNsPtr namespace, char *name, double value) {
+static
+xmlNodePtr _msMetadataGetDecimal(xmlNsPtr namespace, const char *name, double value) {
   char buffer[32];
   xmlNsPtr psNsGco = NULL;
   xmlNodePtr psNode = NULL;
@@ -210,7 +215,8 @@ xmlNodePtr _msMetadataGetDecimal(xmlNsPtr namespace, char *name, double value) {
 /*      Create a gmd:name/gmd:* code list element pattern               */
 /************************************************************************/
 
-xmlNodePtr _msMetadataGetCodeList(xmlNsPtr namespace, char *parent_element, char *name, char *value) {
+static
+xmlNodePtr _msMetadataGetCodeList(xmlNsPtr namespace, const char *parent_element, const char *name, const char *value) {
   char *codelist = NULL;
   xmlNodePtr psNode = NULL;
   xmlNodePtr psCodeNode = NULL;
@@ -233,7 +239,8 @@ xmlNodePtr _msMetadataGetCodeList(xmlNsPtr namespace, char *parent_element, char
 /*      Create a gmd:date or gmd:dateStamp element pattern              */
 /************************************************************************/
 
-xmlNodePtr _msMetadataGetDate(xmlNsPtr namespace, char *parent_element, char *date_type, char *value) {
+static
+xmlNodePtr _msMetadataGetDate(xmlNsPtr namespace, const char *parent_element, const char *date_type, const char *value) {
   xmlNsPtr psNsGco = NULL;
   xmlNodePtr psNode = NULL;
   xmlNodePtr psNode2 = NULL;

--- a/mapogroutput.c
+++ b/mapogroutput.c
@@ -148,7 +148,8 @@ char **msOGRRecursiveFileList( const char *path )
              CPLFormFilename( path, file_list[i], NULL ),
              sizeof(full_filename) );
 
-    VSIStatL( full_filename, &sStatBuf );
+    if( VSIStatL( full_filename, &sStatBuf ) != 0 )
+        continue;
 
     if( VSI_ISREG( sStatBuf.st_mode ) ) {
       result_list = CSLAddString( result_list, full_filename );
@@ -197,7 +198,8 @@ static void msOGRCleanupDS( const char *datasource_name )
              CPLFormFilename( path, file_list[i], NULL ),
              sizeof(full_filename) );
 
-    VSIStatL( full_filename, &sStatBuf );
+    if( VSIStatL( full_filename, &sStatBuf ) != 0 )
+      continue;
 
     if( VSI_ISREG( sStatBuf.st_mode ) ) {
       VSIUnlink( full_filename );

--- a/mapquery.c
+++ b/mapquery.c
@@ -986,9 +986,7 @@ int msQueryByFilter(mapObj *map)
       return MS_SUCCESS;
   }
 
-  if( lp->debug >= MS_DEBUGLEVEL_V ) {
-    msSetError(MS_NOTFOUND, "No matching record(s) found.", "msQueryByFilter()");
-  }
+  msSetError(MS_NOTFOUND, "No matching record(s) found.", "msQueryByFilter()");
   return MS_FAILURE;
 
 query_error:
@@ -1286,9 +1284,7 @@ int msQueryByRect(mapObj *map)
       return(MS_SUCCESS);
   }
 
-  if( lp->debug >= MS_DEBUGLEVEL_V ) {
-    msSetError(MS_NOTFOUND, "No matching record(s) found.", "msQueryByRect()");
-  }
+  msSetError(MS_NOTFOUND, "No matching record(s) found.", "msQueryByRect()");
   return(MS_FAILURE);
 }
 
@@ -1605,9 +1601,7 @@ int msQueryByFeatures(mapObj *map)
     if(GET_LAYER(map, l)->resultcache && GET_LAYER(map, l)->resultcache->numresults > 0) return(MS_SUCCESS);
   }
 
-  if( lp->debug >= MS_DEBUGLEVEL_V ) {
-    msSetError(MS_NOTFOUND, "No matching record(s) found.", "msQueryByFeatures()");
-  }
+  msSetError(MS_NOTFOUND, "No matching record(s) found.", "msQueryByFeatures()");
   return(MS_FAILURE);
 }
 
@@ -1842,9 +1836,7 @@ int msQueryByPoint(mapObj *map)
       return(MS_SUCCESS);
   }
 
-  if( lp->debug >= MS_DEBUGLEVEL_V ) {
-    msSetError(MS_NOTFOUND, "No matching record(s) found.", "msQueryByPoint()");
-  }
+  msSetError(MS_NOTFOUND, "No matching record(s) found.", "msQueryByPoint()");
   return(MS_FAILURE);
 }
 
@@ -2123,9 +2115,7 @@ int msQueryByShape(mapObj *map)
       return(MS_SUCCESS);
   }
 
-  if( lp->debug >= MS_DEBUGLEVEL_V ) {
-    msSetError(MS_NOTFOUND, "No matching record(s) found.", "msQueryByShape()");
-  }
+  msSetError(MS_NOTFOUND, "No matching record(s) found.", "msQueryByShape()");
   return(MS_FAILURE);
 }
 

--- a/mapscript/php/mapscript_i.c
+++ b/mapscript/php/mapscript_i.c
@@ -283,7 +283,7 @@ int mapObj_save(mapObj* self, char *filename)
   return msSaveMap(self, filename);
 }
 
-char *mapObj_getMetaData(mapObj *self, char *name)
+const char *mapObj_getMetaData(mapObj *self, char *name)
 {
   return(msLookupHashTable(&(self->web.metadata), name));
 }
@@ -793,7 +793,7 @@ int layerObj_addFeature(layerObj *self, shapeObj *shape)
     return MS_SUCCESS;
 }
 
-char *layerObj_getMetaData(layerObj *self, char *name)
+const char *layerObj_getMetaData(layerObj *self, char *name)
 {
   return(msLookupHashTable(&(self->metadata), name));
 }

--- a/mapscript/php/php_mapscript.c
+++ b/mapscript/php/php_mapscript.c
@@ -185,7 +185,7 @@ PHP_FUNCTION(ms_newLayerObj)
   layerObj *layer;
   int index;
   php_map_object *php_map;
-  php_layer_object *php_layer;
+  php_layer_object *php_layer = NULL;
   parent_object parent;
 
   PHP_MAPSCRIPT_ERROR_HANDLING(TRUE);

--- a/mapscript/php/php_mapscript.h
+++ b/mapscript/php/php_mapscript.h
@@ -877,7 +877,7 @@ int             mapObj_setWKTProjection(mapObj *self, char *string);
 char*           mapObj_getProjection(mapObj* self);
 int             mapObj_setProjection(mapObj* self, char *string);
 int             mapObj_save(mapObj* self, char *filename);
-char            *mapObj_getMetaData(mapObj *self, char *name);
+const char     *mapObj_getMetaData(mapObj *self, char *name);
 int             mapObj_setMetaData(mapObj *self, char *name, char *value);
 int             mapObj_removeMetaData(mapObj *self, char *name);
 void            mapObj_freeQuery(mapObj *self, int qlayer);
@@ -954,7 +954,7 @@ int             layerObj_setWKTProjection(layerObj *self, char *string);
 char*           layerObj_getProjection(layerObj *self);
 int             layerObj_setProjection(layerObj *self, char *string);
 int             layerObj_addFeature(layerObj *self, shapeObj *shape);
-char            *layerObj_getMetaData(layerObj *self, char *name);
+const char     *layerObj_getMetaData(layerObj *self, char *name);
 int             layerObj_setMetaData(layerObj *self, char *name, char *value);
 int             layerObj_removeMetaData(layerObj *self, char *name);
 char            *layerObj_getWMSFeatureInfoURL(layerObj *self, mapObj *map,

--- a/mapscript/python/pyextend.i
+++ b/mapscript/python/pyextend.i
@@ -336,7 +336,6 @@ def fromstring(data, mappath=None):
         int imgsize;
         PyObject *noerr;
         int retval=MS_FAILURE;
-        rendererVTableObj *renderer = NULL;
 
         /* Return immediately if image driver is not GD */
         if ( !MS_RENDERER_PLUGIN(self->format) )

--- a/msautotest/misc/ogr_empty_geojson.map
+++ b/msautotest/misc/ogr_empty_geojson.map
@@ -34,7 +34,6 @@ MAP
     END
 
     LAYER
-        DEBUG 3
         NAME "geojson"
         TYPE POLYGON
         STATUS DEFAULT

--- a/msautotest/wxs/wfs_200.map
+++ b/msautotest/wxs/wfs_200.map
@@ -323,7 +323,7 @@ END
 
 
 LAYER
-  DEBUG 3
+
   NAME province
   DATA province
   METADATA

--- a/msautotest/wxs/wfs_200_allgeoms.map
+++ b/msautotest/wxs/wfs_200_allgeoms.map
@@ -135,7 +135,7 @@ PROJECTION
 END
 
 LAYER
-  DEBUG 3
+
   NAME "point"
   DATA "point"
   TOLERANCE 50
@@ -154,7 +154,7 @@ LAYER
 END # Layer
 
 LAYER
-  DEBUG 3
+
   NAME "multipoint"
   DATA "multipoint"
   METADATA
@@ -171,7 +171,7 @@ LAYER
 END # Layer
 
 LAYER
-  DEBUG 3
+
   NAME "linestring"
   DATA "linestring"
   METADATA

--- a/msautotest/wxs/wfs_200_cite.map
+++ b/msautotest/wxs/wfs_200_cite.map
@@ -93,7 +93,7 @@ END
 
 
 LAYER
-  DEBUG 3
+
   NAME province
   CONNECTIONTYPE OGR
   CONNECTION "data/province.shp"

--- a/msautotest/wxs/wfs_200_cite_postgis.map
+++ b/msautotest/wxs/wfs_200_cite_postgis.map
@@ -83,7 +83,7 @@ END
 
 
 LAYER
-  DEBUG 3
+
   NAME province
   INCLUDE "postgis.include"
   DATA "the_geom from (select * from province order by gid) as foo using unique gid using srid=3978"

--- a/msautotest/wxs/wfs_200_low_wfsmaxfeatures_no_compute_number_matched.map
+++ b/msautotest/wxs/wfs_200_low_wfsmaxfeatures_no_compute_number_matched.map
@@ -72,7 +72,7 @@ END
 
 
 LAYER
-  DEBUG 3
+
   NAME province
   DATA province
   METADATA

--- a/msautotest/wxs/wfs_filter.map
+++ b/msautotest/wxs/wfs_filter.map
@@ -253,7 +253,7 @@ END
 
 
 LAYER
-  DEBUG 3
+
   NAME province
   DATA province
   METADATA
@@ -305,7 +305,7 @@ END # Layer
 
 
 LAYER
-  DEBUG 3
+
   NAME popplace
   DATA popplace
   METADATA

--- a/msautotest/wxs/wfs_filter_ogr.map
+++ b/msautotest/wxs/wfs_filter_ogr.map
@@ -177,7 +177,7 @@ END
 
 
 LAYER
-  DEBUG 3
+
   NAME province
   CONNECTIONTYPE OGR
   CONNECTION "province.shp"
@@ -205,7 +205,7 @@ END # Layer
 
 
 LAYER
-  DEBUG 3
+
   NAME popplace
   CONNECTIONTYPE OGR
   CONNECTION "popplace.shp"

--- a/msautotest/wxs/wfs_filter_postgis.map
+++ b/msautotest/wxs/wfs_filter_postgis.map
@@ -198,7 +198,7 @@ END
 
 
 LAYER
-  DEBUG 3
+
   NAME province
   INCLUDE "postgis.include"
   DATA "the_geom from (select * from province order by gid) as foo using srid=3978 using unique gid"
@@ -224,7 +224,7 @@ LAYER
 END # Layer
 
 LAYER
-  DEBUG 3
+
   NAME popplace
   INCLUDE "postgis.include"
   DATA "the_geom from (select * from popplace order by gid) as foo using srid=3978 using unique gid"

--- a/msautotest/wxs/wfs_filter_projmeter.map
+++ b/msautotest/wxs/wfs_filter_projmeter.map
@@ -98,7 +98,7 @@ END
 
 
 LAYER
-  DEBUG 3
+
   NAME province
   DATA province
   METADATA
@@ -150,7 +150,7 @@ END # Layer
 
 
 LAYER
-  DEBUG 3
+
   NAME popplace
   DATA popplace
   METADATA

--- a/msautotest/wxs/wfs_ogr_native_sql.map
+++ b/msautotest/wxs/wfs_ogr_native_sql.map
@@ -131,7 +131,7 @@ END
 #
 
 LAYER
-  DEBUG 3
+
   NAME towns
   DATA towns
   CONNECTIONTYPE OGR
@@ -310,7 +310,7 @@ LAYER
 END # Layer
 
 LAYER
-  DEBUG 3
+
   NAME select_zero_feature
   DATA "SELECT * FROM towns WHERE 0"
   CONNECTIONTYPE OGR

--- a/msautotest/wxs/wfs_ogr_no_native_sql.map
+++ b/msautotest/wxs/wfs_ogr_no_native_sql.map
@@ -97,7 +97,7 @@ END
 #
 
 LAYER
-  DEBUG 3
+
   NAME towns
   DATA towns
   CONNECTIONTYPE OGR

--- a/msautotest/wxs/wfs_time.map
+++ b/msautotest/wxs/wfs_time.map
@@ -71,7 +71,7 @@ END
 #
 
 LAYER
-  DEBUG 3
+
   NAME time
   DATA pattern1
   METADATA

--- a/msautotest/wxs/wfs_time_ogr.map
+++ b/msautotest/wxs/wfs_time_ogr.map
@@ -70,7 +70,7 @@ END
 #
 
 LAYER
-  DEBUG 3
+
   NAME time
   CONNECTIONTYPE OGR
   CONNECTION "data/pattern1.shp"

--- a/msautotest/wxs/wfs_time_postgis.map
+++ b/msautotest/wxs/wfs_time_postgis.map
@@ -76,7 +76,7 @@ END
 #
 
 LAYER
-  DEBUG 3
+
   NAME time
   INCLUDE "postgis.include"
   DATA "the_geom from (select * from pattern1 order by gid) as foo using unique gid using srid=4326"

--- a/msautotest/wxs/wms_inspire.map
+++ b/msautotest/wxs/wms_inspire.map
@@ -255,7 +255,7 @@ MAP
     #
 
     LAYER
-        DEBUG 3
+
         NAME TN.CommonTransportElements
         METADATA
             "wms_title" "TN.CommonTransportElements"

--- a/msautotest/wxs/wms_raster.map
+++ b/msautotest/wxs/wms_raster.map
@@ -86,7 +86,7 @@ END
 #
 
 LAYER
-  DEBUG 3
+
   NAME road
   DATA toronto.tif
   METADATA

--- a/renderers/agg/include/agg_conv_curve.h
+++ b/renderers/agg/include/agg_conv_curve.h
@@ -154,8 +154,8 @@ namespace mapserver
             return path_cmd_line_to;
         }
 
-        double ct2_x;
-        double ct2_y;
+        double ct2_x = 0;
+        double ct2_y = 0;
         double end_x;
         double end_y;
 

--- a/renderers/agg/include/agg_path_storage.h
+++ b/renderers/agg/include/agg_path_storage.h
@@ -720,7 +720,7 @@ namespace mapserver
         template<class VertexSource> 
         void concat_path(VertexSource& vs, unsigned path_id = 0)
         {
-            double x, y;
+            double x = 0, y = 0;
             unsigned cmd;
             vs.rewind(path_id);
             while(!is_stop(cmd = vs.vertex(&x, &y)))


### PR DESCRIPTION
Mostly boring compiler warning fixes, but there were interesting issues
in mapquery.c function where the emission of msSetError(MS_NOTFOUND, )
depended on lp->debug >= MS_DEBUGLEVEL_V, which seems inappropriate,
as a few mapfiles actually needed to have DEBUG 3 in their LAYER definition.
Just always emit the error.