### PR TITLE
Add setSymbolByName test

### DIFF
--- a/mapscript/python/tests/cases/style_test.py
+++ b/mapscript/python/tests/cases/style_test.py
@@ -90,7 +90,7 @@ class NewStylesTestCase(MapTestCase):
         assert class0.numstyles == 2, class0.numstyles
         new_style = mapscript.styleObj()
         new_style.color.setRGB(0, 0, 0)
-        new_style.symbol = 1
+        new_style.setSymbolByName(self.map, 'circle')
         new_style.size = 3
         index = class0.insertStyle(new_style)
         assert index == 2, index

--- a/mapserver.h
+++ b/mapserver.h
@@ -990,8 +990,6 @@ extern "C" {
     int rangeitemindex;
 
     int symbol;
-    char *symbolname;
-
     double size;
     double minsize, maxsize;
 

--- a/mapserver.h
+++ b/mapserver.h
@@ -962,6 +962,7 @@ extern "C" {
     %immutable;
 #endif /* SWIG */
     int refcount;
+    char *symbolname;
 #ifdef SWIG
     %mutable;
 #endif /* SWIG */


### PR DESCRIPTION
See mailing list post at [1]. Setting a style symbol name has no effect. This pull request makes it immutable and adds a test for the newer `setSymbolByName` as added in #1835

[1] https://lists.osgeo.org/pipermail/mapserver-users/2019-November/081492.html