### PR TITLE
Updates to build MapScript with SWIG 4.0.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,17 +7,21 @@ image: Visual Studio 2017
 cache:
   - '%LOCALAPPDATA%\pip\Cache'
   - '%APPVEYOR_BUILD_FOLDER%\swigwin-3.0.12.zip'
-
+  - '%APPVEYOR_BUILD_FOLDER%\swigwin-4.0.1.zip'
+  
 environment:
   # VS 2017
   VS_VERSION: Visual Studio 15 2017
   matrix:
   - platform: x86
     PYTHON_EXECUTABLE: c:/python27/python.exe
+    SWIG_VERSION: swigwin-3.0.12
   - platform: x64
     PYTHON_EXECUTABLE: c:/python27-x64/python.exe
+    SWIG_VERSION: swigwin-4.0.1    
   - platform: x64
     PYTHON_EXECUTABLE: c:/python36-x64/python.exe
+    SWIG_VERSION: swigwin-4.0.1    
 
 matrix:
   fast_finish: true
@@ -33,13 +37,13 @@ build_script:
   - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars64.bat"
   - if "%platform%" == "x86" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars32.bat"
   - echo "%VS_FULL%"
-  - if not exist swigwin-3.0.12.zip appveyor DownloadFile https://sourceforge.net/projects/swig/files/swigwin/swigwin-3.0.12/swigwin-3.0.12.zip
+  - if not exist %SWIG_VERSION%.zip appveyor DownloadFile https://sourceforge.net/projects/swig/files/swigwin/%SWIG_VERSION%/%SWIG_VERSION%.zip
   - set SDK_ZIP=%SDK%-dev.zip
   - set SDK_URL=http://download.gisinternals.com/sdk/downloads/%SDK_ZIP%
   - echo "%SDK_ZIP%"
   - echo "%SDK_URL%"
   - mkdir sdk
-  - 7z x swigwin-3.0.12.zip -osdk > nul
+  - 7z x %SWIG_VERSION%.zip -osdk > nul
   - cd sdk
   - appveyor DownloadFile "%SDK_URL%"
   - 7z x "%SDK_ZIP%" > nul
@@ -47,7 +51,7 @@ build_script:
   - set SDK_INC=%BUILD_FOLDER%/sdk/%SDK%/include
   - set SDK_LIB=%BUILD_FOLDER%/sdk/%SDK%/lib
   - set SDK_BIN=%BUILD_FOLDER%/sdk/%SDK%/bin
-  - set SWIG_EXECUTABLE=%BUILD_FOLDER%/sdk/swigwin-3.0.12/swig.exe
+  - set SWIG_EXECUTABLE=%BUILD_FOLDER%/sdk/%SWIG_VERSION%/swig.exe
   - set REGEX_DIR=%BUILD_FOLDER%/sdk/regex-0.12
   - if "%platform%" == "x86" SET PYTHON_EXECUTABLE=c:/python27/python.exe
   - if "%platform%" == "x64" SET PYTHON_EXECUTABLE=c:/python27-x64/python.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,13 +15,13 @@ environment:
   matrix:
   - platform: x86
     PYTHON_EXECUTABLE: c:/python27/python.exe
-    SWIG_VERSION: swigwin-3.0.12
+    SWIG_VER: swigwin-3.0.12
   - platform: x64
     PYTHON_EXECUTABLE: c:/python27-x64/python.exe
-    SWIG_VERSION: swigwin-4.0.1    
+    SWIG_VER: swigwin-4.0.1    
   - platform: x64
     PYTHON_EXECUTABLE: c:/python36-x64/python.exe
-    SWIG_VERSION: swigwin-4.0.1    
+    SWIG_VER: swigwin-4.0.1    
 
 matrix:
   fast_finish: true
@@ -37,13 +37,13 @@ build_script:
   - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars64.bat"
   - if "%platform%" == "x86" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars32.bat"
   - echo "%VS_FULL%"
