### PR TITLE
Allow custom override for gml_types "auto"

### DIFF
--- a/mapmssql2008.c
+++ b/mapmssql2008.c
@@ -887,17 +887,17 @@ static int columnName(msODBCconn *conn, int index, char *buffer, int bufferLengt
             sprintf( gml_width, "%u", (unsigned int)columnSize );
 
       snprintf( md_item_name, sizeof(md_item_name), "gml_%s_type", buffer );
-      if( msOWSLookupMetadata(&(layer->metadata), "G", "type") == NULL )
+      if( msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
         msInsertHashTable(&(layer->metadata), md_item_name, gml_type );
 
       snprintf( md_item_name, sizeof(md_item_name), "gml_%s_width", buffer );
       if( strlen(gml_width) > 0
-          && msOWSLookupMetadata(&(layer->metadata), "G", "width") == NULL )
+          && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
         msInsertHashTable(&(layer->metadata), md_item_name, gml_width );
 
       snprintf( md_item_name, sizeof(md_item_name), "gml_%s_precision",buffer );
       if( strlen(gml_precision) > 0
-          && msOWSLookupMetadata(&(layer->metadata), "G", "precision")==NULL )
+          && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
         msInsertHashTable(&(layer->metadata), md_item_name, gml_precision );
 
       snprintf( md_item_name, sizeof(md_item_name), "gml_%s_nillable",buffer );

--- a/mapmssql2008.c
+++ b/mapmssql2008.c
@@ -836,7 +836,6 @@ static int columnName(msODBCconn *conn, int index, char *buffer, int bufferLengt
     *itemType = dataType;
 
     if (pass_field_def) {
-      char md_item_name[256];
       char gml_width[32], gml_precision[32];
       const char *gml_type = NULL;
 
@@ -886,23 +885,7 @@ static int columnName(msODBCconn *conn, int index, char *buffer, int bufferLengt
       if( columnSize > 0 )
             sprintf( gml_width, "%u", (unsigned int)columnSize );
 
-      snprintf( md_item_name, sizeof(md_item_name), "gml_%s_type", buffer );
-      if( msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
-        msInsertHashTable(&(layer->metadata), md_item_name, gml_type );
-
-      snprintf( md_item_name, sizeof(md_item_name), "gml_%s_width", buffer );
-      if( strlen(gml_width) > 0
-          && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
-        msInsertHashTable(&(layer->metadata), md_item_name, gml_width );
-
-      snprintf( md_item_name, sizeof(md_item_name), "gml_%s_precision",buffer );
-      if( strlen(gml_precision) > 0
-          && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
-        msInsertHashTable(&(layer->metadata), md_item_name, gml_precision );
-
-      snprintf( md_item_name, sizeof(md_item_name), "gml_%s_nillable",buffer );
-      if( nullable > 0 )
-        msInsertHashTable(&(layer->metadata), md_item_name, "true" );
+      updateGMLFieldMetadata(layer, buffer, gml_type, gml_width, gml_precision, (const short) nullable);
     }
     return 1;
   } else {

--- a/mapmssql2008.c
+++ b/mapmssql2008.c
@@ -885,7 +885,7 @@ static int columnName(msODBCconn *conn, int index, char *buffer, int bufferLengt
       if( columnSize > 0 )
             sprintf( gml_width, "%u", (unsigned int)columnSize );
 
-      updateGMLFieldMetadata(layer, buffer, gml_type, gml_width, gml_precision, (const short) nullable);
+      msUpdateGMLFieldMetadata(layer, buffer, gml_type, gml_width, gml_precision, (const short) nullable);
     }
     return 1;
   } else {

--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -2679,7 +2679,7 @@ msOGRPassThroughFieldDefinitions( layerObj *layer, msOGRFileInfo *psInfo )
         break;
     }
 
-    updateGMLFieldMetadata(layer, item, gml_type, gml_width, gml_precision, 0);
+    msUpdateGMLFieldMetadata(layer, item, gml_type, gml_width, gml_precision, 0);
   }
 
   /* Should we try to address style items, or other special items? */

--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -2628,7 +2628,6 @@ msOGRPassThroughFieldDefinitions( layerObj *layer, msOGRFileInfo *psInfo )
 
   for(i=0; i<numitems; i++) {
     OGRFieldDefnH hField = OGR_FD_GetFieldDefn( hDefn, i );
-    char md_item_name[256];
     char gml_width[32], gml_precision[32];
     const char *gml_type = NULL;
     const char *item = OGR_Fld_GetNameRef( hField );
@@ -2680,19 +2679,7 @@ msOGRPassThroughFieldDefinitions( layerObj *layer, msOGRFileInfo *psInfo )
         break;
     }
 
-    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_type", item );
-    if( msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
-      msInsertHashTable(&(layer->metadata), md_item_name, gml_type );
-
-    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_width", item );
-    if( strlen(gml_width) > 0
-        && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
-      msInsertHashTable(&(layer->metadata), md_item_name, gml_width );
-
-    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_precision",item );
-    if( strlen(gml_precision) > 0
-        && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name)==NULL )
-      msInsertHashTable(&(layer->metadata), md_item_name, gml_precision );
+    updateGMLFieldMetadata(layer, item, gml_type, gml_width, gml_precision, 0);
   }
 
   /* Should we try to address style items, or other special items? */

--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -2681,17 +2681,17 @@ msOGRPassThroughFieldDefinitions( layerObj *layer, msOGRFileInfo *psInfo )
     }
 
     snprintf( md_item_name, sizeof(md_item_name), "gml_%s_type", item );
-    if( msOWSLookupMetadata(&(layer->metadata), "G", "type") == NULL )
+    if( msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
       msInsertHashTable(&(layer->metadata), md_item_name, gml_type );
 
     snprintf( md_item_name, sizeof(md_item_name), "gml_%s_width", item );
     if( strlen(gml_width) > 0
-        && msOWSLookupMetadata(&(layer->metadata), "G", "width") == NULL )
+        && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
       msInsertHashTable(&(layer->metadata), md_item_name, gml_width );
 
     snprintf( md_item_name, sizeof(md_item_name), "gml_%s_precision",item );
     if( strlen(gml_precision) > 0
-        && msOWSLookupMetadata(&(layer->metadata), "G", "precision")==NULL )
+        && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name)==NULL )
       msInsertHashTable(&(layer->metadata), md_item_name, gml_precision );
   }
 

--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -2869,7 +2869,6 @@ msOracleSpatialGetFieldDefn( layerObj *layer,
 
 {
   const char *gml_type = "Character";
-  char md_item_name[256];
   char gml_width[32], gml_precision[32];
   int success;
   ub2 rzttype, nOCILen;
@@ -2951,19 +2950,7 @@ msOracleSpatialGetFieldDefn( layerObj *layer,
       gml_type = "Character";
   }
 
-  snprintf( md_item_name, sizeof(md_item_name), "gml_%s_type", item );
-  if( msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == 0 )
-    msInsertHashTable(&(layer->metadata), md_item_name, gml_type );
-
-  snprintf( md_item_name, sizeof(md_item_name), "gml_%s_width", item );
-  if( strlen(gml_width) > 0
-      && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == 0 )
-    msInsertHashTable(&(layer->metadata), md_item_name, gml_width );
-
-  snprintf( md_item_name, sizeof(md_item_name), "gml_%s_precision",item );
-  if( strlen(gml_precision) > 0
-      && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name)==0 )
-    msInsertHashTable(&(layer->metadata), md_item_name, gml_precision );
+    updateGMLFieldMetadata(layer, item, gml_type, gml_width, gml_precision, 0);
 }
 
 int msOracleSpatialLayerGetItems( layerObj *layer )

--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -2950,7 +2950,7 @@ msOracleSpatialGetFieldDefn( layerObj *layer,
       gml_type = "Character";
   }
 
-    updateGMLFieldMetadata(layer, item, gml_type, gml_width, gml_precision, 0);
+    msUpdateGMLFieldMetadata(layer, item, gml_type, gml_width, gml_precision, 0);
 }
 
 int msOracleSpatialLayerGetItems( layerObj *layer )

--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -2952,17 +2952,17 @@ msOracleSpatialGetFieldDefn( layerObj *layer,
   }
 
   snprintf( md_item_name, sizeof(md_item_name), "gml_%s_type", item );
-  if( msOWSLookupMetadata(&(layer->metadata), "G", "type") == 0 )
+  if( msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == 0 )
     msInsertHashTable(&(layer->metadata), md_item_name, gml_type );
 
   snprintf( md_item_name, sizeof(md_item_name), "gml_%s_width", item );
   if( strlen(gml_width) > 0
-      && msOWSLookupMetadata(&(layer->metadata), "G", "width") == 0 )
+      && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == 0 )
     msInsertHashTable(&(layer->metadata), md_item_name, gml_width );
 
   snprintf( md_item_name, sizeof(md_item_name), "gml_%s_precision",item );
   if( strlen(gml_precision) > 0
-      && msOWSLookupMetadata(&(layer->metadata), "G", "precision")==0 )
+      && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name)==0 )
     msInsertHashTable(&(layer->metadata), md_item_name, gml_precision );
 }
 

