### PR TITLE
Make it possible to send scale_independent to drawLegend via MapScript

### DIFF
--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -318,8 +318,8 @@
 
     %newobject drawLegend;
     /// Draw map legend, returning an :class:`imageObj`.
-    imageObj *drawLegend() {
-      return msDrawLegend(self, MS_FALSE, NULL);
+    imageObj *drawLegend(int scale_independent=MS_FALSE) {
+      return msDrawLegend(self, scale_independent, NULL);
     }
 
     %newobject drawScalebar;


### PR DESCRIPTION
This make it possible to create a legend for all layers even if they are not within scale range.