### PR TITLE
Don't use CIRCULARSTRING when fetching geography data from SQL Server.

### DIFF
--- a/mapmssql2008.c
+++ b/mapmssql2008.c
@@ -1339,8 +1339,14 @@ static int prepare_database(layerObj *layer, rectObj rect, char **query_string)
     "Geometry::STGeomFromText('POLYGON(())',)" + terminator = 40 chars
     Plus 10 formatted doubles (15 digits of precision, a decimal point, a space/comma delimiter each = 17 chars each)
     Plus SRID + comma - if SRID is a long...we'll be safe with 10 chars
+
+  	or for geography columns
+	
+    "Geography::STGeomFromText('CURVEPOLYGON(())',)" + terminator = 46 chars
+    Plus 18 formatted doubles (15 digits of precision, a decimal point, a space/comma delimiter each = 17 chars each)
+    Plus SRID + comma - if SRID is a long...we'll be safe with 10 chars
   */
-  char        box3d[40 + 10 * 22 + 11];
+  char        box3d[46 + 18 * 22 + 11];
   int         t;
 
   char        *pos_from, *pos_ftab, *pos_space, *pos_paren;
@@ -1395,10 +1401,25 @@ static int prepare_database(layerObj *layer, rectObj rect, char **query_string)
       /* create point shape for rectangles with zero area */
       sprintf(box3d, "%s::STGeomFromText('POINT(%.15g %.15g)',%s)", /* %s.STSrid)", */
           layerinfo->geom_column_type, rect.minx, rect.miny, layerinfo->user_srid);
-  }
-  else {
-      sprintf(box3d, "%s::STGeomFromText('POLYGON((%.15g %.15g,%.15g %.15g,%.15g %.15g,%.15g %.15g,%.15g %.15g))',%s)", /* %s.STSrid)", */
-          layerinfo->geom_column_type,
+  } else if (strcasecmp(layerinfo->geom_column_type, "geography") == 0) {
+	  /* SQL Server has a problem when x is -180 or 180 */  
+	  double minx = rect.minx <= -180? -179.999: rect.minx;
+	  double maxx = rect.maxx >= 180? 179.999: rect.maxx;
+	  double miny = rect.miny < -90? -90: rect.miny;
+	  double maxy = rect.maxy > 90? 90: rect.maxy;
+	  sprintf(box3d, "Geography::STGeomFromText('CURVEPOLYGON((%.15g %.15g,%.15g %.15g,%.15g %.15g,%.15g %.15g,%.15g %.15g,%.15g %.15g,%.15g %.15g,%.15g %.15g,%.15g %.15g))',%s)", /* %s.STSrid)", */
+          minx, miny,
+          minx + (maxx - minx) / 2, miny,
+          maxx, miny,
+          maxx, miny + (maxy - miny) / 2,
+          maxx, maxy,
+          minx + (maxx - minx) / 2, maxy,
+          minx, maxy,
+          minx, miny + (maxy - miny) / 2,
+          minx, miny,
+          layerinfo->user_srid);  
+  } else {
+      sprintf(box3d, "Geometry::STGeomFromText('POLYGON((%.15g %.15g,%.15g %.15g,%.15g %.15g,%.15g %.15g,%.15g %.15g))',%s)", /* %s.STSrid)", */
           rect.minx, rect.miny,
           rect.maxx, rect.miny,
           rect.maxx, rect.maxy,


### PR DESCRIPTION
Use CURVEPOLYGON(()) instead of CURVEPOLYGON(CIRCULARSTRING()) when fetching geography data from SQL Server. This will increase the performance.