--- a/mapows.c
+++ b/mapows.c
@@ -2904,6 +2904,41 @@ outputFormatObj* msOwsIsOutputFormatValid(mapObj *map, const char *format,
   return psFormat;
 }
 
+/************************************************************************/
+/*                         updateGMLFieldMetadata                       */
+/*                                                                      */
+/*      Updates a fields GML metadata if it has not already             */
+/*      been set. Nullable is not implemented for all drivers           */
+/*      and can be set to 0 if unknown                                  */
+/************************************************************************/
+int updateGMLFieldMetadata(layerObj *layer, const char *field_name, const char *gml_type, const char *gml_width, 
+                        const char *gml_precision, const short nullable)
+{
+
+    char md_item_name[256];
+
+    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_type", field_name );
+    if( msLookupHashTable(&(layer->metadata), md_item_name) == NULL )
+    msInsertHashTable(&(layer->metadata), md_item_name, gml_type );
+
+    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_width", field_name );
+    if( strlen(gml_width) > 0
+        && msLookupHashTable(&(layer->metadata), md_item_name) == NULL )
+    msInsertHashTable(&(layer->metadata), md_item_name, gml_width );
+
+    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_precision", field_name );
+    if( strlen(gml_precision) > 0
+        && msLookupHashTable(&(layer->metadata), md_item_name) == NULL )
+    msInsertHashTable(&(layer->metadata), md_item_name, gml_precision );
+
+    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_nillable", field_name );
+    if( nullable > 0 
+        && msLookupHashTable(&(layer->metadata), md_item_name) == NULL )
+    msInsertHashTable(&(layer->metadata), md_item_name, "true" );
+
+    return MS_TRUE;
+}
+
 #endif /* USE_WMS_SVR || USE_WFS_SVR  || USE_WCS_SVR */
 
 

