### PR TITLE
Hide some SWIG Java warnings

### DIFF
--- a/mapscript/java/CMakeLists.txt
+++ b/mapscript/java/CMakeLists.txt
@@ -15,7 +15,7 @@ set (CMAKE_SWIG_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/edu/umn/gis/mapscript")
 set(CMAKE_SWIG_FLAGS -package edu.umn.gis.mapscript)
 
 # hide warnings
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCC OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing")
 endif ()
 

--- a/mapscript/java/CMakeLists.txt
+++ b/mapscript/java/CMakeLists.txt
@@ -4,7 +4,7 @@ include(${SWIG_USE_FILE})
 find_package(JNI)
 find_package(Java)
 if(NOT JNI_INCLUDE_DIRS OR NOT Java_JAVAC_EXECUTABLE OR NOT Java_JAR_EXECUTABLE)
-   message(SEND_ERROR "Could not find required Java componenents. Try setting the JAVA_HOME environment variable (required on e.g. Ubuntu)")
+   message(SEND_ERROR "Could not find required Java components. Try setting the JAVA_HOME environment variable (required on e.g. Ubuntu)")
 endif(NOT JNI_INCLUDE_DIRS OR NOT Java_JAVAC_EXECUTABLE OR NOT Java_JAR_EXECUTABLE)
 
 include_directories(${JNI_INCLUDE_DIRS})
@@ -13,6 +13,9 @@ include_directories(${PROJECT_SOURCE_DIR}/mapscript/)
 include_directories(${PROJECT_SOURCE_DIR}/mapscript/java)
 set (CMAKE_SWIG_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/edu/umn/gis/mapscript")
 set(CMAKE_SWIG_FLAGS -package edu.umn.gis.mapscript)
+
+# see http://www.swig.org/Doc4.0/Java.html#Java_compiling_dynamic
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing")
 
 if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER 3.7)
     swig_add_library(javamapscript TYPE MODULE LANGUAGE java SOURCES ../mapscript.i)

--- a/mapscript/java/CMakeLists.txt
+++ b/mapscript/java/CMakeLists.txt
@@ -15,7 +15,10 @@ set (CMAKE_SWIG_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/edu/umn/gis/mapscript")
 set(CMAKE_SWIG_FLAGS -package edu.umn.gis.mapscript)
 
 # hide warnings
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing")
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_GNUCC OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing")
+endif ()
+
 
 if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER 3.7)
     swig_add_library(javamapscript TYPE MODULE LANGUAGE java SOURCES ../mapscript.i)

--- a/mapscript/java/CMakeLists.txt
+++ b/mapscript/java/CMakeLists.txt
@@ -15,7 +15,7 @@ set (CMAKE_SWIG_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/edu/umn/gis/mapscript")
 set(CMAKE_SWIG_FLAGS -package edu.umn.gis.mapscript)
 
 # hide warnings
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing -Wunused-function")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing")
 
 if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER 3.7)
     swig_add_library(javamapscript TYPE MODULE LANGUAGE java SOURCES ../mapscript.i)

--- a/mapscript/java/CMakeLists.txt
+++ b/mapscript/java/CMakeLists.txt
@@ -14,8 +14,8 @@ include_directories(${PROJECT_SOURCE_DIR}/mapscript/java)
 set (CMAKE_SWIG_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/edu/umn/gis/mapscript")
 set(CMAKE_SWIG_FLAGS -package edu.umn.gis.mapscript)
 
-# see http://www.swig.org/Doc4.0/Java.html#Java_compiling_dynamic
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing")
+# hide warnings
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing -Wunused-function")
 
 if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER 3.7)
     swig_add_library(javamapscript TYPE MODULE LANGUAGE java SOURCES ../mapscript.i)


### PR DESCRIPTION
Currently the Travis build with optimisations has a 15,000 line log file: https://travis-ci.org/github/mapserver/mapserver/jobs/699304461 = lines 15357

Many of these are warnings related to the Java MapScript bindings e.g.:

` /home/travis/build/mapserver/mapserver/build/mapscript/java/edu/umn/gis/mapscript/mapscriptJAVA_wrap.c:12271:19: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
`

This is caused by the optimisation flag:

`make cmakebuild MFLAGS="-j2" CMAKE_C_FLAGS="-O2...`

See https://github.com/mapserver/mapserver/blob/master/ci/travis/script.sh#L30

A similar issue arose at https://github.com/microsoft/LightGBM/issues/1556

See SWIG notes at http://www.swig.org/Doc4.0/Java.html#Java_compiling_dynamic

> Important
> If you are going to use optimisations turned on with gcc (for example -O2), ensure you also compile with -fno-strict-aliasing. The GCC optimisations have become more aggressive from gcc-4.0 onwards and will result in code that fails with strict aliasing optimisations turned on. See the C/C++ to Java typemaps section for more details. 

Hiding these warnings takes 5,000 lines off the log which makes it easier to see other errors. E.g. https://travis-ci.org/github/geographika/mapserver/jobs/701402353

