### PR TITLE
Make numlabels and labelLeaderObj immutable

### DIFF
--- a/mapserver.h
+++ b/mapserver.h
@@ -1195,6 +1195,7 @@ typedef struct labelObj labelObj;
     %immutable;
 #endif
     int numstyles;
+    int numlabels;
 #ifdef SWIG
     %mutable;
 #endif
@@ -1203,10 +1204,8 @@ typedef struct labelObj labelObj;
     labelObj **labels;
     int maxlabels;
 #endif
-    int numlabels; /* should be immutable */
-
     char *name; /* should be unique within a layer */
-    char *title; /* used for legend labeling */
+    char *title; /* used for legend labelling */
 
 #ifndef SWIG
     expressionObj text;
@@ -1234,6 +1233,7 @@ typedef struct labelObj labelObj;
 #endif /* SWIG */
     int refcount;
     struct layerObj *layer;
+    labelLeaderObj *leader;
 #ifdef SWIG
     %mutable;
 #endif /* SWIG */
@@ -1242,7 +1242,6 @@ typedef struct labelObj labelObj;
     char *keyimage;
 
     char *group;
-    labelLeaderObj *leader;
   };
 
   /************************************************************************/


### PR DESCRIPTION
See comments at https://github.com/mapserver/mapserver/pull/5870#issuecomment-531785730

> 
>     Numlabels - or any similar counters - should be immutable. So following that logic numstyles should also be immutable.
>     Leader - no so sure about that one. Looks like styles and labels aren't even exposed to MapScript and users must work through the helper methods. Makes sense since they are arrays. 