--- a/mapows.c
+++ b/mapows.c
@@ -2905,14 +2905,14 @@ outputFormatObj* msOwsIsOutputFormatValid(mapObj *map, const char *format,
 }
 
 /************************************************************************/
-/*                         updateGMLFieldMetadata                       */
+/*                         msUpdateGMLFieldMetadata                     */
 /*                                                                      */
 /*      Updates a fields GML metadata if it has not already             */
 /*      been set. Nullable is not implemented for all drivers           */
 /*      and can be set to 0 if unknown                                  */
 /************************************************************************/
-int updateGMLFieldMetadata(layerObj *layer, const char *field_name, const char *gml_type, const char *gml_width, 
-                        const char *gml_precision, const short nullable)
+int msUpdateGMLFieldMetadata(layerObj *layer, const char *field_name, const char *gml_type,
+                             const char *gml_width, const char *gml_precision, const short nullable)
 {
 
     char md_item_name[256];

--- a/mapows.h
+++ b/mapows.h
@@ -150,8 +150,8 @@ MS_DLL_EXPORT const char * msOWSLookupMetadata2(hashTableObj *pri,
     const char *namespaces,
     const char *name);
 
-MS_DLL_EXPORT int updateGMLFieldMetadata(layerObj *layer, const char *field_name, const char *gml_type, const char *gml_width, 
-                        const char *gml_precision, const short nullable);
+MS_DLL_EXPORT int msUpdateGMLFieldMetadata(layerObj *layer, const char *field_name,
+    const char *gml_type, const char *gml_width, const char *gml_precision, const short nullable);
 
 void msOWSInitRequestObj(owsRequestObj *ows_request);
 void msOWSClearRequestObj(owsRequestObj *ows_request);

--- a/mapows.h
+++ b/mapows.h
@@ -149,7 +149,10 @@ MS_DLL_EXPORT const char * msOWSLookupMetadata2(hashTableObj *pri,
     hashTableObj *sec,
     const char *namespaces,
     const char *name);
-    
+
+MS_DLL_EXPORT int updateGMLFieldMetadata(layerObj *layer, const char *field_name, const char *gml_type, const char *gml_width, 
+                        const char *gml_precision, const short nullable);
+
 void msOWSInitRequestObj(owsRequestObj *ows_request);
 void msOWSClearRequestObj(owsRequestObj *ows_request);
 

--- a/mappostgis.cpp
+++ b/mappostgis.cpp
@@ -2891,20 +2891,8 @@ msPostGISPassThroughFieldDefinitions( layerObj *layer,
       gml_type = "DateTime";
     }
 
-    char md_item_name[256];
-    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_type", item );
-    if( msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
-      msInsertHashTable(&(layer->metadata), md_item_name, gml_type );
+    updateGMLFieldMetadata(layer, item, gml_type, gml_width.c_str(), gml_precision.c_str(), 0);
 
-    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_width", item );
-    if( !gml_width.empty()
-        && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
-      msInsertHashTable(&(layer->metadata), md_item_name, gml_width.c_str() );
-
-    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_precision",item );
-    if( !gml_precision.empty()
-        && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name)==NULL )
-      msInsertHashTable(&(layer->metadata), md_item_name, gml_precision.c_str() );
   }
 }
 #endif /* defined(USE_POSTGIS) */

