### PR TITLE
Deploy MapScript to PyPI for any release tag

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,11 +106,14 @@ artifacts:
 
 deploy_script:
   - ps: |
-        if ($env:APPVEYOR_REPO_BRANCH -ne "master" -or $env:APPVEYOR_REPO_TAG -ne $TRUE) { return }
+deploy_script:
+  - ps: |
+        if ($env:APPVEYOR_REPO_TAG -ne $TRUE -and ($env:APPVEYOR_REPO_TAG -cSplit "-").Count -eq 4) { return }
             if ($env:PYTHON_EXECUTABLE -eq "c:/python36-x64/python.exe") {
+            # create a single source dist
             cd $env:APPVEYOR_BUILD_FOLDER\build\mapscript\python\Release
                 & $env:PYTHON_EXECUTABLE setup.py sdist
             }
             echo "Deploying Python Wheel to PyPI"
             & $env:PYTHON_EXECUTABLE -m pip --disable-pip-version-check install twine
-            & $env:PYTHON_EXECUTABLE -m twine upload --repository-url https://test.pypi.org/legacy/ --skip-existing $env:APPVEYOR_BUILD_FOLDER\build\mapscript\python\Release\dist\*
+            & $env:PYTHON_EXECUTABLE -m twine upload --repository-url https://pypi.org/legacy/ --skip-existing $env:APPVEYOR_BUILD_FOLDER\build\mapscript\python\Release\dist\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -106,8 +106,6 @@ artifacts:
 
 deploy_script:
   - ps: |
-deploy_script:
-  - ps: |
         if ($env:APPVEYOR_REPO_TAG -ne $TRUE -and ($env:APPVEYOR_REPO_TAG -cSplit "-").Count -eq 4) { return }
             if ($env:PYTHON_EXECUTABLE -eq "c:/python36-x64/python.exe") {
             # create a single source dist


### PR DESCRIPTION
This automates deploying to PyPI for any release tag (previously the PS script had assumed this would be on a master branch, and would have deployed to the test PyPI site). 

Release tags are assumed to be in the format `"rel-7-6-0"` which should exclude any release candidates and betas from being deployed. 

```
("rel-7-6-0" -cSplit "-").Count -eq 4
("rel-7-6-0-rc4" -cSplit "-").Count -eq 5
```