### PR TITLE
WCS 1.0.0 server: Skip broken layers instead of a complete failure.

### DIFF
--- a/mapwcs.c
+++ b/mapwcs.c
@@ -905,9 +905,7 @@ static int msWCSGetCapabilities_ContentMetadata(mapObj *map, wcsParamsObj *param
         continue;
 
       if(msWCSGetCapabilities_CoverageOfferingBrief((GET_LAYER(map, i)), params, script_url_encoded) != MS_SUCCESS ) {
-        msIO_printf("</ContentMetadata>\n");
-        msFree(script_url_encoded);
-        return MS_FAILURE;
+        msIO_printf("  <!-- WARNING: There was a problem with one of layers. See server log for details. -->\n");
       }
     }
   }


### PR DESCRIPTION
When a WCS 1.0.0 GetCapabilities reply is made, a single failing layer (e.g. a wrong file name/path) will cause MapServer to truncate output of Capabilities document and list only thus far processed valid layers. This is strange choice as there is no error generated to indicate a failure and at the same time produced Capabilities document does not contain all valid layers. Thus the change causes Capabilities generator to just skip bad layer and continue with remaining layers.