--- a/mappostgis.cpp
+++ b/mappostgis.cpp
@@ -2891,7 +2891,7 @@ msPostGISPassThroughFieldDefinitions( layerObj *layer,
       gml_type = "DateTime";
     }
 
-    updateGMLFieldMetadata(layer, item, gml_type, gml_width.c_str(), gml_precision.c_str(), 0);
+    msUpdateGMLFieldMetadata(layer, item, gml_type, gml_width.c_str(), gml_precision.c_str(), 0);
 
   }
 }

--- a/mappostgis.cpp
+++ b/mappostgis.cpp
@@ -2893,17 +2893,17 @@ msPostGISPassThroughFieldDefinitions( layerObj *layer,
 
     char md_item_name[256];
     snprintf( md_item_name, sizeof(md_item_name), "gml_%s_type", item );
-    if( msOWSLookupMetadata(&(layer->metadata), "G", "type") == NULL )
+    if( msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
       msInsertHashTable(&(layer->metadata), md_item_name, gml_type );
 
     snprintf( md_item_name, sizeof(md_item_name), "gml_%s_width", item );
     if( !gml_width.empty()
-        && msOWSLookupMetadata(&(layer->metadata), "G", "width") == NULL )
+        && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
       msInsertHashTable(&(layer->metadata), md_item_name, gml_width.c_str() );
 
     snprintf( md_item_name, sizeof(md_item_name), "gml_%s_precision",item );
     if( !gml_precision.empty()
-        && msOWSLookupMetadata(&(layer->metadata), "G", "precision")==NULL )
+        && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name)==NULL )
       msInsertHashTable(&(layer->metadata), md_item_name, gml_precision.c_str() );
   }
 }

