### PR TITLE
Wrong OFFSET in query for CONNECTIONTYPE OGR

### DIFF
--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -2475,7 +2475,7 @@ static int msOGRFileWhichShapes(layerObj *layer, rectObj rect, msOGRFileInfo *ps
 
         if ( !bOffsetAlreadyAdded && psInfo->bPaging && layer->startindex > 0 ) {
             char szOffset[50];
-            snprintf(szOffset, sizeof(szOffset), " OFFSET %d", layer->startindex);
+            snprintf(szOffset, sizeof(szOffset), " OFFSET %d", layer->startindex-1);
             select = msStringConcatenate(select, szOffset);
         }
 


### PR DESCRIPTION
There is an issue in the OGR driver regarding the OFFSET used in the query. It is based on the startindex parameter in the WFS request. In [this code](https://github.com/mapserver/mapserver/blob/e39cf5dd20c599fe8f87c24e2abe921902fa4a4d/mapwfs.c#L2889) the startindex is increased with one. In the postgis driver this is being compensated by doing a -1 on the startindex before using it as the OFFSET in the query. For the OGR driver this is omitted.