### PR TITLE
mappostgis: restore case insensitive comparisons for 'using unique' in DATA

### DIFF
--- a/mappostgis.cpp
+++ b/mappostgis.cpp
@@ -1159,12 +1159,12 @@ static int msPostGISParseData(layerObj *layer)
     for ( tmp = pos_use_2nd + 5; *tmp == ' '; tmp++ )
     {
     }
-    if ( strncmp ( tmp, "unique ", 7 ) == 0 ) {
+    if ( strncasecmp ( tmp, "unique ", 7 ) == 0 ) {
       for ( pos_uid = tmp + 7; *pos_uid == ' '; pos_uid++ )
       {
       }
     }
-    if ( strncmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
+    if ( strncasecmp ( tmp, "srid=", 5 ) == 0 ) pos_srid = tmp + 5;
   }
 
   /*
@@ -1176,7 +1176,7 @@ static int msPostGISParseData(layerObj *layer)
     for ( tmp = pos_use_1st + 5; *tmp == ' '; tmp++ )
     {
     }
-    if ( strncmp ( tmp, "unique ", 7 ) == 0 )
+    if ( strncasecmp ( tmp, "unique ", 7 ) == 0 )
     {
       if ( pos_uid )
       {
@@ -1187,7 +1187,7 @@ static int msPostGISParseData(layerObj *layer)
       {
       }
     }
-    if ( strncmp ( tmp, "srid=", 5 ) == 0 )
+    if ( strncasecmp ( tmp, "srid=", 5 ) == 0 )
     {
       if ( pos_srid )
       {

--- a/msautotest/mspython/test_postgis.py
+++ b/msautotest/mspython/test_postgis.py
@@ -167,6 +167,7 @@ def test_postgis_invalid_data(data):
 @pytest.mark.parametrize("data",
                          ["the_geom from multipolygon3d",
                           "the_geom from (select * from multipolygon3d) as foo using unique id",
+                          "the_geom FROM (SELECT * FROM multipolygon3d) AS foo USING UNIQUE id",
                           "the_geom from multipolygon3d using unique id",
                           "the_geom from multipolygon3d using srid=27700",
                           "the_geom from multipolygon3d using srid=27700 using unique id",


### PR DESCRIPTION
Fixes #6060