### PR TITLE
install PHPNG required file 'mapscript.php'

### DIFF
--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -38,7 +38,7 @@
 #endif
 %}
 
-#ifndef SWIGPHPNG
+#ifndef SWIGPHP7
 %module mapscript
 #else
 %module mapscriptng

--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -38,7 +38,7 @@
 #endif
 %}
 
-#ifndef SWIGPHP7
+#ifndef SWIGPHPNG
 %module mapscript
 #else
 %module mapscriptng

--- a/mapscript/phpng/CMakeLists.txt
+++ b/mapscript/phpng/CMakeLists.txt
@@ -84,4 +84,6 @@ set_target_properties(${SWIG_MODULE_mapscript_REAL_NAME} PROPERTIES PREFIX "")
 
 if(NOT WIN32)
   install(TARGETS php_mapscriptng DESTINATION ${PHP_EXTENSION_DIR})
+  # install the required file containing MapServer constants and functions
+  install(FILES mapscript.php DESTINATION ${PHP_EXTENSION_DIR} COMPONENT dev)
 endif()

--- a/mapscript/phpng/CMakeLists.txt
+++ b/mapscript/phpng/CMakeLists.txt
@@ -85,5 +85,5 @@ set_target_properties(${SWIG_MODULE_mapscript_REAL_NAME} PROPERTIES PREFIX "")
 if(NOT WIN32)
   install(TARGETS php_mapscriptng DESTINATION ${PHP_EXTENSION_DIR})
   # install the required file containing MapServer constants and functions
-  install(FILES mapscript.php DESTINATION ${PHP_EXTENSION_DIR} COMPONENT dev)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mapscript.php DESTINATION ${PHP_EXTENSION_DIR} COMPONENT dev)
 endif()

--- a/mapscript/phpng/php7module.i
+++ b/mapscript/phpng/php7module.i
@@ -1,3 +1,5 @@
+%module mapscriptng;
+
 %pragma(php) phpinfo="
   php_info_print_table_start();
   php_info_print_table_row(2, \"MapServer Version\", msGetVersion());


### PR DESCRIPTION
 - fixes reports of Debian-GIS not including the required file 'mapscript.php' (https://bugs.launchpad.net/ubuntu/+source/mapserver/+bug/1884854)
 - will install the file into the PHP_EXTENSTION_DIR, such as:

     `-- Installing: /usr/lib/php/20170718/mapscript.php`