### PR TITLE
Don't remove all temporary memory files for WMS layers before creating a new

### DIFF
--- a/mapwmslayer.c
+++ b/mapwmslayer.c
@@ -1414,7 +1414,6 @@ int msDrawWMSLayerLow(int nLayerId, httpRequestObj *pasReqInfo,
    * to attach a "VSI" name to this buffer.
    * ------------------------------------------------------------------ */
   if( pasReqInfo[iReq].pszOutputFile == NULL ) {
-    msCleanVSIDir( "/vsimem/msout" );
     mem_filename = msTmpFile(map, NULL, "/vsimem/msout/", "img.tmp" );
 
     VSIFCloseL(
@@ -1496,7 +1495,7 @@ int msDrawWMSLayerLow(int nLayerId, httpRequestObj *pasReqInfo,
       if (msDrawLayer(map, lp, img) != 0)
         status = MS_FAILURE;
 
-      if (!lp->debug)
+      if (!lp->debug || mem_filename != NULL)
         VSIUnlink( wldfile );
     } else {
       msSetError(MS_WMSCONNERR,
@@ -1508,7 +1507,7 @@ int msDrawWMSLayerLow(int nLayerId, httpRequestObj *pasReqInfo,
   }
 
   /* We're done with the remote server's response... delete it. */
-  if (!lp->debug)
+  if (!lp->debug || mem_filename != NULL)
     VSIUnlink(lp->data);
 
   /* restore prveious type */


### PR DESCRIPTION
When WMS layers use memory files as temporary storage we can't delete all existing memory files before creating a new. This will generate a lot of "Unable to access file..." errors in a multi-threded application that uses MapScript.
However, we can always remove the temporary memory files even if the layer has debug enabled.