### PR TITLE
[WIP] Limit SQL Select to required fields

### DIFF
--- a/maplayer.c
+++ b/maplayer.c
@@ -990,7 +990,7 @@ int msLayerWhichItems(layerObj *layer, int get_all, const char *metadata)
       for(i=0; i<n; i++) {
         bFound = 0;
         for(j=0; j<layer->numitems; j++) {
-          if(strcmp(tokens[i], layer->items[j]) == 0) {
+          if(strcasecmp(tokens[i], layer->items[j]) == 0) {
             bFound = 1;
             break;
           }

--- a/mapquery.c
+++ b/mapquery.c
@@ -1116,7 +1116,17 @@ int msQueryByRect(mapObj *map)
     msLayerEnablePaging(lp, paging);
 
     /* build item list, we want *all* items */
-    status = msLayerWhichItems(lp, MS_TRUE, NULL);
+    /* change to just get selected items */
+    const char *value = NULL;
+    value = msOWSLookupMetadata(&(lp->metadata), "G", "include_items");
+
+    if(value){
+        status = msLayerWhichItems(lp, MS_FALSE, value);
+    }
+    else {
+        status = msLayerWhichItems(lp, MS_TRUE, NULL);
+    }
+
     if(status != MS_SUCCESS) {
       msFreeShape(&searchshape);
       return(MS_FAILURE);

--- a/mapquery.c
+++ b/mapquery.c
@@ -1116,15 +1116,15 @@ int msQueryByRect(mapObj *map)
     msLayerEnablePaging(lp, paging);
 
     const char *value = NULL;
-    value = msOWSLookupMetadata(&(lp->metadata), "G", "include_items");
+    value = msOWSLookupMetadata(&(lp->metadata), "G", "select_items");
 
-    if(!value || strcasecmp(value, "all") == 0){
-        /* build item list, we want *all* items */
-        status = msLayerWhichItems(lp, MS_TRUE, NULL);
-    }
-    else {
+    if(value){
         /* get only selected items */
         status = msLayerWhichItems(lp, MS_FALSE, value);
+    }
+    else {
+        /* build item list, we want *all* items */
+        status = msLayerWhichItems(lp, MS_TRUE, NULL);
     }
 
     if(status != MS_SUCCESS) {

--- a/mapquery.c
+++ b/mapquery.c
@@ -1118,7 +1118,7 @@ int msQueryByRect(mapObj *map)
     const char *value = NULL;
     value = msOWSLookupMetadata(&(lp->metadata), "G", "include_items");
 
-    if(!value || value == "all"){
+    if(!value || strcasecmp(value, "all") == 0){
         /* build item list, we want *all* items */
         status = msLayerWhichItems(lp, MS_TRUE, NULL);
     }

--- a/mapquery.c
+++ b/mapquery.c
@@ -1115,16 +1115,16 @@ int msQueryByRect(mapObj *map)
     }
     msLayerEnablePaging(lp, paging);
 
-    /* build item list, we want *all* items */
-    /* change to just get selected items */
     const char *value = NULL;
     value = msOWSLookupMetadata(&(lp->metadata), "G", "include_items");
 
-    if(value){
-        status = msLayerWhichItems(lp, MS_FALSE, value);
+    if(!value || value == "all"){
+        /* build item list, we want *all* items */
+        status = msLayerWhichItems(lp, MS_TRUE, NULL);
     }
     else {
-        status = msLayerWhichItems(lp, MS_TRUE, NULL);
+        /* get only selected items */
+        status = msLayerWhichItems(lp, MS_FALSE, value);
     }
 
     if(status != MS_SUCCESS) {

--- a/mapwfs.c
+++ b/mapwfs.c
@@ -2527,9 +2527,8 @@ this request. Check wfs/ows_enable_request settings.", "msWFSGetFeature()",
         lp = GET_LAYER(map, j);
         if (lp->status == MS_ON) {
           if(paramsObj->pszPropertyName){
-            // override gml_items with properties passed in
-            // possible security risk?
-            msInsertHashTable(&(lp->metadata), "gml_include_items", paramsObj->pszPropertyName);
+            // add a new gml_select_items properties with only fields to be used for a selection
+            msInsertHashTable(&(lp->metadata), "gml_select_items", paramsObj->pszPropertyName);
           }
           int status = msWFSRunBasicGetFeature(map, lp, paramsObj, nWFSVersion);
           if( status != MS_SUCCESS )

--- a/mapwfs.c
+++ b/mapwfs.c
@@ -2528,8 +2528,7 @@ this request. Check wfs/ows_enable_request settings.", "msWFSGetFeature()",
         if (lp->status == MS_ON) {
           if(paramsObj->pszPropertyName){
             // override gml_items with properties passed in
-            // security risk!
-            //if( msOWSLookupMetadata(&(layer->metadata), "G", "type") == NULL
+            // possible security risk?
             msInsertHashTable(&(lp->metadata), "gml_include_items", paramsObj->pszPropertyName);
           }
           int status = msWFSRunBasicGetFeature(map, lp, paramsObj, nWFSVersion);

--- a/mapwfs.c
+++ b/mapwfs.c
@@ -2526,6 +2526,12 @@ this request. Check wfs/ows_enable_request settings.", "msWFSGetFeature()",
         layerObj *lp;
         lp = GET_LAYER(map, j);
         if (lp->status == MS_ON) {
+          if(paramsObj->pszPropertyName){
+            // override gml_items with properties passed in
+            // security risk!
+            //if( msOWSLookupMetadata(&(layer->metadata), "G", "type") == NULL
+            msInsertHashTable(&(lp->metadata), "gml_include_items", paramsObj->pszPropertyName);
+          }
           int status = msWFSRunBasicGetFeature(map, lp, paramsObj, nWFSVersion);
           if( status != MS_SUCCESS )
               return status;


### PR DESCRIPTION
A WFS LAYER can be configured with "gml_include_items" "all" to allow maximum flexibility for the client. A WFS request allows a propertyName parameter to be passed via the query string to only return data for the requested fields e.g. &propertyName=ogr_fid,name will return features with only these 2 attributes. This greatly reduces the amount of data transferred to the client. 
However the database query itself still selects data for all fields for the layer (confirmed in both the MSSQL and PostGIS drivers). 

Selecting only the propertyName fields in the query can have a huge effect on the database query time, especially for layers which have 10s of fields, but where each request may only require 5-6 fields at any one time. In my test case 13,000 records with 50 fields takes 12 seconds compared to running instantly for 5 fields. 

This is a proposed draft approach to limiting the number of fields used in a database select statement. As it currently is it has a number of issues (as reflected in the failing tests):

- The case-sensitivity of fields is affected
- The order fields are returned is affected
- Older style query templates miss data as they do not use the "gml_include_items" metadata value

Further discussions are in the [dev mailing list thread](https://lists.osgeo.org/pipermail/mapserver-dev/2020-February/016082.html). 

I also found this related RFC: https://mapserver.org/id/development/rfc/ms-rfc-33.html

