### PR TITLE
Fixed rounding error in WMS client

### DIFF
--- a/mapwmslayer.c
+++ b/mapwmslayer.c
@@ -731,8 +731,8 @@ msBuildWMSLayerURL(mapObj *map, layerObj *lp, int nRequestType,
 
         msRectIntersect( &bbox, &layer_rect );
 
-        bbox_width = ceil((bbox.maxx - bbox.minx) / cellsize);
-        bbox_height = ceil((bbox.maxy - bbox.miny) / cellsize);
+        bbox_width = round((bbox.maxx - bbox.minx) / cellsize);
+        bbox_height = round((bbox.maxy - bbox.miny) / cellsize);
 
         /* Force going through the resampler if we're going to receive a clipped BBOX (#4931) */
         if(msLayerGetProcessingKey(lp, "RESAMPLE") == NULL) {


### PR DESCRIPTION
When using a tile size of 256 in Web Mercator the cascaded WMS request could be computed to a height or width of 257.