### PR TITLE
Remove submodule name from mapscript package

### DIFF
--- a/mapscript/python/mapscript/__init__.py
+++ b/mapscript/python/mapscript/__init__.py
@@ -1,1 +1,12 @@
+import inspect
 from .mapscript import *
+
+# change all the class module names from mapscript.mapscript to mapscript
+
+for key, value in globals().copy().items():
+    if inspect.isclass(value) and value.__module__.startswith('mapscript.'):
+        value.__module__= 'mapscript'
+
+# remove the submodule name
+
+del mapscript


### PR DESCRIPTION
This pull request removes the submodule name from the class names. 

Currently all classes are imported into the package root namespace in `__init__.py`. 
However the class module names are still set to the subpackage. This change will make them appear in the root, based on the answer at https://stackoverflow.com/questions/1808522/masquerading-real-module-of-a-class/

Before:

```python
>>> import mapscript
>>> mapscript.classObj.__module__
'mapscript.mapscript'
```

After:

```python
>>> mapscript.classObj.__module__
'mapscript'
```

For Python MapScript users nothing will change. The main benefit is for the ongoing autodoc work with Sphinx. 