### PR TITLE
add content encoding to OL template

### DIFF
--- a/maptemplate.c
+++ b/maptemplate.c
@@ -47,6 +47,8 @@ static char *olUrl = "//www.mapserver.org/lib/OpenLayers-ms60.js";
 static char *olTemplate = \
                           "<html>\n"
                           "<head>\n"
+                          "<meta content=\"text/html;charset=utf-8\" http-equiv=\"Content-Type\">\n"
+                          "<meta content=\"utf-8\" http-equiv=\"encoding\">\n"
                           "  <title>MapServer Simple Viewer</title>\n"
                           "    <script type=\"text/javascript\" src=\"[openlayers_js_url]\"></script>\n"
                           "    </head>\n"

--- a/maptemplate.c
+++ b/maptemplate.c
@@ -48,7 +48,6 @@ static char *olTemplate = \
                           "<html>\n"
                           "<head>\n"
                           "<meta content=\"text/html;charset=utf-8\" http-equiv=\"Content-Type\">\n"
-                          "<meta content=\"utf-8\" http-equiv=\"encoding\">\n"
                           "  <title>MapServer Simple Viewer</title>\n"
                           "    <script type=\"text/javascript\" src=\"[openlayers_js_url]\"></script>\n"
                           "    </head>\n"


### PR DESCRIPTION
 - recent browsers throw error of "The character encoding of the HTML document was not declared." when using template=openlayers
 - this adds the content encoding type to the meta tag in the OpenLayers template