### PR TITLE
Add PHP typemap for gdBuffer. 

### DIFF
--- a/mapscript/phpng/php7module.i
+++ b/mapscript/phpng/php7module.i
@@ -3,3 +3,11 @@
   php_info_print_table_row(2, \"MapServer Version\", msGetVersion());
   php_info_print_table_end();
 "
+
+
+/* To support imageObj::getBytes */
+%typemap(out) gdBuffer {
+    RETVAL_STRINGL((const char*)$1.data, $1.size);
+    if( $1.owns_data )
+       msFree($1.data);
+}


### PR DESCRIPTION
This patch adds a SWIG typemap to return gdBuffer as a string in PHP, similar to the Python Mapscript behaviour (ref. RFC-16).  This fixes the bug reported in #5798, where PHP Mapscript msIO_getStdoutBufferBytes() returns a resource handle instead of the actual buffer.

