### PR TITLE
Add classObj property strings and update MapScript docstrings

### DIFF
--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -251,12 +251,18 @@ typedef struct {
 =============================================================================
 */
 
+%feature("autodoc"); // autodoc all struct properties in the header files
+
 %include "../../mapserver.h"
 %include "../../mapserver-version.h"
 %include "../../mapprimitive.h"
 %include "../../mapshape.h"
 %include "../../mapproject.h"
 %include "../../mapsymbol.h"
+
+// clear autodoc for SWIG functions as we can use the -py3 flag to add typehints
+// which can be read by Sphinx
+%feature("autodoc", "");
 
 %apply Pointer NONNULL { mapObj *map };
 %apply Pointer NONNULL { layerObj *layer };

--- a/mapscript/swiginc/class.i
+++ b/mapscript/swiginc/class.i
@@ -28,11 +28,10 @@
    ===========================================================================
 */
 
-%feature("autodoc", ""); // turn off autodoc
 
 %extend classObj {
 
-    %feature("autodoc", "Create a new child classObj instance at the tail (highest index) of the 
+    %feature("docstring", "Create a new child classObj instance at the tail (highest index) of the 
 class array of the parent_layer. A class can be created outside the 
 context of a parent layer by omitting the layerObj constructor argument") classObj;
 

--- a/mapscript/swiginc/class.i
+++ b/mapscript/swiginc/class.i
@@ -28,6 +28,8 @@
    ===========================================================================
 */
 
+%feature("autodoc", ""); // turn off autodoc
+
 %extend classObj {
 
     %feature("autodoc", "Create a new child classObj instance at the tail (highest index) of the 

--- a/mapscript/swiginc/class.i
+++ b/mapscript/swiginc/class.i
@@ -30,19 +30,7 @@
 
 %extend classObj {
 
-#ifdef SWIGPYTHON
-    %pythoncode %{
-
-    debug = property() #: :data:`MS_TRUE` or :data:`MS_FALSE`. See :ref:`DEBUG <mapfile-class-debug>`
-    maxscaledenom = property() #: `double`. See :ref:`MAXSCALEDENOM <mapfile-class-maxscaledenom>`
-
-    %}
-#endif /* SWIGPYTHON */
-
-    // manually add parameter here or get mapscript.mapscript.layerObj in output docs
-    %feature("autodoc", "classObj.__init__(layerObj layer=None)
-
-Create a new child classObj instance at the tail (highest index) of the 
+    %feature("autodoc", "Create a new child classObj instance at the tail (highest index) of the 
 class array of the parent_layer. A class can be created outside the 
 context of a parent layer by omitting the layerObj constructor argument") classObj;
 
@@ -143,7 +131,7 @@ context of a parent layer by omitting the layerObj constructor argument") classO
     }
 
   %feature("docstring") setExpression 
-  "Set :mapfile:`EXPRESSION <class.html#index-4>` string where `expression` is a MapServer regular, logical or string expression. 
+  "Set :ref:`EXPRESSION <mapfile-class-expression>` string where `expression` is a MapServer regular, logical or string expression. 
 Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE`";
   int setExpression(char *expression) 
   {
@@ -155,14 +143,14 @@ Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE`";
   }
 
   %feature("docstring") getExpressionString 
-  "Return a string representation of the :mapfile:`EXPRESSION <class.html#index-4>` enclosed in the quote characters appropriate to the expression type";
+  "Return a string representation of the :ref:`EXPRESSION <mapfile-class-expression>` enclosed in the quote characters appropriate to the expression type";
   %newobject getExpressionString;
   char *getExpressionString() {
     return msGetExpressionString(&(self->expression));
   }
 
   %feature("docstring") setText 
-  "Set :mapfile:`TEXT <class.html#index-22>` string where `text` is a MapServer text expression.
+  "Set :ref:`TEXT <mapfile-class-text>` string where `text` is a MapServer text expression.
 Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE`";
   int setText(char *text) {
     if (!text || strlen(text) == 0) {
@@ -262,7 +250,7 @@ Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE`";
 
   %feature("docstring") removeLabel 
   "Remove the :class:`labelObj` at *index* from the labels array and return a
-reference to the :class:`labelObj`.  numlabels is decremented, and the array is updated";
+reference to the :class:`labelObj`. numlabels is decremented, and the array is updated";
   %newobject removeLabel;
   labelObj *removeLabel(int index) {
     labelObj* label = (labelObj *) msRemoveLabelFromClass(self, index);

--- a/mapscript/swiginc/class.i
+++ b/mapscript/swiginc/class.i
@@ -30,15 +30,13 @@
 
 %extend classObj {
 
-%pythoncode %{
+    %pythoncode %{
 
-    debug = property()
-    """:data:`MS_TRUE` or :data:`MS_FALSE`. See :ref:`DEBUG <mapfile-class-debug>`"""
+    debug = property() #: :data:`MS_TRUE` or :data:`MS_FALSE`. See :ref:`DEBUG <mapfile-class-debug>`
+    maxscaledenom = property() #: `double`. See :ref:`MAXSCALEDENOM <mapfile-class-maxscaledenom>`
 
-    maxscaledenom = property()
-    """`double`. See :ref:`MAXSCALEDENOM <mapfile-class-maxscaledenom>`"""
-    
-%}
+    %}
+
     // manually add parameter here or get mapscript.mapscript.layerObj in output docs
     %feature("autodoc", "classObj.__init__(layerObj layer=None)
 

--- a/mapscript/swiginc/class.i
+++ b/mapscript/swiginc/class.i
@@ -30,6 +30,15 @@
 
 %extend classObj {
 
+%pythoncode %{
+
+    debug = property()
+    """:data:`MS_TRUE` or :data:`MS_FALSE`. See :ref:`DEBUG <mapfile-class-debug>`"""
+
+    maxscaledenom = property()
+    """`double`. See :ref:`MAXSCALEDENOM <mapfile-class-maxscaledenom>`"""
+    
+%}
     // manually add parameter here or get mapscript.mapscript.layerObj in output docs
     %feature("autodoc", "classObj.__init__(layerObj layer=None)
 
@@ -164,7 +173,7 @@ Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE`";
   }
 
   %feature("docstring") getTextString 
-  "Return a string representation of :mapfile:`TEXT <class.html#index-22>`";
+  "Return a string representation of :ref:`TEXT <mapfile-class-text>`";
   %newobject getTextString;
   char *getTextString() {
     return msGetExpressionString(&(self->text));

--- a/mapscript/swiginc/class.i
+++ b/mapscript/swiginc/class.i
@@ -30,12 +30,14 @@
 
 %extend classObj {
 
+#ifdef SWIGPYTHON
     %pythoncode %{
 
     debug = property() #: :data:`MS_TRUE` or :data:`MS_FALSE`. See :ref:`DEBUG <mapfile-class-debug>`
     maxscaledenom = property() #: `double`. See :ref:`MAXSCALEDENOM <mapfile-class-maxscaledenom>`
 
     %}
+#endif /* SWIGPYTHON */
 
     // manually add parameter here or get mapscript.mapscript.layerObj in output docs
     %feature("autodoc", "classObj.__init__(layerObj layer=None)

--- a/mapserver.h
+++ b/mapserver.h
@@ -1190,10 +1190,17 @@ typedef struct labelObj labelObj;
   /*                                                                      */
   /*      basic symbolization and classification information              */
   /************************************************************************/
-
+#ifdef SWIG
+    %feature("autodoc");
+#endif
   struct classObj {
 #ifndef SWIG
     expressionObj expression; /* the expression to be matched */
+#endif
+
+#ifdef SWIG
+    %mutable;
+    %feature("docstring", ":data:`MS_ON` or :data:`MS_OFF` - draw features of this class or do not. See :ref:`STATUS <mapfile-class-status>`") status;
 #endif
 
     int status;
@@ -1207,11 +1214,15 @@ typedef struct labelObj labelObj;
 
 #ifdef SWIG
     %immutable;
+    %feature("docstring", "**immutable**. Number of styles for class") numstyles;
+    %feature("docstring", "**immutable**. Number of labels for class") numlabels;
 #endif
     int numstyles;
     int numlabels;
 #ifdef SWIG
     %mutable;
+    %feature("docstring", "See :ref:`NAME <mapfile-class-name>`") name;
+    %feature("docstring", "See :ref:`NAME <mapfile-class-title>`") title;
 #endif
 
 #ifndef SWIG
@@ -1233,23 +1244,33 @@ typedef struct labelObj labelObj;
 
 #ifdef SWIG
     %immutable;
+    %feature("docstring", "**immutable**. See :ref:`METADATA <mapfile-class-metadata>`") metadata;
+    %feature("docstring", "**immutable**. See :ref:`VALIDATION <mapfile-class-validation>`") validation;
 #endif /* SWIG */
     hashTableObj metadata;
     hashTableObj validation;
 #ifdef SWIG
     %mutable;
+    %feature("docstring", "See :ref:`MINSCALEDENOM <mapfile-class-minscaledenom>`") minscaledenom;
+    %feature("docstring", "See :ref:`MAXSCALEDENOM <mapfile-CLASS-maxscaledenom>`") maxscaledenom;
+    %feature("docstring", "See :ref:`MINFEATURESIZE <mapfile-class-minfeaturesize>`") minfeaturesize;
 #endif /* SWIG */
-
     double minscaledenom, maxscaledenom;
     int minfeaturesize; /* minimum feature size (in pixels) to shape */
 #ifdef SWIG
     %immutable;
+    %feature("docstring", "**immutable** Reference to the parent layer") layer;
+    %feature("docstring", "**immutable**. See :ref:`LEADER <mapfile-class-leader>`") leader;
 #endif /* SWIG */
     int refcount;
     struct layerObj *layer;
     labelLeaderObj *leader;
 #ifdef SWIG
     %mutable;
+    %feature("docstring", ":data:`MS_TRUE` or :data:`MS_FALSE`. See :ref:`DEBUG <mapfile-class-debug>`") debug;
+    %feature("docstring", "See :ref:`KEYIMAGE <mapfile-class-keyimage>`") keyimage;
+    %feature("docstring", "See :ref:`GROUP <mapfile-class-group>`") group;
+    %feature("docstring", "Supersedes layer's sizeunits and applies to all styles and labels. See :ref:`LAYER SIZEUNITS <mapfile-layer-sizeunits>`") sizeunits;
 #endif /* SWIG */
     int debug;
 

--- a/mapserver.h
+++ b/mapserver.h
@@ -1194,7 +1194,6 @@ typedef struct labelObj labelObj;
   struct classObj {
 
 #ifdef SWIG
-    %feature("autodoc"); // setting this adds types to properties but breaks Sphinx links of function parameters
     %immutable;
     %feature("docstring", "**immutable**. See :ref:`METADATA <mapfile-class-metadata>`") metadata;
     %feature("docstring", "**immutable**. See :ref:`VALIDATION <mapfile-class-validation>`") validation;
@@ -1238,6 +1237,12 @@ typedef struct labelObj labelObj;
     char *group;
     int sizeunits; // supersedes layer's sizeunits and applies to all styles and labels
 
+#ifndef __cplusplus
+    char *template;
+#else /* __cplusplus */
+    char *_template; // keyword in cplusplus
+#endif /* __cplusplus */
+
 #ifndef SWIG
     expressionObj text;
     expressionObj expression; /* the expression to be matched */
@@ -1247,12 +1252,6 @@ typedef struct labelObj labelObj;
     styleObj **styles;
     double scalefactor; // computed, not set
 #endif /* not SWIG */
-
-#ifndef __cplusplus
-    char *template;
-#else /* __cplusplus */
-    char *_template;
-#endif /* __cplusplus */
 
   };
 

--- a/mapserver.h
+++ b/mapserver.h
@@ -1190,50 +1190,62 @@ typedef struct labelObj labelObj;
   /*                                                                      */
   /*      basic symbolization and classification information              */
   /************************************************************************/
-#ifdef SWIG
-    %feature("autodoc");
-#endif
+
   struct classObj {
-#ifndef SWIG
-    expressionObj expression; /* the expression to be matched */
-#endif
+
+#ifdef SWIG
+    %feature("autodoc"); // setting this adds types to properties but breaks Sphinx links of function parameters
+    %immutable;
+    %feature("docstring", "**immutable**. See :ref:`METADATA <mapfile-class-metadata>`") metadata;
+    %feature("docstring", "**immutable**. See :ref:`VALIDATION <mapfile-class-validation>`") validation;
+    %feature("docstring", "**immutable**. Number of styles for class") numstyles;
+    %feature("docstring", "**immutable**. Number of labels for class") numlabels;
+    %feature("docstring", "**immutable** Reference to the parent layer") layer;
+    %feature("docstring", "**immutable**. See :ref:`LEADER <mapfile-class-leader>`") leader;
+#endif /* SWIG */
+
+    hashTableObj metadata;
+    hashTableObj validation;
+    int numstyles;
+    int numlabels;
+    int refcount;
+    struct layerObj *layer;
+    labelLeaderObj *leader;
 
 #ifdef SWIG
     %mutable;
     %feature("docstring", ":data:`MS_ON` or :data:`MS_OFF` - draw features of this class or do not. See :ref:`STATUS <mapfile-class-status>`") status;
+    %feature("docstring", "See :ref:`NAME <mapfile-class-name>`") name;
+    %feature("docstring", "See :ref:`NAME <mapfile-class-title>`") title;
+    %feature("docstring", "See :ref:`MINSCALEDENOM <mapfile-class-minscaledenom>`") minscaledenom;
+    %feature("docstring", "See :ref:`MAXSCALEDENOM <mapfile-CLASS-maxscaledenom>`") maxscaledenom;
+    %feature("docstring", "See :ref:`MINFEATURESIZE <mapfile-class-minfeaturesize>`") minfeaturesize;
+    %feature("docstring", ":data:`MS_TRUE` or :data:`MS_FALSE`. See :ref:`DEBUG <mapfile-class-debug>`") debug;
+    %feature("docstring", "See :ref:`KEYIMAGE <mapfile-class-keyimage>`") keyimage;
+    %feature("docstring", "See :ref:`GROUP <mapfile-class-group>`") group;
+    %feature("docstring", "Supersedes layer's sizeunits and applies to all styles and labels. See :ref:`LAYER SIZEUNITS <mapfile-layer-sizeunits>`") sizeunits;
 #endif
 
     int status;
-    int isfallback; // TRUE if this class should be applied if and only if
-                    // no other class is applicable (e.g. SLD <ElseFilter/>)
-
-#ifndef SWIG
-    styleObj **styles;
-    int maxstyles;
-#endif
-
-#ifdef SWIG
-    %immutable;
-    %feature("docstring", "**immutable**. Number of styles for class") numstyles;
-    %feature("docstring", "**immutable**. Number of labels for class") numlabels;
-#endif
-    int numstyles;
-    int numlabels;
-#ifdef SWIG
-    %mutable;
-    %feature("docstring", "See :ref:`NAME <mapfile-class-name>`") name;
-    %feature("docstring", "See :ref:`NAME <mapfile-class-title>`") title;
-#endif
-
-#ifndef SWIG
-    labelObj **labels;
-    int maxlabels;
-#endif
+    int isfallback; // TRUE if this class should be applied if and only if no other class is applicable (e.g. SLD <ElseFilter/>)
     char *name; /* should be unique within a layer */
     char *title; /* used for legend labelling */
+    double minscaledenom;
+    double maxscaledenom;
+    int minfeaturesize; /* minimum feature size (in pixels) to shape */
+    int debug;
+    char *keyimage;
+    char *group;
+    int sizeunits; // supersedes layer's sizeunits and applies to all styles and labels
 
 #ifndef SWIG
     expressionObj text;
+    expressionObj expression; /* the expression to be matched */
+    labelObj **labels;
+    int maxlabels;
+    int maxstyles;
+    styleObj **styles;
+    double scalefactor; // computed, not set
 #endif /* not SWIG */
 
 #ifndef __cplusplus
@@ -1241,47 +1253,6 @@ typedef struct labelObj labelObj;
 #else /* __cplusplus */
     char *_template;
 #endif /* __cplusplus */
-
-#ifdef SWIG
-    %immutable;
-    %feature("docstring", "**immutable**. See :ref:`METADATA <mapfile-class-metadata>`") metadata;
-    %feature("docstring", "**immutable**. See :ref:`VALIDATION <mapfile-class-validation>`") validation;
-#endif /* SWIG */
-    hashTableObj metadata;
-    hashTableObj validation;
-#ifdef SWIG
-    %mutable;
-    %feature("docstring", "See :ref:`MINSCALEDENOM <mapfile-class-minscaledenom>`") minscaledenom;
-    %feature("docstring", "See :ref:`MAXSCALEDENOM <mapfile-CLASS-maxscaledenom>`") maxscaledenom;
-    %feature("docstring", "See :ref:`MINFEATURESIZE <mapfile-class-minfeaturesize>`") minfeaturesize;
-#endif /* SWIG */
-    double minscaledenom, maxscaledenom;
-    int minfeaturesize; /* minimum feature size (in pixels) to shape */
-#ifdef SWIG
-    %immutable;
-    %feature("docstring", "**immutable** Reference to the parent layer") layer;
-    %feature("docstring", "**immutable**. See :ref:`LEADER <mapfile-class-leader>`") leader;
-#endif /* SWIG */
-    int refcount;
-    struct layerObj *layer;
-    labelLeaderObj *leader;
-#ifdef SWIG
-    %mutable;
-    %feature("docstring", ":data:`MS_TRUE` or :data:`MS_FALSE`. See :ref:`DEBUG <mapfile-class-debug>`") debug;
-    %feature("docstring", "See :ref:`KEYIMAGE <mapfile-class-keyimage>`") keyimage;
-    %feature("docstring", "See :ref:`GROUP <mapfile-class-group>`") group;
-    %feature("docstring", "Supersedes layer's sizeunits and applies to all styles and labels. See :ref:`LAYER SIZEUNITS <mapfile-layer-sizeunits>`") sizeunits;
-#endif /* SWIG */
-    int debug;
-
-    char *keyimage;
-
-    char *group;
-
-    int sizeunits; // supersedes layer's sizeunits and applies to all styles and labels
-#ifndef SWIG
-    double scalefactor; // computed, not set
-#endif /* not SWIG */
 
   };
 


### PR DESCRIPTION
This pull request builds on https://github.com/mapserver/docs/pull/327 and allows direct links from the planned generated MapScript docs to Mapfile keyword syntax. 

It also adds property docstrings to the classObj in mapserver.h
Initially I added these as Python only docstrings [here](https://github.com/mapserver/mapserver/pull/6071/commits/19d40f2a4572e3eba76e57f1dabc1a9d788114e4), but using the SWIG feature and adding to where classObj is defined allows types to be automatically generated for each property. 

Keeping the docstrings and property declarations together also has more chance of them being maintained. 