--- a/mapshape.c
+++ b/mapshape.c
@@ -2522,7 +2522,7 @@ static void msSHPPassThroughFieldDefinitions( layerObj *layer, DBFHandle hDBF )
         break;
     }
 
-    updateGMLFieldMetadata(layer, item, gml_type, gml_width, gml_precision, 0);
+    msUpdateGMLFieldMetadata(layer, item, gml_type, gml_width, gml_precision, 0);
 
   }
 }

--- a/mapshape.c
+++ b/mapshape.c
@@ -2494,7 +2494,6 @@ static void msSHPPassThroughFieldDefinitions( layerObj *layer, DBFHandle hDBF )
   for(i=0; i<numitems; i++) {
     char item[16];
     int  nWidth=0, nPrecision=0;
-    char md_item_name[64];
     char gml_width[32], gml_precision[32];
     DBFFieldType eType;
     const char *gml_type = NULL;
@@ -2523,19 +2522,8 @@ static void msSHPPassThroughFieldDefinitions( layerObj *layer, DBFHandle hDBF )
         break;
     }
 
-    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_type", item );
-    if( msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
-      msInsertHashTable(&(layer->metadata), md_item_name, gml_type );
+    updateGMLFieldMetadata(layer, item, gml_type, gml_width, gml_precision, 0);
 
-    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_width", item );
-    if( strlen(gml_width) > 0
-        && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
-      msInsertHashTable(&(layer->metadata), md_item_name, gml_width );
-
-    snprintf( md_item_name, sizeof(md_item_name), "gml_%s_precision",item );
-    if( strlen(gml_precision) > 0
-        && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name)==NULL )
-      msInsertHashTable(&(layer->metadata), md_item_name, gml_precision );
   }
 }
 

--- a/mapshape.c
+++ b/mapshape.c
@@ -2524,17 +2524,17 @@ static void msSHPPassThroughFieldDefinitions( layerObj *layer, DBFHandle hDBF )
     }
 
     snprintf( md_item_name, sizeof(md_item_name), "gml_%s_type", item );
-    if( msOWSLookupMetadata(&(layer->metadata), "G", "type") == NULL )
+    if( msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
       msInsertHashTable(&(layer->metadata), md_item_name, gml_type );
 
     snprintf( md_item_name, sizeof(md_item_name), "gml_%s_width", item );
     if( strlen(gml_width) > 0
-        && msOWSLookupMetadata(&(layer->metadata), "G", "width") == NULL )
+        && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name) == NULL )
       msInsertHashTable(&(layer->metadata), md_item_name, gml_width );
 
     snprintf( md_item_name, sizeof(md_item_name), "gml_%s_precision",item );
     if( strlen(gml_precision) > 0
-        && msOWSLookupMetadata(&(layer->metadata), "G", "precision")==NULL )
+        && msOWSLookupMetadata(&(layer->metadata), NULL, md_item_name)==NULL )
       msInsertHashTable(&(layer->metadata), md_item_name, gml_precision );
   }
 }

