### PR TITLE
CleanVSIDir: make it actually work (memory usage and perf fix)

### DIFF
--- a/mapgdal.c
+++ b/mapgdal.c
@@ -112,13 +112,13 @@ void msGDALCleanup( void )
 }
 
 /************************************************************************/
-/*                            CleanVSIDir()                             */
+/*                          msCleanVSIDir()                             */
 /*                                                                      */
 /*      For the temporary /vsimem/msout directory we need to be sure    */
 /*      things are clean before we start, and after we are done.        */
 /************************************************************************/
 
-void CleanVSIDir( const char *pszDir )
+void msCleanVSIDir( const char *pszDir )
 
 {
   char **papszFiles = CPLReadDir( pszDir );
@@ -129,7 +129,7 @@ void CleanVSIDir( const char *pszDir )
         || strcasecmp(papszFiles[i],"..") == 0 )
       continue;
 
-    VSIUnlink( papszFiles[i] );
+    VSIUnlink( CPLFormFilename(pszDir, papszFiles[i], NULL) );
   }
 
   CSLDestroy( papszFiles );
@@ -192,7 +192,7 @@ int msSaveImageGDAL( mapObj *map, imageObj *image, const char *filenameIn )
 
     if( bUseXmp == MS_FALSE && GDALGetMetadataItem( hOutputDriver, GDAL_DCAP_VIRTUALIO, NULL )
         != NULL ) {
-      CleanVSIDir( "/vsimem/msout" );
+      msCleanVSIDir( "/vsimem/msout" );
       filenameToFree = msTmpFile(map, NULL, "/vsimem/msout/", pszExtension );
     }
 
@@ -512,7 +512,7 @@ int msSaveImageGDAL( mapObj *map, imageObj *image, const char *filenameIn )
     VSIFCloseL( fp );
 
     VSIUnlink( filename );
-    CleanVSIDir( "/vsimem/msout" );
+    msCleanVSIDir( "/vsimem/msout" );
 
     msFree( filenameToFree );
   }

--- a/mapserver.h
+++ b/mapserver.h
@@ -2789,6 +2789,9 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   /* ==================================================================== */
   MS_DLL_EXPORT int msSaveImageGDAL( mapObj *map, imageObj *image, const char *filename );
   MS_DLL_EXPORT int msInitDefaultGDALOutputFormat( outputFormatObj *format );
+#ifdef USE_GDAL
+  void msCleanVSIDir( const char *pszDir );
+#endif
 
   /* ==================================================================== */
   /*      prototypes for functions in mapogroutput.c                      */

--- a/mapwmslayer.c
+++ b/mapwmslayer.c
@@ -44,8 +44,6 @@
 #  include "cpl_vsi.h"
 #endif
 
-void CleanVSIDir( const char *pszDir );
-
 /**********************************************************************
  *                          msInitWmsParamsObj()
  *
@@ -1363,7 +1361,7 @@ int msDrawWMSLayerLow(int nLayerId, httpRequestObj *pasReqInfo,
    * to attach a "VSI" name to this buffer.
    * ------------------------------------------------------------------ */
   if( pasReqInfo[iReq].pszOutputFile == NULL ) {
-    CleanVSIDir( "/vsimem/msout" );
+    msCleanVSIDir( "/vsimem/msout" );
     mem_filename = msTmpFile(map, NULL, "/vsimem/msout/", "img.tmp" );
 
     VSIFCloseL(


### PR DESCRIPTION
The function didn't remove the temporary files, mostly when
saving an image through GDAL in /vsimem/msout
This would result in memory usage and execution time for repeated
requests in the same process to grow linearly with the number of
requests, instead of remaining constant.