### PR TITLE
Make default_ in VALIDATION block case insensitive

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -6907,7 +6907,7 @@ static void applyOutputFormatDefaultSubstitutions(outputFormatObj *format, const
     char *tmpfilename = msStrdup(filename);
     const char *default_key = msFirstKeyFromHashTable(table);
     while(default_key) {
-      if(!strncmp(default_key,"default_",8)) {
+      if(!strncasecmp(default_key,"default_",8)) {
         char *new_filename = NULL;
         size_t buffer_size = (strlen(default_key)-5);
         char *tag = (char *)msSmallMalloc(buffer_size);
@@ -6931,7 +6931,7 @@ static void applyClassDefaultSubstitutions(classObj *class, hashTableObj *table)
 {
   const char *default_key = msFirstKeyFromHashTable(table);
   while(default_key) {
-    if(!strncmp(default_key,"default_",8)) {
+    if(!strncasecmp(default_key,"default_",8)) {
       size_t buffer_size = (strlen(default_key)-5);
       char *tag = (char *)msSmallMalloc(buffer_size);
       snprintf(tag, buffer_size, "%%%s%%", &(default_key[8]));
@@ -6950,7 +6950,7 @@ static void applyLayerDefaultSubstitutions(layerObj *layer, hashTableObj *table)
   int i;
   const char *default_key = msFirstKeyFromHashTable(table);
   while(default_key) {
-    if(!strncmp(default_key,"default_",8)) {
+    if(!strncasecmp(default_key,"default_",8)) {
       size_t buffer_size = (strlen(default_key)-5);
       const char *to = msLookupHashTable(table, default_key);
       char *tag = (char *)msSmallMalloc(buffer_size);
@@ -6971,7 +6971,7 @@ static void applyHashTableDefaultSubstitutions(hashTableObj *hashTab, hashTableO
 {
 	const char *default_key = msFirstKeyFromHashTable(table);
 	while (default_key) {
-		if (!strncmp(default_key, "default_", 8)) {
+		if (!strncasecmp(default_key, "default_", 8)) {
 			size_t buffer_size = (strlen(default_key) - 5);
 			const char *to = msLookupHashTable(table, default_key);
 			char *tag = (char *)msSmallMalloc(buffer_size);

--- a/mapstring.c
+++ b/mapstring.c
@@ -1503,7 +1503,7 @@ char *msCommifyString(char *str)
 /* ------------------------------------------------------------------------------- */
 /*       Replace all occurrences of old with new in str.                           */
 /*       It is assumed that str was dynamically created using malloc.              */
-/*       Same function as msReplaceSubstring but this is case ins                  */
+/*       Same function as msReplaceSubstring but this is case insensitive          */
 /* ------------------------------------------------------------------------------- */
 char *msCaseReplaceSubstring(char *str, const char *old, const char *new)
 {

--- a/mapstring.c
+++ b/mapstring.c
@@ -1501,9 +1501,9 @@ char *msCommifyString(char *str)
 
 
 /* ------------------------------------------------------------------------------- */
-/*       Replace all occurances of old with new in str.                            */
+/*       Replace all occurrences of old with new in str.                           */
 /*       It is assumed that str was dynamically created using malloc.              */
-/*       Same function as msReplaceSubstring but this is case incensitive                        */
+/*       Same function as msReplaceSubstring but this is case ins                  */
 /* ------------------------------------------------------------------------------- */
 char *msCaseReplaceSubstring(char *str, const char *old, const char *new)
 {

--- a/msautotest/misc/expected/runtime_sub_test_caps.xml
+++ b/msautotest/misc/expected/runtime_sub_test_caps.xml
@@ -96,7 +96,7 @@ Content-Type: text/xml; charset=UTF-8
     <Layer queryable="0" opaque="0" cascaded="0">
       <Name>layer5b</Name>
 <!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
-      <Title>layer5</Title>
+      <Title>layer5b</Title>
       <EX_GeographicBoundingBox>
         <westBoundLongitude>1.10894</westBoundLongitude>
         <eastBoundLongitude>7.19753</eastBoundLongitude>
@@ -107,7 +107,7 @@ Content-Type: text/xml; charset=UTF-8
                   minx="123446" miny="4.76081e+06" maxx="801225" maxy="5.48737e+06" />
       <MetadataURL type="TC211">
         <Format>text/xml</Format>
-        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://foo/?request=GetMetadata&amp;layer=layer5"/>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://foo/?request=GetMetadata&amp;layer=layer5b"/>
       </MetadataURL>
     </Layer>
     <Layer queryable="0" opaque="0" cascaded="0">

--- a/msautotest/misc/expected/runtime_sub_test_caps.xml
+++ b/msautotest/misc/expected/runtime_sub_test_caps.xml
@@ -94,6 +94,23 @@ Content-Type: text/xml; charset=UTF-8
         </MetadataURL>
     </Layer>
     <Layer queryable="0" opaque="0" cascaded="0">
+      <Name>layer5b</Name>
+<!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
+      <Title>layer5</Title>
+      <EX_GeographicBoundingBox>
+        <westBoundLongitude>1.10894</westBoundLongitude>
+        <eastBoundLongitude>7.19753</eastBoundLongitude>
+        <southBoundLatitude>39.2727</southBoundLatitude>
+        <northBoundLatitude>44.1415</northBoundLatitude>
+      </EX_GeographicBoundingBox>
+      <BoundingBox CRS="EPSG:3857"
+                  minx="123446" miny="4.76081e+06" maxx="801225" maxy="5.48737e+06" />
+      <MetadataURL type="TC211">
+        <Format>text/xml</Format>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://foo/?request=GetMetadata&amp;layer=layer5"/>
+      </MetadataURL>
+    </Layer>
+    <Layer queryable="0" opaque="0" cascaded="0">
         <Name>layer6</Name>
 <!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
         <Title>layer6</Title>

--- a/msautotest/misc/expected/runtime_sub_test_caps.xml
+++ b/msautotest/misc/expected/runtime_sub_test_caps.xml
@@ -59,6 +59,16 @@ Content-Type: text/xml; charset=UTF-8
         </MetadataURL>
     </Layer>
     <Layer queryable="0" opaque="0" cascaded="0">
+        <Name>layer2</Name>
+<!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
+        <Title>layer2</Title>
+        <!-- WARNING: Optional Ex_GeographicBoundingBox could not be established for this layer.  Consider setting the EXTENT in the LAYER object, or wms_extent metadata. Also check that your data exists in the DATA statement -->
+        <MetadataURL type="TC211">
+          <Format>text/xml</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://foo/?request=GetMetadata&amp;layer=layer2"/>
+        </MetadataURL>
+    </Layer>    
+    <Layer queryable="0" opaque="0" cascaded="0">
         <Name>layer3</Name>
 <!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
         <Title>layer3</Title>

--- a/msautotest/misc/expected/runtime_sub_test_caps.xml
+++ b/msautotest/misc/expected/runtime_sub_test_caps.xml
@@ -109,7 +109,7 @@ Content-Type: text/xml; charset=UTF-8
           <Format>text/xml</Format>
           <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://foo/?request=GetMetadata&amp;layer=layer5b"/>
         </MetadataURL>
-    </Layer>    
+    </Layer>
     <Layer queryable="0" opaque="0" cascaded="0">
         <Name>layer6</Name>
 <!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->

--- a/msautotest/misc/expected/runtime_sub_test_caps.xml
+++ b/msautotest/misc/expected/runtime_sub_test_caps.xml
@@ -3,6 +3,8 @@ Content-Type: text/xml; charset=UTF-8
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://foo/?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
 
+<!-- MapServer version 7.4.2 OUTPUT=PNG OUTPUT=JPEG OUTPUT=KML SUPPORTS=PROJ SUPPORTS=AGG SUPPORTS=FREETYPE SUPPORTS=CAIRO SUPPORTS=SVG_SYMBOLS SUPPORTS=SVGCAIRO SUPPORTS=ICONV SUPPORTS=FRIBIDI SUPPORTS=WMS_SERVER SUPPORTS=WMS_CLIENT SUPPORTS=WFS_SERVER SUPPORTS=WFS_CLIENT SUPPORTS=WCS_SERVER SUPPORTS=SOS_SERVER SUPPORTS=FASTCGI SUPPORTS=THREADS SUPPORTS=GEOS SUPPORTS=PBF INPUT=JPEG INPUT=POSTGIS INPUT=OGR INPUT=GDAL INPUT=SHAPEFILE -->
+
 <Service>
   <Name>WMS</Name>
 <!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
@@ -57,16 +59,6 @@ Content-Type: text/xml; charset=UTF-8
         </MetadataURL>
     </Layer>
     <Layer queryable="0" opaque="0" cascaded="0">
-        <Name>layer2</Name>
-<!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
-        <Title>layer2</Title>
-        <!-- WARNING: Optional Ex_GeographicBoundingBox could not be established for this layer.  Consider setting the EXTENT in the LAYER object, or wms_extent metadata. Also check that your data exists in the DATA statement -->
-        <MetadataURL type="TC211">
-          <Format>text/xml</Format>
-          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://foo/?request=GetMetadata&amp;layer=layer2"/>
-        </MetadataURL>
-    </Layer>
-    <Layer queryable="0" opaque="0" cascaded="0">
         <Name>layer3</Name>
 <!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
         <Title>layer3</Title>
@@ -94,21 +86,21 @@ Content-Type: text/xml; charset=UTF-8
         </MetadataURL>
     </Layer>
     <Layer queryable="0" opaque="0" cascaded="0">
-      <Name>layer5b</Name>
+        <Name>layer5b</Name>
 <!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
-      <Title>layer5b</Title>
-      <EX_GeographicBoundingBox>
-        <westBoundLongitude>1.10894</westBoundLongitude>
-        <eastBoundLongitude>7.19753</eastBoundLongitude>
-        <southBoundLatitude>39.2727</southBoundLatitude>
-        <northBoundLatitude>44.1415</northBoundLatitude>
-      </EX_GeographicBoundingBox>
-      <BoundingBox CRS="EPSG:3857"
-                  minx="123446" miny="4.76081e+06" maxx="801225" maxy="5.48737e+06" />
-      <MetadataURL type="TC211">
-        <Format>text/xml</Format>
-        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://foo/?request=GetMetadata&amp;layer=layer5b"/>
-      </MetadataURL>
+        <Title>layer5b</Title>
+        <EX_GeographicBoundingBox>
+            <westBoundLongitude>1.10894</westBoundLongitude>
+            <eastBoundLongitude>7.19753</eastBoundLongitude>
+            <southBoundLatitude>39.2727</southBoundLatitude>
+            <northBoundLatitude>44.1415</northBoundLatitude>
+        </EX_GeographicBoundingBox>
+        <BoundingBox CRS="EPSG:3857"
+                    minx="123446" miny="4.76081e+06" maxx="801225" maxy="5.48737e+06" />
+        <MetadataURL type="TC211">
+          <Format>text/xml</Format>
+          <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://foo/?request=GetMetadata&amp;layer=layer5b"/>
+        </MetadataURL>
     </Layer>
     <Layer queryable="0" opaque="0" cascaded="0">
         <Name>layer6</Name>

--- a/msautotest/misc/expected/runtime_sub_test_caps.xml
+++ b/msautotest/misc/expected/runtime_sub_test_caps.xml
@@ -3,8 +3,6 @@ Content-Type: text/xml; charset=UTF-8
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://foo/?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
 
-<!-- MapServer version 7.4.2 OUTPUT=PNG OUTPUT=JPEG OUTPUT=KML SUPPORTS=PROJ SUPPORTS=AGG SUPPORTS=FREETYPE SUPPORTS=CAIRO SUPPORTS=SVG_SYMBOLS SUPPORTS=SVGCAIRO SUPPORTS=ICONV SUPPORTS=FRIBIDI SUPPORTS=WMS_SERVER SUPPORTS=WMS_CLIENT SUPPORTS=WFS_SERVER SUPPORTS=WFS_CLIENT SUPPORTS=WCS_SERVER SUPPORTS=SOS_SERVER SUPPORTS=FASTCGI SUPPORTS=THREADS SUPPORTS=GEOS SUPPORTS=PBF INPUT=JPEG INPUT=POSTGIS INPUT=OGR INPUT=GDAL INPUT=SHAPEFILE -->
-
 <Service>
   <Name>WMS</Name>
 <!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
@@ -67,7 +65,7 @@ Content-Type: text/xml; charset=UTF-8
           <Format>text/xml</Format>
           <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://foo/?request=GetMetadata&amp;layer=layer2"/>
         </MetadataURL>
-    </Layer>    
+    </Layer>
     <Layer queryable="0" opaque="0" cascaded="0">
         <Name>layer3</Name>
 <!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->
@@ -111,7 +109,7 @@ Content-Type: text/xml; charset=UTF-8
           <Format>text/xml</Format>
           <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://foo/?request=GetMetadata&amp;layer=layer5b"/>
         </MetadataURL>
-    </Layer>
+    </Layer>    
     <Layer queryable="0" opaque="0" cascaded="0">
         <Name>layer6</Name>
 <!-- WARNING: Mandatory metadata '..._title' was missing in this context. -->

--- a/msautotest/misc/runtime_sub.map
+++ b/msautotest/misc/runtime_sub.map
@@ -8,6 +8,7 @@
 # RUN_PARMS: runtime_sub_test004.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer3&name3=bdry_counpy2" > [RESULT_DEMIME]
 # RUN_PARMS: runtime_sub_test005.txt [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer3&name3=bad+value" > [RESULT_DEVERSION] [STRIP:ShapefileOpen]
 # RUN_PARMS: runtime_sub_test008.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer5" > [RESULT_DEMIME]
+# RUN_PARMS: runtime_sub_test008.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer5b" > [RESULT_DEMIME]
 # RUN_PARMS: runtime_sub_test009.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer6&eppl=40" > [RESULT_DEMIME]
 # RUN_PARMS: runtime_sub_test010.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer7&eppl=40" > [RESULT_DEMIME]
 # RUN_PARMS: runtime_sub_test011.png [MAPSERV] QUERY_STRING="map=[MAPFILE]&mode=map&layer=layer8&eppl2=40" > [RESULT_DEMIME]
@@ -99,7 +100,22 @@ MAP
       STYLE OUTLINECOLOR 51 51 51 END
     END
   END
-  
+
+  # default value - case-insensitive
+  LAYER
+    NAME 'layer5b'
+    STATUS OFF
+    DATA '../query/data/%name5%'
+    TYPE POLYGON
+    VALIDATION
+      'DEFAULT_NAME5' 'indx_q100kpy4'
+      'name5' 'bdry_counpy2|indx_q100kpy4'
+    END
+    CLASS
+      STYLE OUTLINECOLOR 51 51 51 END
+    END
+  END
+
   #class sub from class validation
   LAYER
     NAME 'layer6'


### PR DESCRIPTION
See #5895

* Pull request changes `strncmp` to `strncasecmp` in the relevant checks of "default_"
* Adds a new test and results using DEFAULT_
* Fixes a couple of typos in a string function comment

Can be squashed before merging. 