### PR TITLE
msGetThreadId(): fix for Windows

### DIFF
--- a/mapthread.c
+++ b/mapthread.c
@@ -273,18 +273,10 @@ void msThreadInit()
 /*                           msGetThreadId()                            */
 /************************************************************************/
 
-union voidStartDWORD
-{
-    void* ptr;
-    DWORD dword;
-};
-
 void* msGetThreadId()
 
 {
-  union voidStartDWORD u;
-  u.dword = GetCurrentThreadId();
-  return u.ptr;
+  return (void*) (size_t) GetCurrentThreadId();
 }
 
 /************************************************************************/


### PR DESCRIPTION
Revert partly https://github.com/mapserver/mapserver/commit/ba3d172764b6901c60e93eb4b51d2c17813161c1
Credits to @geographika for bisecting down to that commit.