### PR TITLE
Add a new padding template format option

### DIFF
--- a/maptemplate.c
+++ b/maptemplate.c
@@ -1320,8 +1320,8 @@ static int processItemTag(layerObj *layer, char **line, shapeObj *shape)
           char *paddedValue = NULL;
           paddedValue = (char *) msSmallMalloc(paddedSize);
           snprintf(paddedValue, paddedSize, "%-*s", padding, tagValue);
-          tagValue = msStrdup(paddedValue);
-          msFree(paddedValue);
+          msFree(tagValue);
+          tagValue = paddedValue;
       }
 
       if(!tagValue) {

--- a/maptemplate.c
+++ b/maptemplate.c
@@ -1315,7 +1315,7 @@ static int processItemTag(layerObj *layer, char **line, shapeObj *shape)
       tagValue = msReplaceSubstring(tagValue, "$value", itemValue);
       msFree(itemValue);
 
-      if (padding != -1) {
+      if (padding > 0 && padding < 1000) {
           int paddedSize = strlen(tagValue) + padding + 1;
           char *paddedValue = NULL;
           paddedValue = (char *) msSmallMalloc(paddedSize);

--- a/maptemplate.c
+++ b/maptemplate.c
@@ -1207,7 +1207,7 @@ static int processItemTag(layerObj *layer, char **line, shapeObj *shape)
   const char *argValue=NULL;
 
   const char *name=NULL, *pattern=NULL;
-  const char *format=NULL, *nullFormat=NULL, *paddingFormatString = NULL;
+  const char *format=NULL, *nullFormat=NULL;
   int precision;
   int padding;
   int uc, lc, commify;
@@ -1224,7 +1224,6 @@ static int processItemTag(layerObj *layer, char **line, shapeObj *shape)
 
   while (tagStart) {
     format = "$value"; /* initialize the tag arguments */
-    paddingFormatString = "%-*s";
     nullFormat = "";
     precision = -1;
     padding = -1;
@@ -1317,10 +1316,10 @@ static int processItemTag(layerObj *layer, char **line, shapeObj *shape)
       msFree(itemValue);
 
       if (padding != -1) {
-          int paddedSize = sizeof(tagValue) + (padding * sizeof(char*));
+          int paddedSize = strlen(tagValue) + padding + 1;
           char *paddedValue = NULL;
-          paddedValue = (char *) msSmallMalloc(paddedSize + 1);
-          snprintf(paddedValue, paddedSize, paddingFormatString, padding, tagValue);
+          paddedValue = (char *) msSmallMalloc(paddedSize);
+          snprintf(paddedValue, paddedSize, "%-*s", padding, tagValue);
           tagValue = msStrdup(paddedValue);
           msFree(paddedValue);
       }

--- a/msautotest/query/expected/query_test013.txt
+++ b/msautotest/query/expected/query_test013.txt
@@ -1,0 +1,2 @@
+ST. LOUIS           :stlo      
+

--- a/msautotest/query/query.map
+++ b/msautotest/query/query.map
@@ -39,6 +39,9 @@
 # Test 12: simple mode=indexquery, one layer, index query 
 # RUN_PARMS: query_test012.txt [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=indexquery&mapext=420000+5120000+582000+5200000&qlayer=bdry_counpy2&shapeindex=5' > [RESULT_DEMIME]
 #
+# Test 13: simple mode=indexquery, one layer, index query, with formatting
+# RUN_PARMS: query_test012.txt [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=indexquery&mapext=420000+5120000+582000+5200000&qlayer=bdry_counpy2&shapeindex=5&qformat=formattmpl' > [RESULT_DEMIME]
+#
 
 MAP
   NAME 'query'
@@ -54,6 +57,13 @@ MAP
     DRIVER 'TEMPLATE'
     MIMETYPE 'text/html'
     FORMATOPTION "FILE=template/query.tmpl"
+  END
+
+  OUTPUTFORMAT
+    NAME 'formattmpl'
+    DRIVER 'TEMPLATE'
+    MIMETYPE 'text/html'
+    FORMATOPTION "FILE=template/query_formatted.tmpl"
   END
 
   LAYER

--- a/msautotest/query/query.map
+++ b/msautotest/query/query.map
@@ -40,7 +40,7 @@
 # RUN_PARMS: query_test012.txt [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=indexquery&mapext=420000+5120000+582000+5200000&qlayer=bdry_counpy2&shapeindex=5' > [RESULT_DEMIME]
 #
 # Test 13: simple mode=indexquery, one layer, index query, with formatting
-# RUN_PARMS: query_test012.txt [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=indexquery&mapext=420000+5120000+582000+5200000&qlayer=bdry_counpy2&shapeindex=5&qformat=formattmpl' > [RESULT_DEMIME]
+# RUN_PARMS: query_test013.txt [MAPSERV] QUERY_STRING='map=[MAPFILE]&mode=indexquery&mapext=420000+5120000+582000+5200000&qlayer=bdry_counpy2&shapeindex=5&qformat=formattmpl' > [RESULT_DEMIME]
 #
 
 MAP

--- a/msautotest/query/template/query_formatted.tmpl
+++ b/msautotest/query/template/query_formatted.tmpl
@@ -1,3 +1,3 @@
 <!-- MapServer Template -->
-[resultset layer="bdry_counpy2"][feature][item name="cty_name" padding="20" uc="true"]:[item name="cty_abbr" lc="true" padding="10"] [/feature][/resultset]
+[resultset layer="bdry_counpy2"][feature][item name="cty_name" padding="20" uc="true"]:[item name="cty_abbr" lc="true" padding="10"][/feature][/resultset]
 

--- a/msautotest/query/template/query_formatted.tmpl
+++ b/msautotest/query/template/query_formatted.tmpl
@@ -1,0 +1,3 @@
+<!-- MapServer Template -->
+[resultset layer="bdry_counpy2"][feature][item name="cty_name" padding="20" uc="true"]:[item name="cty_abbr" lc="true" padding="10"] [/feature][/resultset]
+


### PR DESCRIPTION
See #5889 - adds a new "padding" format option for fixed length strings in a template. 

Online testing in REPL at https://repl.it/repls/LeftSlimQuotient
Reviews of C code welcome, especially if variable declarations should be moved, and everything is created and freed correctly. 