-  - if not exist %SWIG_VERSION%.zip appveyor DownloadFile https://sourceforge.net/projects/swig/files/swigwin/%SWIG_VERSION%/%SWIG_VERSION%.zip
+  - if not exist %SWIG_VER%.zip appveyor DownloadFile https://sourceforge.net/projects/swig/files/swigwin/%SWIG_VER%/%SWIG_VER%.zip
   - set SDK_ZIP=%SDK%-dev.zip
   - set SDK_URL=http://download.gisinternals.com/sdk/downloads/%SDK_ZIP%
   - echo "%SDK_ZIP%"
   - echo "%SDK_URL%"
   - mkdir sdk
-  - 7z x %SWIG_VERSION%.zip -osdk > nul
+  - 7z x %SWIG_VER%.zip -osdk > nul
   - cd sdk
   - appveyor DownloadFile "%SDK_URL%"
   - 7z x "%SDK_ZIP%" > nul
@@ -51,7 +51,7 @@ build_script:
   - set SDK_INC=%BUILD_FOLDER%/sdk/%SDK%/include
   - set SDK_LIB=%BUILD_FOLDER%/sdk/%SDK%/lib
   - set SDK_BIN=%BUILD_FOLDER%/sdk/%SDK%/bin
-  - set SWIG_EXECUTABLE=%BUILD_FOLDER%/sdk/%SWIG_VERSION%/swig.exe
+  - set SWIG_EXECUTABLE=%BUILD_FOLDER%/sdk/%SWIG_VER%/swig.exe
   - set REGEX_DIR=%BUILD_FOLDER%/sdk/regex-0.12
   - if "%platform%" == "x86" SET PYTHON_EXECUTABLE=c:/python27/python.exe
   - if "%platform%" == "x64" SET PYTHON_EXECUTABLE=c:/python27-x64/python.exe

--- a/mapscript/csharp/swig_csharp_extensions.i
+++ b/mapscript/csharp/swig_csharp_extensions.i
@@ -224,28 +224,28 @@
   }
 %}
 
-%typemap(csfinalize) SWIGTYPE %{
-  /* %typemap(csfinalize) SWIGTYPE */
-  ~$csclassname() {
-    Dispose();
-  }
-%}
+//%typemap(csfinalize) SWIGTYPE %{
+//  /* %typemap(csfinalize) SWIGTYPE */
+//  ~$csclassname() {
+//    Dispose();
+//  }
+//%}
 
 %typemap(csconstruct, excode=SWIGEXCODE) SWIGTYPE %{: this($imcall, true, null) {$excode
   }
 %}
 
-%typemap(csdestruct, methodname="Dispose", methodmodifiers="public") SWIGTYPE {
-  lock(this) {
-      if(swigCPtr.Handle != System.IntPtr.Zero && swigCMemOwn) {
-        swigCMemOwn = false;
-        $imcall;
-      }
-      swigCPtr = new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
-      swigParentRef = null;
-      System.GC.SuppressFinalize(this);
-    }
-  }
+//%typemap(csdestruct, methodname="Dispose", methodmodifiers="public") SWIGTYPE {
+//  lock(this) {
+//      if(swigCPtr.Handle != System.IntPtr.Zero && swigCMemOwn) {
+//        swigCMemOwn = false;
+//        $imcall;
+//      }
+//      swigCPtr = new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
+//      swigParentRef = null;
+//      System.GC.SuppressFinalize(this);
+//    }
+//  }
 
 %typemap(csdestruct_derived, methodname="Dispose", methodmodifiers="public") TYPE {
   lock(this) {

--- a/mapscript/csharp/swig_csharp_extensions.i
+++ b/mapscript/csharp/swig_csharp_extensions.i
@@ -224,28 +224,32 @@
   }
 %}
 
-//%typemap(csfinalize) SWIGTYPE %{
-//  /* %typemap(csfinalize) SWIGTYPE */
-//  ~$csclassname() {
-//    Dispose();
-//  }
-//%}
+#if SWIG_VERSION < 0x040000
+%typemap(csfinalize) SWIGTYPE %{
+  /* %typemap(csfinalize) SWIGTYPE */
+  ~$csclassname() {
+    Dispose();
+  }
+%}
+#endif
 
 %typemap(csconstruct, excode=SWIGEXCODE) SWIGTYPE %{: this($imcall, true, null) {$excode
   }
 %}
 
