### PR TITLE
Document the DBFInfo and shapefileObj with Doxygen comments

### DIFF
--- a/maperror.c
+++ b/maperror.c
@@ -88,6 +88,7 @@ static char *ms_errorCodes[MS_NUMERRORCODES] = {"",
                                                };
 #ifndef USE_THREAD
 
+/// Get the MapServer error object
 errorObj *msGetErrorObj()
 {
   static errorObj ms_error = {MS_NOERR, "", "", MS_FALSE, 0, NULL};

--- a/mapscript/swiginc/class.i
+++ b/mapscript/swiginc/class.i
@@ -161,7 +161,7 @@
     return msGetExpressionString(&(self->text));
   }
 
-  /// **/To be removed in 8.0** -  use the metadata property
+  /// \**To be removed in 8.0** -  use the metadata property
   char *getMetaData(char *name) {
     char *value = NULL;
     if (!name) {
@@ -176,19 +176,19 @@
     return value;
   }
 
-  /// **/To be removed** -  use the metadata property
+  /// \**To be removed** -  use the metadata property
   int setMetaData(char *name, char *value) {
     if (msInsertHashTable(&(self->metadata), name, value) == NULL)
         return MS_FAILURE;
     return MS_SUCCESS;
   }
 
-  /// **/To be removed** -  use the metadata property
+  /// \**To be removed** -  use the metadata property
   char *getFirstMetaDataKey() {
     return (char *) msFirstKeyFromHashTable(&(self->metadata));
   }
 
-  /// **To be removed** -  use the metadata property
+  /// \**To be removed** -  use the metadata property
   char *getNextMetaDataKey(char *lastkey) {
     return (char *) msNextKeyFromHashTable(&(self->metadata), lastkey);
   }
@@ -234,9 +234,9 @@
 %clear labelObj *label;
 #endif
 
+  %newobject removeLabel;
   /// Remove the :class:`labelObj` at *index* from the labels array and return a
   /// reference to the :class:`labelObj`. numlabels is decremented, and the array is updated
-  %newobject removeLabel;
   labelObj *removeLabel(int index) {
     labelObj* label = (labelObj *) msRemoveLabelFromClass(self, index);
     if (label) MS_REFCNT_INCR(label);

--- a/mapserver.h
+++ b/mapserver.h
@@ -777,17 +777,17 @@ extern "C" {
   } parseObj;
 #endif
 
-  /* MS RFC 69*/
+  /************************************************************************/
+  /*                          clusterObj                                  */
+  /************************************************************************/
+
+/**
+The :ref:`CLUSTER <cluster>` object. See :ref:`RFC 69 <rfc69>`.
+*/
   typedef struct {
-#ifdef SWIG
-    %feature("docstring", "The :ref:`CLUSTER <cluster>` object. See :ref:`RFC 69 <rfc69>`.") clusterObj;
-    %feature("docstring", "See :ref:`BUFFER <mapfile-class-maxdistance>`") maxdistance;
-    %feature("docstring", "See :ref:`MAXDISTANCE <mapfile-class-buffer>`") buffer;
-    %feature("docstring", "See :ref:`REGION <mapfile-class-region>`") region;
-#endif /* SWIG */
-    double maxdistance; /* max distance between clusters */
-    double buffer;      /* the buffer size around the selection area */
-    char* region;       /* type of the cluster region (rectangle or ellipse) */
+    double maxdistance; ///< Maximum distance between clusters - see :ref:`MAXDISTANCE <mapfile-cluster-maxdistance>`
+    double buffer; ///< The buffer size around the selection area - see :ref:`BUFFER <mapfile-cluster-buffer>`
+    char* region; ///< The type of the cluster region (rectangle or ellipse) - see :ref:`REGION <mapfile-cluster-region>`
 #ifndef SWIG
     expressionObj group; /* expression to identify the groups */
     expressionObj filter; /* expression for filtering the shapes */
@@ -1190,6 +1190,10 @@ typedef struct labelObj labelObj;
 #define MS_LABEL_PERPENDICULAR_TOP_OFFSET 99
 #define IS_PERPENDICULAR_OFFSET(offsety) ((offsety) == MS_LABEL_PERPENDICULAR_OFFSET || (offsety) == MS_LABEL_PERPENDICULAR_TOP_OFFSET)
 
+  /************************************************************************/
+  /*                          classObj                                    */
+  /************************************************************************/
+
 /**
  * The :ref:`CLASS <class>` object. Used for symbolization and classification information.
  *
@@ -1204,7 +1208,7 @@ typedef struct labelObj labelObj;
     hashTableObj validation; ///< \**immutable** see :ref:`VALIDATION <mapfile-class-validation>`
     int numstyles; ///< \**immutable** number of styles for class
     int numlabels;  ///< \**immutable** number of labels for class
-    int refcount;
+    int refcount; ///< \**immutable** number of references to this object
     struct layerObj *layer; ///< \**immutable** reference to the parent layer
     labelLeaderObj *leader; ///< \**immutable** see :ref:`LEADER <mapfile-class-leader>`
 

--- a/mapshape.h
+++ b/mapshape.h
@@ -109,19 +109,28 @@ extern "C" {
   typedef SHPInfo * SHPHandle;
 #endif
 
+  /************************************************************************/
+  /*                          DBFInfo                                     */
+  /************************************************************************/
 
-
+/**
+ * An object containing information about a DBF file
+ *
+ */
   typedef struct {
 #ifdef SWIG
     %immutable;
 #endif
+
+    int   nRecords; ///< Number of records in the DBF
+    int   nFields; ///< Number of fields in the DBF
+
+
+#ifndef SWIG
     VSILFILE  *fp;
-
-    int   nRecords;
-
     unsigned int nRecordLength;
     int   nHeaderLength;
-    int   nFields;
+
     int   *panFieldOffset;
     int   *panFieldSize;
     int   *panFieldDecimals;
@@ -138,41 +147,39 @@ extern "C" {
 
     char  *pszStringField;
     int   nStringFieldLen;
-#ifdef SWIG
-    %mutable;
-#endif
+#endif /* not SWIG */
   } DBFInfo;
+
   typedef DBFInfo * DBFHandle;
 
   typedef enum {FTString, FTInteger, FTDouble, FTInvalid} DBFFieldType;
 
-  /* Shapefile object, no write access via scripts */
+  /************************************************************************/
+  /*                          shapefileObj                                */
+  /************************************************************************/
+
+/**
+ * An object representing a Shapefile. There is no write access to this object
+ * using MapScript.
+ */
   typedef struct {
 #ifdef SWIG
     %immutable;
 #endif
+
+    int type; ///< Shapefile type - see mapshape.h for values of type
+    int numshapes; ///< Number of shapes
+    rectObj bounds; ///< Extent of shapes
+
+#ifndef SWIG
     char source[MS_PATH_LENGTH]; /* full path to this file data */
-
-#ifndef SWIG
+    int lastshape;
+    ms_bitarray status;
+    int isopen;
     SHPHandle hSHP; /* SHP/SHX file pointer */
-#endif
-
-    int type; /* shapefile type */
-    int numshapes; /* number of shapes */
-    rectObj bounds; /* shape extent */
-
-#ifndef SWIG
     DBFHandle hDBF; /* DBF file pointer */
 #endif
 
-    int lastshape;
-
-    ms_bitarray status;
-
-    int isopen;
-#ifdef SWIG
-    %mutable;
-#endif
   } shapefileObj;
 
 #ifndef SWIG


### PR DESCRIPTION
A few other minor Doxygen comment fixes included. 
Undocumented struct properties hidden from SWIG for DBFInfo and shapefileObj. 
Relates to https://www.mapserver.org/fr/development/rfc/ms-rfc-132.html