### PR TITLE
Add a bounding box filter to requests passed down to OGR whenever possible

### DIFF
--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -3447,7 +3447,11 @@ static int  msOGRExtractTopSpatialFilter( msOGRFileInfo *info,
                                           pSpatialFilterNode);
   }
 
-  if( (expr->m_nToken == MS_TOKEN_COMPARISON_INTERSECTS || expr->m_nToken == MS_TOKEN_COMPARISON_CONTAINS ) &&
+  if( (expr->m_nToken == MS_TOKEN_COMPARISON_INTERSECTS ||
+      expr->m_nToken == MS_TOKEN_COMPARISON_OVERLAPS ||
+      expr->m_nToken == MS_TOKEN_COMPARISON_CROSSES ||
+      expr->m_nToken == MS_TOKEN_COMPARISON_WITHIN ||
+      expr->m_nToken == MS_TOKEN_COMPARISON_CONTAINS) &&
       expr->m_aoChildren.size() == 2 &&
       expr->m_aoChildren[1]->m_nToken == MS_TOKEN_LITERAL_SHAPE )
   {


### PR DESCRIPTION
We observed that our WFS (MapServer + GeoPackage utilizing the OGR backend) is a lot slower when specific spatial operators are used in a filter condition. Although the spatial index in the GeoPackage could be used to accelerate those specific operators it was not.

By adding a bounding box filter to the request passed down to OGR whenever possible (= depending on which operator is used) the spatial index in GeoPackage is utilized for those requests resulting a very significant performance improvement.