### PR TITLE
Add /w14701 compiler check for potentially uninitialized local variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -847,7 +847,7 @@ endif(UNIX)
 if (WIN32)
     ms_link_libraries( ${MS_EXTERNAL_LIBS} ws2_32.lib)
     if (MSVC)
-        set_target_properties(mapserver PROPERTIES COMPILE_FLAGS "/wd4267 /wd4244 /wd4018")
+        set_target_properties(mapserver PROPERTIES COMPILE_FLAGS "/wd4267 /wd4244 /wd4018 /w14701")
     endif(MSVC)
 endif (WIN32)
 


### PR DESCRIPTION
As per discussions in #5974 add in the compiler flag to check for uninitialized variables. See [C6001docs](https://docs.microsoft.com/en-us/visualstudio/code-quality/c6001?view=vs-2019) for details. Also [StackOverflow](https://stackoverflow.com/questions/2544805/vs-2008-compiler-option-for-flagging-uninitialized-variables). 

List of warnings as follows:

```
  \mapserver\mapservutil.c(1901): warning C4701: potentially uninitialized local variable 'execstarttime' used 
  \mapserver\mapservutil.c(1890): warning C4701: potentially uninitialized local variable 'requeststarttime' used 
  \mapserver\mapwmslayer.c(1002): warning C4701: potentially uninitialized local variable 'bbox_height' used 
  \mapserver\mapwmslayer.c(1002): warning C4701: potentially uninitialized local variable 'bbox_width' used 
  \mapserver\mapwmslayer.c(1216): warning C4701: potentially uninitialized local variable 'bbox' used 
  \mapserver\mapwms.c(822): warning C4701: potentially uninitialized local variable 'numranges' used 
  \mapserver\mapwms.c(824): warning C4701: potentially uninitialized local variable 'numonerange' used 
  \mapserver\mapchart.c(540): warning C4701: potentially uninitialized local variable 'barMaxVal' used 
  \mapserver\mapchart.c(540): warning C4701: potentially uninitialized local variable 'barMinVal' used 
  \mapserver\mapchart.c(421): warning C4701: potentially uninitialized local variable 'diameter' used 
  \mapserver\mapchart.c(403): warning C4701: potentially uninitialized local variable 'maxvalue' used 
  \mapserver\mapchart.c(401): warning C4701: potentially uninitialized local variable 'minvalue' used 
  \mapserver\mapchart.c(404): warning C4701: potentially uninitialized local variable 'maxdiameter' used 
  \mapserver\mapimageio.c(422): warning C4701: potentially uninitialized local variable 'a' used 
  \mapserver\mapdraw.c(2350): warning C4701: potentially uninitialized local variable 'ts' used 
  \mapserver\mapdraw.c(2373): warning C4701: potentially uninitialized local variable 'lbounds' used 
  \mapserver\mapdraw.c(2395): warning C4701: potentially uninitialized local variable 'p' used 
  \mapserver\mapdraw.c(3484): warning C4701: potentially uninitialized local variable 'starttime' used 
  \mapserver\mapdraw.c(3428): warning C4701: potentially uninitialized local variable 'labelpoly_bounds' used 
  \mapserver\mapdraw.c(583): warning C4701: potentially uninitialized local variable 'mapstarttime' used 
  \mapserver\mapdraw.c(343): warning C4701: potentially uninitialized local variable 'starttime' used 
  \mapserver\mapprimitive.c(1024): warning C4701: potentially uninitialized local variable 'x0' used 
  \mapserver\mapprimitive.c(1025): warning C4701: potentially uninitialized local variable 'y0' used 
  \mapserver\mapresample.c(1497): warning C4701: potentially uninitialized local variable 'sSrcExtent' used 
  \mapserver\mapmetadata.c(365): warning C4701: potentially uninitialized local variable 'n' used 
  \mapserver\mapfile.c(6458): warning C4701: potentially uninitialized local variable 'starttime' used 
  \mapserver\mapfile.c(6580): warning C4701: potentially uninitialized local variable 'starttime' used 
  \mapserver\mapogcfilter.c(1280): warning C4701: potentially uninitialized local variable 'sBox' used 
  \mapserver\maprasterquery.c(1366): warning C4701: potentially uninitialized local variable 'nXSize' used 
  \mapserver\maprasterquery.c(1360): warning C4701: potentially uninitialized local variable 'nYSize' used 
  \mapserver\maprasterquery.c(1010): warning C4701: potentially uninitialized local variable 'previous_maxresults' used 
  \mapserver\mapuvraster.c(876): warning C4701: potentially uninitialized local variable 'nXSize' used 
  \mapserver\mapuvraster.c(870): warning C4701: potentially uninitialized local variable 'nYSize' used 
  \mapserver\mapuvraster.c(642): warning C4701: potentially uninitialized local variable 'oldLayerExtent' used 
  \mapserver\mapuvraster.c(643): warning C4701: potentially uninitialized local variable 'oldLayerProjection' used 
  \mapserver\mapdrawgdal.c(2137): warning C4701: potentially uninitialized local variable 'starttime' used 
  \mapserver\maputil.c(996): warning C4701: potentially uninitialized local variable 'starttime' used 
  \mapserver\maputil.c(2719): warning C4701: potentially uninitialized local variable 'dX0' used 
  \mapserver\maputil.c(2720): warning C4701: potentially uninitialized local variable 'dY0' used 
  \mapserver\maputil.c(1897): warning C4701: potentially uninitialized local variable 'old_pt' used 
  \mapserver\mapscale.c(283): warning C4701: potentially uninitialized local variable 'strokeStyle' used
``` 
 
