### PR TITLE
Add runsub MapScript functions

### DIFF
--- a/mapscript/python/pymodule.i
+++ b/mapscript/python/pymodule.i
@@ -91,6 +91,47 @@ CreateTupleFromDoubleArray( double *first, unsigned int size ) {
   $result = t_output_helper($result,r);
 }
 
+/*
+ *  Typemap to turn a Python dict into two sequences and
+ *  an item count. Used for msApplySubstitutions
+ */
+%typemap(in) (char **names, char **values, int npairs) {
+  /* Check if is a dict */
+  if (PyDict_Check($input)) {
+
+    int size = PyDict_Size($input);
+    $3 = size;
+    $1 = (char **) malloc((size+1)*sizeof(char *));
+    $2 = (char **) malloc((size+1)*sizeof(char *));
+    int i = 0;
+
+    PyObject* keys = PyDict_Keys($input);
+    PyObject* values = PyDict_Values($input);
+    PyObject *key;
+    PyObject *val;
+
+    for (i = 0; i < size; i++) {
+        key = PyList_GetItem(keys, i);
+        val = PyList_GetItem(values, i);
+
+        $1[i] = PyString_AsString(key);
+        $2[i] = PyString_AsString(val);
+    }
+
+    $1[i] = 0;
+    $2[i] = 0;
+
+  } else {
+    PyErr_SetString(PyExc_TypeError, "Input not a dictionary");
+    SWIG_fail;
+  }
+}
+
+%typemap(freearg) (char **names, char **values, int npairs) {
+  free((char *) $1);
+  free((char *) $2);
+}
+
 /**************************************************************************
  * MapServer Errors and Python Exceptions
  **************************************************************************

--- a/mapscript/swiginc/layer.i
+++ b/mapscript/swiginc/layer.i
@@ -688,7 +688,8 @@
     }
 
     %feature("autodoc", "3");
-    %feature("docstring") "Returns the requested item's field type.
+    %feature("docstring") getItemType 
+"Returns the requested item's field type.
 A layer must be open to retrieve the item definition. 
 
 Pass in the attribute index to retrieve the type. The 

--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -509,4 +509,24 @@
         return msWriteMapToString(self);
     }
 
+    %feature("autodoc", "3");
+    %feature("docstring") applyDefaultSubstitutions 
+    "Apply any default values 
+defined in a VALIDATION block used for runtime substitutions"
+    void applyDefaultSubstitutions()
+    {
+        msApplyDefaultSubstitutions(self);
+    }
+
+    %feature("autodoc", "3");
+    %feature("docstring") applySubstitutions
+"Pass in runtime substitution 
+keys and values and apply them to the map. 
+
+**Note** This method is currently enabled for Python only. 
+Typemaps are needed for other mapscript languages."
+    void applySubstitutions(char **names, char **values, int npairs)
+    {
+        msApplySubstitutions(self, names, values, npairs);
+    }
 }


### PR DESCRIPTION
This pull request adds a `applyDefaultSubstitutions` function to all SWIG MapScripts, and an `applySubstitutions` function to Python MapScript along with an appropriate typemap. 

Usage is as follows - `applyDefaultSubstitutions` can be called directly on a mabObj:

```python
        s = """
MAP
    WEB
        VALIDATION
            'key1' '.*'
            'default_key1' 'Test Title'
        END
        METADATA
            "wms_title" "%key1%"
        END
    END
END
        """
        map = mapscript.fromstring(s)
        map.applyDefaultSubstitutions()
```

`applySubstitutions` can be used in Python by supplying a dict of keys and values (both need to be strings) to replace any variables in a Mapfile. 

```python
        s = """
MAP
    WEB
        VALIDATION
            'key1' '.*'
            'default_key1' 'Test Title'
        END
        METADATA
            "wms_title" "%key1%"
        END
    END
    LAYER
        TYPE POINT
        FILTER ([size]<%my_filter%)
        VALIDATION
            'my_filter' '^[0-9]$'
        END
    END
END
        """
        map = mapscript.fromstring(s)

        d = {"key1": "New Title", "my_filter": "3"}
        map.applySubstitutions(d)
```