### PR TITLE
Include mserror.i and call msSetup() for PHP7 Swig mapscript

### DIFF
--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -197,7 +197,7 @@ typedef struct {
 ============================================================================
 */
 
-#if defined(SWIGCSHARP) || defined(SWIGJAVA) || defined(SWIGRUBY)
+#if defined(SWIGCSHARP) || defined(SWIGJAVA) || defined(SWIGRUBY) || defined(SWIGPHP7)
 %include "../mserror.i"
 #endif
 

--- a/mapscript/phpng/php7module.i
+++ b/mapscript/phpng/php7module.i
@@ -11,3 +11,20 @@
     if( $1.owns_data )
        msFree($1.data);
 }
+
+
+/* Module initialization: call msSetup() and register msCleanup() */
+%init %{
+    if (msSetup() != MS_SUCCESS)
+    {
+        msSetError(MS_MISCERR, "Failed to set up threads and font cache",
+                   "msSetup()");
+    }
+
+%}
+
+%mshutdown {
+    msCleanup();
+}
+
+


### PR DESCRIPTION
The default exception handling routines in mserror.i is missing if the only mapscript module defined is SWIGPHP7. This causes all mapscript errors to throw an uncathable 'E_ERROR' and quit php instead of throwing an exception.




