### PR TITLE
msautotest: in --strict mode, as run by the CI, make absence of expected file an error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-AUTOTEST_OPTS?=--strict
+AUTOTEST_OPTS?=--strict_mode
 PHP_MAPSCRIPT=build/mapscript/php/php_mapscript.so
 PYTHON_MAPSCRIPT_PATH=build/mapscript/python
 JAVA_MAPSCRIPT_PATH=build/mapscript/java

--- a/msautotest/pymod/mstestlib.py
+++ b/msautotest/pymod/mstestlib.py
@@ -712,6 +712,9 @@ def _run(map, out_file, command, extra_args):
         return False, ('no result file generated', map, out_file)
 
     elif cmp == 'noexpected':
+        if strict:
+            return False, ('no existing file expected/' + out_file)
+
         if not quiet:
             print('     no expected file exists, accepting result as expected.')
         else:


### PR DESCRIPTION
Should address remark of https://github.com/mapserver/mapserver/pull/6000#issue-381070490