### PR TITLE
Add py37 MapScript build and testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ cache:
 environment:
 
   global:
+    SWIG_VER: swigwin-4.0.1
     TWINE_USERNAME: mapserver
     TWINE_PASSWORD:
       secure: mHoJHeXdXbBNoDf7MA4ZEg==
@@ -24,10 +25,10 @@ environment:
     SWIG_VER: swigwin-3.0.12
   - platform: x64
     PYTHON_EXECUTABLE: c:/python27-x64/python.exe
-    SWIG_VER: swigwin-4.0.1
   - platform: x64
     PYTHON_EXECUTABLE: c:/python36-x64/python.exe
-    SWIG_VER: swigwin-4.0.1
+  - platform: x64
+    PYTHON_EXECUTABLE: c:/python37-x64/python.exe
 
 services:
   - mssql2017
@@ -37,6 +38,15 @@ matrix:
 
 shallow_clone: false
 clone_depth: 5
+
+init:
+  - ps: |
+        if ($env:APPVEYOR_REPO_TAG -ne $TRUE) {
+            if ("c:/python27-x64/python.exe","c:/python36-x64/python.exe" -contains $env:PYTHON_EXECUTABLE -eq $TRUE) {
+                Write-Host "Skipping build, not a tagged release."
+                Exit-AppVeyorBuild
+            }
+        }
 
 build_script:
   - ps: Write-Host "Build tags - $env:APPVEYOR_REPO_TAG $env:APPVEYOR_REPO_TAG_NAME"

--- a/mapscript/python/CMakeLists.txt
+++ b/mapscript/python/CMakeLists.txt
@@ -108,7 +108,9 @@ add_custom_command(
     DEPENDS mapscriptwheel.stamp
     OUTPUT mapscripttests.stamp
     COMMAND ${PYTHON_VENV_SCRIPTS}/pip install --no-index --find-links=${OUTPUT_FOLDER}/dist mapscript
-    COMMAND ${PYTHON_VENV_SCRIPTS}/pytest --pyargs mapscript.tests
+    # ERROR: file or package not found: mapscript.tests (missing __init__.py?) is caused by
+    # ImportError: DLL load failed while importing _mapscript: The specified module could not be found.
+    COMMAND ${PYTHON_VENV_SCRIPTS}/python -m pytest --pyargs mapscript.tests
     COMMAND ${PYTHON_VENV_SCRIPTS}/python -m mapscript.examples.project_csv ${PROJECT_SOURCE_DIR}/tests/cities.csv 2 1 EPSG:4326 EPSG:3857 > test.csv
     COMMAND ${PYTHON_VENV_SCRIPTS}/python -m mapscript.examples.shpdump ${PROJECT_SOURCE_DIR}/tests/polygon.shp > shpdump.txt
     COMMAND ${PYTHON_VENV_SCRIPTS}/python -m mapscript.examples.shpinfo ${PROJECT_SOURCE_DIR}/tests/polygon.shp > shpinfo.txt

--- a/mapscript/python/pymodule.i
+++ b/mapscript/python/pymodule.i
@@ -114,8 +114,10 @@ CreateTupleFromDoubleArray( double *first, unsigned int size ) {
         PyObject* val = PyList_GetItem(values, i);
 
         %#if PY_MAJOR_VERSION >= 3
-            $1[i] = PyUnicode_AsUTF8(key);
-            $2[i] = PyUnicode_AsUTF8(val);
+            // Changed in version 3.7: The return type is now const char * rather of char *.
+            // avoid warning C4090: '=': different 'const' qualifiers
+            $1[i] = (char *)PyUnicode_AsUTF8(key);
+            $2[i] = (char *)PyUnicode_AsUTF8(val);
         %#else
             $1[i] = PyString_AsString(key);
             $2[i] = PyString_AsString(val);

--- a/mapscript/python/pymodule.i
+++ b/mapscript/python/pymodule.i
@@ -114,7 +114,7 @@ CreateTupleFromDoubleArray( double *first, unsigned int size ) {
         PyObject* val = PyList_GetItem(values, i);
 
         %#if PY_MAJOR_VERSION >= 3
-            // Changed in version 3.7: The return type is now const char * rather of char *.
+            // Changed in version 3.7: The return type is now const char * rather than char *
             // avoid warning C4090: '=': different 'const' qualifiers
             $1[i] = (char *)PyUnicode_AsUTF8(key);
             $2[i] = (char *)PyUnicode_AsUTF8(val);


### PR DESCRIPTION
This pull request builds and test Python MapScript on Python 3.7

This requires a small fix due to a chnage in the Python C-API:

> The result of PyUnicode_AsUTF8AndSize() and PyUnicode_AsUTF8() is now of type const char * rather of char *. (Contributed by Serhiy Storchaka in bpo-28769.)

https://docs.python.org/3/whatsnew/3.7.html#c-api-changes

In addition, the following changes have been made to the Appveyor build:

* Only two Python versions are fully built - py27-32 and py37-64. There is little reason to do a full MapServer compile for every single version of Python (with py 3.8 out and 3.9 on the way). Other Python versions will only build on a release so that bindings are automatically pushed to PyPI
* pytest is run using the `-m` switch to ensure it is the version used in the virtual environment