-//%typemap(csdestruct, methodname="Dispose", methodmodifiers="public") SWIGTYPE {
-//  lock(this) {
-//      if(swigCPtr.Handle != System.IntPtr.Zero && swigCMemOwn) {
-//        swigCMemOwn = false;
-//        $imcall;
-//      }
-//      swigCPtr = new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
-//      swigParentRef = null;
-//      System.GC.SuppressFinalize(this);
-//    }
-//  }
+#if SWIG_VERSION < 0x040000
+%typemap(csdestruct, methodname="Dispose", methodmodifiers="public") SWIGTYPE {
+  lock(this) {
+      if(swigCPtr.Handle != System.IntPtr.Zero && swigCMemOwn) {
+        swigCMemOwn = false;
+        $imcall;
+      }
+      swigCPtr = new System.Runtime.InteropServices.HandleRef(null, System.IntPtr.Zero);
+      swigParentRef = null;
+      System.GC.SuppressFinalize(this);
+    }
+  }
+#endif
 
 %typemap(csdestruct_derived, methodname="Dispose", methodmodifiers="public") TYPE {
   lock(this) {

--- a/mapscript/python/pyextend.i
+++ b/mapscript/python/pyextend.i
@@ -13,6 +13,7 @@
  *
  *****************************************************************************/
 
+
 /* fromstring: Factory for mapfile objects */
 
 %pythoncode %{
@@ -222,18 +223,16 @@ def fromstring(data, mappath=None):
                         }
                     }
 
-        def getItemDefinitions(self):
+        @property
+        def itemdefinitions(self):
             return self._item_definitions
 
-        def setItemDefinitions(self, item_definitions):
+        @itemdefinitions.setter
+        def itemdefinitions(self, item_definitions):
             self._item_definitions = item_definitions
-
-        __swig_getmethods__["itemdefinitions"] = getItemDefinitions
-        __swig_setmethods__["itemdefinitions"] = setItemDefinitions
 
 %}
 }
-
 
 /******************************************************************************
  * Extensions to mapObj
@@ -425,24 +424,13 @@ def fromstring(data, mappath=None):
         memcpy( *argout, self->pattern, sizeof(double) * *pnListSize);
     }
 
-    void patternlength_set2(int patternlength)
-    {
-        msSetError(MS_MISCERR, "pattern is read-only", "patternlength_set()");
-    }
 
 %pythoncode %{
 
-    __swig_setmethods__["patternlength"] = _mapscript.styleObj_patternlength_set2
-    __swig_getmethods__["patternlength"] = _mapscript.styleObj_patternlength_get
-    if _newclass:patternlength = _swig_property(_mapscript.styleObj_patternlength_get, _mapscript.styleObj_patternlength_set2)
+pattern = property(pattern_get, pattern_set)
 
-    __swig_setmethods__["pattern"] = _mapscript.styleObj_pattern_set
-    __swig_getmethods__["pattern"] = _mapscript.styleObj_pattern_get
-    if _newclass:pattern = _swig_property(_mapscript.styleObj_pattern_get, _mapscript.styleObj_pattern_set)
 %}
-
 }
-
 
 /******************************************************************************
  * Extensions to hashTableObj - add dict methods

--- a/mapscript/python/pymodule.i
+++ b/mapscript/python/pymodule.i
@@ -17,7 +17,7 @@
  *****************************************************************************/
 
 /* Translates Python None to C NULL for strings */
-%typemap(in,parse="z") char * "";
+//%typemap(in,parse="z") char * "";
 
 /* To support imageObj::getBytes */
 %typemap(out) gdBuffer {
@@ -250,33 +250,15 @@ MapServerError = _mapscript.MapServerError
 MapServerChildError = _mapscript.MapServerChildError
 %}
 
