### PR TITLE
Backport pull request #5926 from master.

### DIFF
--- a/mapservutil.c
+++ b/mapservutil.c
@@ -1666,6 +1666,7 @@ int msCGIDispatchLegendIconRequest(mapservObj *mapserv)
     status = MS_FAILURE;
     goto li_cleanup;
   }
+  img->map = mapserv->map;
 
   /* drop this reference to output format */
   msApplyOutputFormat(&format, NULL, MS_NOOVERRIDE, MS_NOOVERRIDE, MS_NOOVERRIDE);


### PR DESCRIPTION
This fixes a segfault issue with mode=legendicon and certain conditions where the opaque pointer back to the parent mapObj is used, for instance when dealing with truetype symbols along a line.