--- a/msautotest/mssql/expected/wfs_mssql_describefeature.xml
+++ b/msautotest/mssql/expected/wfs_mssql_describefeature.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<schema
+   targetNamespace="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   xmlns="http://www.w3.org/2001/XMLSchema"
+   xmlns:gml="http://www.opengis.net/gml/3.2"
+   elementFormDefault="qualified" version="0.1" >
+
+  <import namespace="http://www.opengis.net/gml/3.2"
+          schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd" />
+
+  <element name="cities"
+           type="ms:citiesType"
+           substitutionGroup="gml:AbstractFeature" />
+
+  <complexType name="citiesType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="msGeometry" type="gml:GeometryPropertyType" minOccurs="0" maxOccurs="1"/>
+          <element name="ogr_fid" minOccurs="0" type="integer"/>
+          <element name="name" minOccurs="0" nillable="true" type="string"/>
+          <element name="name_ar" minOccurs="0" nillable="true" type="string"/>
+          <element name="name_hi" minOccurs="0" nillable="true" type="string"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+
+</schema>

--- a/msautotest/mssql/expected/wfs_mssql_describefeature.xml
+++ b/msautotest/mssql/expected/wfs_mssql_describefeature.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding="UTF-8" ?>
 <schema
-   targetNamespace="http://mapserver.gis.umn.edu/mapserver"
-   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   targetNamespace="http://mapserver.gis.umn.edu/mapserver" 
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver" 
    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
    xmlns="http://www.w3.org/2001/XMLSchema"
    xmlns:gml="http://www.opengis.net/gml/3.2"
@@ -10,8 +10,8 @@
   <import namespace="http://www.opengis.net/gml/3.2"
           schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd" />
 
-  <element name="cities"
-           type="ms:citiesType"
+  <element name="cities" 
+           type="ms:citiesType" 
            substitutionGroup="gml:AbstractFeature" />
 
   <complexType name="citiesType">

--- a/msautotest/mssql/expected/wfs_mssql_describefeature_custom_type.xml
+++ b/msautotest/mssql/expected/wfs_mssql_describefeature_custom_type.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<schema
+   targetNamespace="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   xmlns="http://www.w3.org/2001/XMLSchema"
+   xmlns:gml="http://www.opengis.net/gml/3.2"
+   elementFormDefault="qualified" version="0.1" >
+
+  <import namespace="http://www.opengis.net/gml/3.2"
+          schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd" />
+
+  <element name="cities_custom_gml_type"
+           type="ms:cities_custom_gml_typeType"
+           substitutionGroup="gml:AbstractFeature" />
+
+  <complexType name="cities_custom_gml_typeType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="msGeometry" type="gml:GeometryPropertyType" minOccurs="0" maxOccurs="1"/>
+          <element name="ogr_fid" minOccurs="0" type="long"/>
+          <element name="name" minOccurs="0" nillable="true" type="string"/>
+          <element name="name_ar" minOccurs="0" nillable="true" type="string"/>
+          <element name="name_hi" minOccurs="0" nillable="true" type="string"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+
+</schema>

--- a/msautotest/mssql/expected/wfs_mssql_describefeature_custom_type.xml
+++ b/msautotest/mssql/expected/wfs_mssql_describefeature_custom_type.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding="UTF-8" ?>
 <schema
-   targetNamespace="http://mapserver.gis.umn.edu/mapserver"
-   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   targetNamespace="http://mapserver.gis.umn.edu/mapserver" 
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver" 
    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
    xmlns="http://www.w3.org/2001/XMLSchema"
    xmlns:gml="http://www.opengis.net/gml/3.2"
@@ -10,8 +10,8 @@
   <import namespace="http://www.opengis.net/gml/3.2"
           schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd" />
 
-  <element name="cities_custom_gml_type"
-           type="ms:cities_custom_gml_typeType"
+  <element name="cities_custom_gml_type" 
+           type="ms:cities_custom_gml_typeType" 
            substitutionGroup="gml:AbstractFeature" />
 
   <complexType name="cities_custom_gml_typeType">