-/* The bogus "if 1:" is to introduce a new scope to work around indentation
-   handling with pythonappend in different versions.  (#3180) */
-%feature("pythonappend") layerObj %{if 1:
-            self.p_map=None
-            try:
-                # python 2.5
-                if args and len(args)!=0: 
-                    self.p_map=args[0]
-            except NameError:
-                # python 2.6
-                if map: 
-                    self.p_map=map
-       %}
+%feature("pythonappend") layerObj %{
+    self.p_map = None
+    if map: 
+        self.p_map = map%}
 
-/* The bogus "if 1:" is to introduce a new scope to work around indentation
-   handling with pythonappend in different versions. (#3180) */
-%feature("pythonappend") classObj %{if 1:
-            self.p_layer =None
-            try:
-                # python 2.5
-                if args and len(args)!=0: 
-                    self.p_layer=args[0]
-            except NameError:
-                # python 2.6
-                if layer: 
-                    self.p_layer=layer
-       %}
+%feature("pythonappend") classObj %{
+    self.p_layer = None
+    if layer: 
+        self.p_layer = layer%}
 
 %feature("shadow") insertClass %{
     def insertClass(*args):

--- a/mapscript/python/tests/cases/style_test.py
+++ b/mapscript/python/tests/cases/style_test.py
@@ -175,6 +175,53 @@ class NewStylesTestCase(MapTestCase):
         self.assertRaises(mapscript.MapServerChildError,
                           class0.insertStyle, None)
 
+    def testPattern(self):
+        """See https://github.com/mapserver/mapserver/issues/4943"""
+
+        si = mapscript.styleObj()
+        assert si.pattern == ()
+        assert si.patternlength == 0
+
+    def testPattern2(self):
+
+        si = mapscript.styleObj()
+        si.pattern = [2.0, 3, 4]
+        assert si.pattern == (2.0, 3.0, 4.0)
+        assert si.patternlength == 3
+
+    def testPattern3(self):
+        """a pattern must have at least 2 elements"""
+
+        si = mapscript.styleObj()
+        exception = None
+        try:
+            si.pattern = [1.0]
+        except Exception:
+            exception = True
+        assert exception is True
+
+    def testPattern4(self):
+        """a pattern can have a max of 10 elements
+        This is set in mapsymbol.h with #define MS_MAXPATTERNLENGTH 10"""
+
+        si = mapscript.styleObj()
+        exception = None
+        try:
+            si.pattern = [i for i in range(11)]
+        except Exception:
+            exception = True
+        assert exception is True
+
+    def testPattern5(self):
+        """pattern length is read-only"""
+        si = mapscript.styleObj()
+        exception = None
+        try:
+            si.patternlength = 0
+        except Exception:
+            exception = True
+        assert exception is True
+
 
 class BrushCachingTestCase(MapTestCase):
 

--- a/msautotest/mspython/test_bug_check.py
+++ b/msautotest/mspython/test_bug_check.py
@@ -85,36 +85,6 @@ def test_bug_673():
 
     pmstestlib.compare_and_report( 'bug673.png', this_path = os.path.dirname(__file__) )
 
-###############################################################################
-# Test https://github.com/mapserver/mapserver/issues/4943
-
-def test_pattern():
-
-    si = mapscript.styleObj()
-    assert len(si.pattern) == 0
-    assert si.patternlength == 0
-
-    si.pattern = [2.0,3,4]
-    assert si.pattern == (2.0, 3.0, 4.0)
-    assert si.patternlength == 3
-
-    try:
-        si.pattern = [1.0]
-        assert False
-    except mapscript.MapServerError:
-        pass
-
-    try:
-        si.pattern = [i for i in range(11)]
-        assert False
-    except mapscript.MapServerError:
-        pass
-
-    try:
-        si.patternlength = 0
-        assert False
-    except mapscript.MapServerError:
-        pass
 
 ###############################################################################
 # Test reprojection of lines from Polar Stereographic and crossing the antimerdian


### PR DESCRIPTION
See issue #5982

- Python test suite now passes when built with SWIG 4.0.1 with this pull request. 
- Appveyor checks Python with both SWIG 3.0.12 (in the x32 build) and SWIG 4.0.1
- C# binding code commented out to successfully build, but I'm unsure if there are any unwanted side-effects
- PHP and Perl are built and tested on Travis so this will need updating to check these are working
