### PR TITLE
Initialize status variable for cached WFS results

### DIFF
--- a/mapogroutput.c
+++ b/mapogroutput.c
@@ -895,7 +895,7 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
   /*      Process each layer with a resultset.                            */
   /* ==================================================================== */
   for( iLayer = 0; iLayer < map->numlayers; iLayer++ ) {
-    int status;
+    int status = 0;
     layerObj *layer = GET_LAYER(map, iLayer);
     shapeObj resultshape;
     OGRLayerH hOGRLayer;
@@ -1106,7 +1106,7 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
       if( layer->resultcache->results[i].shape )
       {
           /* msDebug("Using cached shape %ld\n", layer->resultcache->results[i].shapeindex); */
-          msCopyShape(layer->resultcache->results[i].shape, &resultshape);
+          status = msCopyShape(layer->resultcache->results[i].shape, &resultshape);
       }
       else
       {

--- a/mapogroutput.c
+++ b/mapogroutput.c
@@ -1110,16 +1110,17 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
       }
       else
       {
-        status = msLayerGetShape(layer, &resultshape, &(layer->resultcache->results[i]));
-        if(status != MS_SUCCESS) {
-            OGR_DS_Destroy( hDS );
-            msOGRCleanupDS( datasource_name );
-            msGMLFreeItems(item_list);
-            msFreeShape(&resultshape);
-            CSLDestroy(layer_options);
-            return status;
-        }
+          status = msLayerGetShape(layer, &resultshape, &(layer->resultcache->results[i]));
       }
+      
+      if(status != MS_SUCCESS) {
+          OGR_DS_Destroy( hDS );
+          msOGRCleanupDS( datasource_name );
+          msGMLFreeItems(item_list);
+          msFreeShape(&resultshape);
+          CSLDestroy(layer_options);
+          return status;
+      }      
 
       /*
       ** Perform classification, and some annotation related magic.


### PR DESCRIPTION
On Windows the following error is thrown in the debugger as the status variable was never set:

`Run-Time Check Failure #3 - The variable 'status' is being used without being initialized.`

This caused OGR output from a WFS cache to return:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">
  <ows:Exception exceptionCode="NoApplicableCode" locator="mapserv"/>
</ows:ExceptionReport>
```

This pull request initialises the variable at the top of the function (maybe unnecessary?), and also sets when retrieved from the cache using `msCopyShape`. 

See email thread at https://lists.osgeo.org/pipermail/mapserver-users/2020-January/081530.html