### PR TITLE
Don't set Python debug lib on Windows

### DIFF
--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -30,6 +30,12 @@
 ============================================================================
 */
 
+%begin %{
+#ifdef _MSC_VER
+#define SWIG_PYTHON_INTERPRETER_NO_DEBUG
+#endif
+%}
+
 #ifndef SWIGPHPNG
 %module mapscript
 #else


### PR DESCRIPTION
Currently when compiling with MSVC on Windows using `-DWITH_PYTHON=1` and in DEBUG the following error occurs:

`LINK : fatal error LNK1104: cannot open file 'python27_d.lib`

To resolve this would require compiling Python from scratch. Ideally we want to be able to create a DEBUG release of MapServer with Python, but don't require Python itself to be in DEBUG mode. 

SWIG has an option to avoid this as [documented here](http://www.swig.org/Doc4.0/Python.html#Python_nn12)

See also https://stackoverflow.com/a/32631330/179520