### PR TITLE
Revert #5929 due to line endings

### DIFF
--- a/mapserver.h
+++ b/mapserver.h
@@ -579,7 +579,7 @@ extern "C" {
     char *filter;
     struct _CompositingFilter *next;
   } CompositingFilter;
-
+  
   typedef struct _LayerCompositer{
     CompositingOperation comp_op;
     int opacity;
@@ -769,7 +769,7 @@ extern "C" {
     colorObj *pixel; /* for raster layers */
     shapeObj *shape; /* for vector layers */
     double dblval; /* for map cellsize used by simplify */
-    double dblval2; /* for data cellsize */
+    double dblval2; /* for data cellsize */    
     expressionObj *expr; /* expression to be evaluated (contains tokens) */
     int type; /* type of parse: boolean, string/text or shape/geometry */
     parseResultObj result; /* parse result */
@@ -878,10 +878,10 @@ extern "C" {
     long tileindex;
     int clear_resultcache;
 
-    int  maxfeatures; /* global maxfeatures */
+    int  maxfeatures; /* global maxfeatures */    
     int  startindex;
     int  only_cache_result_count; /* set to 1 sometimes by WFS 2.0 GetFeature request */
-
+    
     expressionObj filter; /* by filter */
     char *filteritem;
 
@@ -1138,7 +1138,7 @@ extern "C" {
 
     labelLeaderObj *leader;
   };
-
+  
 #ifdef SWIG
 #ifdef	__cplusplus
 extern "C" {
@@ -1155,7 +1155,7 @@ typedef struct labelObj labelObj;
     lineObj *poly;
     rectObj bbox;
   } label_bounds;
-
+  
   typedef struct {
     labelObj *label;
     char *annotext;
@@ -1178,7 +1178,7 @@ typedef struct labelObj labelObj;
   /*                                                                      */
   /*      basic symbolization and classification information              */
   /************************************************************************/
-
+  
   struct classObj {
 #ifndef SWIG
     expressionObj expression; /* the expression to be matched */
@@ -1195,7 +1195,6 @@ typedef struct labelObj labelObj;
     %immutable;
 #endif
     int numstyles;
-    int numlabels;
 #ifdef SWIG
     %mutable;
 #endif
@@ -1204,8 +1203,10 @@ typedef struct labelObj labelObj;
     labelObj **labels;
     int maxlabels;
 #endif
+    int numlabels; /* should be immutable */
+
     char *name; /* should be unique within a layer */
-    char *title; /* used for legend labelling */
+    char *title; /* used for legend labeling */
 
 #ifndef SWIG
     expressionObj text;
@@ -1233,7 +1234,6 @@ typedef struct labelObj labelObj;
 #endif /* SWIG */
     int refcount;
     struct layerObj *layer;
-    labelLeaderObj *leader;
 #ifdef SWIG
     %mutable;
 #endif /* SWIG */
@@ -1242,6 +1242,7 @@ typedef struct labelObj labelObj;
     char *keyimage;
 
     char *group;
+    labelLeaderObj *leader;
   };
 
   /************************************************************************/
@@ -1574,7 +1575,7 @@ typedef struct labelObj labelObj;
     double maxscale;
     char *value;
   } scaleTokenEntryObj;
-
+  
   typedef struct {
      char *name;
      int n_entries;
@@ -1656,7 +1657,7 @@ typedef struct labelObj labelObj;
     scaleTokenObj *scaletokens;
     int numscaletokens;
     originalScaleTokenStrings *orig_st;
-
+    
 #endif
 
     char *data; /* filename, can be relative or full path */
@@ -1782,7 +1783,7 @@ typedef struct labelObj labelObj;
 #endif
     char *mask;
 
-#ifndef SWIG
+#ifndef SWIG    
     expressionObj _geomtransform;
 #endif
 
@@ -1796,7 +1797,7 @@ typedef struct labelObj labelObj;
 #ifndef SWIG
     sortByClause sortBy;
 #endif
-
+    
     LayerCompositer *compositer;
 
     hashTableObj connectionoptions;
@@ -2532,7 +2533,7 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   MS_DLL_EXPORT int msGraticuleLayerInitializeVirtualTable(layerObj *layer);
   MS_DLL_EXPORT int msRASTERLayerInitializeVirtualTable(layerObj *layer);
   MS_DLL_EXPORT int msUVRASTERLayerInitializeVirtualTable(layerObj *layer);
-  MS_DLL_EXPORT int msContourLayerInitializeVirtualTable(layerObj *layer);
+  MS_DLL_EXPORT int msContourLayerInitializeVirtualTable(layerObj *layer);  
   MS_DLL_EXPORT int msPluginLayerInitializeVirtualTable(layerObj *layer);
   MS_DLL_EXPORT int msUnionLayerInitializeVirtualTable(layerObj *layer);
   MS_DLL_EXPORT void msPluginFreeVirtualTableFactory(void);
@@ -2552,7 +2553,7 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   MS_DLL_EXPORT int msDrawQueryLayer(mapObj *map, layerObj *layer, imageObj *image);
   MS_DLL_EXPORT int msDrawWMSLayer(mapObj *map, layerObj *layer, imageObj *image);
   MS_DLL_EXPORT int msDrawWFSLayer(mapObj *map, layerObj *layer, imageObj *image);
-
+  
 #define MS_DRAWMODE_FEATURES    0x00001
 #define MS_DRAW_FEATURES(mode) (MS_DRAWMODE_FEATURES&(mode))
 #define MS_DRAWMODE_LABELS      0x00002
@@ -2697,7 +2698,7 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   MS_DLL_EXPORT unsigned char *msSaveImageBuffer(imageObj* image, int *size_ptr, outputFormatObj *format);
   MS_DLL_EXPORT shapeObj* msOffsetPolyline(shapeObj* shape, double offsetx, double offsety);
   MS_DLL_EXPORT int msMapSetLayerProjections(mapObj* map);
-
+  
   /* Functions to chnage the drawing order of the layers. */
   /* Defined in mapobject.c */
   MS_DLL_EXPORT int msMoveLayerUp(mapObj *map, int nLayerIndex);
@@ -2945,8 +2946,8 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   MS_DLL_EXPORT void msStyleSetGeomTransform(styleObj *s, char *transform);
   MS_DLL_EXPORT char *msStyleGetGeomTransform(styleObj *style);
 
-  MS_DLL_EXPORT int msGeomTransformShape(mapObj *map, layerObj *layer, shapeObj *shape);
-
+  MS_DLL_EXPORT int msGeomTransformShape(mapObj *map, layerObj *layer, shapeObj *shape);  
+  
   /* ==================================================================== */
   /*      end of prototypes for functions in mapgeomtransform.c                 */
   /* ==================================================================== */
@@ -2966,7 +2967,7 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   /*      prototypes for functions in mapsmoothing.c                      */
   /* ==================================================================== */
   MS_DLL_EXPORT shapeObj* msSmoothShapeSIA(shapeObj *shape, int ss, int si, char *preprocessing);
-
+  
   /* ==================================================================== */
   /*      end of prototypes for functions in mapsmoothing.c               */
   /* ==================================================================== */
@@ -2981,7 +2982,7 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   MS_DLL_EXPORT char* msV8GetFeatureStyle(mapObj *map, const char *filename,
                                           layerObj *layer, shapeObj *shape);
   MS_DLL_EXPORT shapeObj *msV8TransformShape(shapeObj *shape,
-                                             const char* filename);
+                                             const char* filename);  
 #endif
   /* ==================================================================== */
   /*      end of prototypes for functions in mapv8.cpp                    */
@@ -3111,10 +3112,10 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   int msSaveRasterBuffer(mapObj *map, rasterBufferObj *data, FILE *stream, outputFormatObj *format);
   int msSaveRasterBufferToBuffer(rasterBufferObj *data, bufferObj *buffer, outputFormatObj *format);
   int msLoadMSRasterBufferFromFile(char *path, rasterBufferObj *rb);
-
+  
   /* in mapagg.cpp */
   void msApplyBlurringCompositingFilter(rasterBufferObj *rb, unsigned int radius);
-
+  
   int WARN_UNUSED msApplyCompositingFilter(mapObj *map, rasterBufferObj *rb, CompositingFilter *filter);
 
   void msBufferInit(bufferObj *buffer);


### PR DESCRIPTION
Revert "Make numlabels and labelLeaderObj immutable (#5929)" due to line ending changes (thanks Visual Studio). 

This reverts commit 5a06fc84789bc2daf9f936dcaeacad382673f6ce.