### PR TITLE
Add const to input parameters

### DIFF
--- a/mapscript/python/pymodule.i
+++ b/mapscript/python/pymodule.i
@@ -95,7 +95,7 @@ CreateTupleFromDoubleArray( double *first, unsigned int size ) {
  *  Typemap to turn a Python dict into two sequences and
  *  an item count. Used for msApplySubstitutions
  */
-%typemap(in) (char **names, char **values, int npairs) {
+%typemap(in) (const char **names, const char **values, int npairs) {
   /* Check if is a dict */
   if (PyDict_Check($input)) {
 


### PR DESCRIPTION
To fix warnings - mapscriptpython_wrap.c(37348): warning C4090: '=': different 'const' qualifiers
This is causing issues when trying to build with py38 in Appveyor. 