--- a/msautotest/mssql/wfs_mssql.map
+++ b/msautotest/mssql/wfs_mssql.map
@@ -6,6 +6,8 @@
 # RUN_PARMS: wfs_mssql_maxfeatures.json [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAME=cities&OUTPUTFORMAT=geojson" > [RESULT_DEMIME]
 # RUN_PARMS: wfs_mssql_maxfeatures_order.json [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAME=cities_with_order&OUTPUTFORMAT=geojson" > [RESULT_DEMIME]
 # RUN_PARMS: wfs_mssql_maxfeatures_qs.json [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAME=cities&OUTPUTFORMAT=geojson&MAXFEATURES=2" > [RESULT_DEMIME]
+# RUN_PARMS: wfs_mssql_describefeature.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=cities" > [RESULT_DEMIME]
+# RUN_PARMS: wfs_mssql_describefeature_custom_type.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=cities_custom_gml_type" > [RESULT_DEMIME]
 
 MAP
   NAME 'wfs_mssql'
@@ -59,5 +61,16 @@ MAP
     END
   END
 
+  LAYER
+    NAME 'cities_custom_gml_type'
+    EXTENT -20026376.39 -20048966.10 20026376.39 20048966.10
+    INCLUDE 'include/cities_mssql.map'
+    DATA "ogr_geometry from (select * from cities) as foo USING UNIQUE ogr_fid USING SRID=3857"
+    METADATA
+        "gml_include_items" "all"
+        "gml_types" "auto"
+        "gml_ogr_fid_type" "long" # override the default gml type
+    END
+  END
 
 END

--- a/msautotest/mssql/wfs_mssql.map
+++ b/msautotest/mssql/wfs_mssql.map
@@ -6,8 +6,8 @@
 # RUN_PARMS: wfs_mssql_maxfeatures.json [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAME=cities&OUTPUTFORMAT=geojson" > [RESULT_DEMIME]
 # RUN_PARMS: wfs_mssql_maxfeatures_order.json [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAME=cities_with_order&OUTPUTFORMAT=geojson" > [RESULT_DEMIME]
 # RUN_PARMS: wfs_mssql_maxfeatures_qs.json [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAME=cities&OUTPUTFORMAT=geojson&MAXFEATURES=2" > [RESULT_DEMIME]
-# RUN_PARMS: wfs_mssql_describefeature.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=cities" > [RESULT_DEMIME]
-# RUN_PARMS: wfs_mssql_describefeature_custom_type.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=cities_custom_gml_type" > [RESULT_DEMIME]
+# RUN_PARMS: wfs_mssql_describefeature.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=cities" > [RESULT_DEMIME_DEVERSION]
+# RUN_PARMS: wfs_mssql_describefeature_custom_type.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAME=cities_custom_gml_type" > [RESULT_DEMIME_DEVERSION]
 
 MAP
   NAME 'wfs_mssql'


### PR DESCRIPTION
This pull request allows GML types to be set automatically for the MSSQL driver, but still allow individual fields to be overwritten manually if required. See #5408 and #5418
I believe this was the original intention of the code, but from debugging and testing I don't believe this has ever been the case. 

The code currently checks the "gml" namespace for "type", "width", and "precision" using msOWSLookupMetadata. However, these properties only ever exist with a property name e.g. 

```
gml_[item name]_type
gml_[item name]_precision
gml_[item name]_width
```

Therefore, the searches always return 0, and the auto values are always used. 
It looks like the code has been copied from driver to driver. 

As in the test case included in the pull request:

```
    METADATA
        "gml_include_items" "all"
        "gml_types" "auto"
        "gml_ogr_fid_type" "long" # override the default gml type of integer
    END
```

Returns:

```xml
    <element name="ogr_fid" minOccurs="0" type="long"/>
    <element name="name" minOccurs="0" nillable="true" type="string"/>
    <element name="name_ar" minOccurs="0" nillable="true" type="string"/>
```

Please let me know if I am missing something. 

I've also added the update for the following drivers:

- Oracle
- Shapefile
- PostGIS
- OGR

Looks like the original code is from 2010 as part of https://github.com/mapserver/mapserver/issues/3570 implementing https://mapserver.org/development/rfc/ms-rfc-62.html#gml-types-auto
