### PR TITLE
Enable check-crlf github action

### DIFF
--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -15,6 +15,6 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Use action to check for CRLF endings
-        uses: erclu/check-crlf@v2
+        uses: erclu/check-crlf@v1.1.0
         exclude: msautotest/misc/data/ /msautotest/renderers/expected/
         

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -16,4 +16,4 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Use action to check for CRLF endings
-        uses: erclu/check-crlf@v1.1.0        
+        uses: erclu/check-crlf@v1.1.1        

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -15,4 +15,6 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Use action to check for CRLF endings
-        uses: erclu/check-crlf@v1.0.0
+        uses: erclu/check-crlf@v2
+        exclude: msautotest/misc/data/ /msautotest/renderers/expected/
+        

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -16,4 +16,5 @@ jobs:
 
       - name: Use action to check for CRLF endings
         uses: erclu/check-crlf@v1.1.1
-        exclude: msautotest/misc/data/ /msautotest/renderers/expected/       
+        with: # ignore directories containing *.pdf and *.tab
+          exclude: msautotest/misc/data/ /msautotest/renderers/expected/       

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -9,11 +9,11 @@ jobs:
   Check-CRLF:
     name: verify that only LF linefeeds are used
     runs-on: ubuntu-18.04
-    exclude: msautotest/misc/data/ /msautotest/renderers/expected/
 
     steps:
       - name: Checkout repository contents
         uses: actions/checkout@v1
 
       - name: Use action to check for CRLF endings
-        uses: erclu/check-crlf@v1.1.1        
+        uses: erclu/check-crlf@v1.1.1
+        exclude: msautotest/misc/data/ /msautotest/renderers/expected/       

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -1,0 +1,18 @@
+# check for Windows CRLF in files
+# homepage: https://github.com/marketplace/actions/check-crlf
+
+name: Check CRLF
+
+on: [push, pull_request]
+
+jobs:
+  Check-CRLF:
+    name: verify that only LF linefeeds are used
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout repository contents
+        uses: actions/checkout@v1
+
+      - name: Use action to check for CRLF endings
+        uses: erclu/check-crlf@v1.0.0

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -9,12 +9,11 @@ jobs:
   Check-CRLF:
     name: verify that only LF linefeeds are used
     runs-on: ubuntu-18.04
+    exclude: msautotest/misc/data/ /msautotest/renderers/expected/
 
     steps:
       - name: Checkout repository contents
         uses: actions/checkout@v1
 
       - name: Use action to check for CRLF endings
-        uses: erclu/check-crlf@v1.1.0
-        exclude: msautotest/misc/data/ /msautotest/renderers/expected/
-        
+        uses: erclu/check-crlf@v1.1.0        

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -15,6 +15,6 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Use action to check for CRLF endings
-        uses: erclu/check-crlf@v1.1.1
+        uses: erclu/check-crlf@v1.1.2
         with: # ignore directories containing *.pdf and *.tab
           exclude: msautotest/misc/data/ /msautotest/renderers/expected/

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -15,4 +15,6 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Use action to check for CRLF endings
-        uses: erclu/check-crlf@v1.0.0
+        uses: erclu/check-crlf@v1.1.1
+        with: # ignore directories containing *.pdf and *.tab
+          exclude: msautotest/misc/data/ /msautotest/renderers/expected/

--- a/.github/workflows/check-crlf.yml
+++ b/.github/workflows/check-crlf.yml
@@ -15,6 +15,4 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Use action to check for CRLF endings
-        uses: erclu/check-crlf@v1.1.1
-        with: # ignore directories containing *.pdf and *.tab
-          exclude: msautotest/misc/data/ /msautotest/renderers/expected/       
+        uses: erclu/check-crlf@v1.0.0


### PR DESCRIPTION
- now also excludes directories (as our msautotest contains a few TAB and PDF files with CRLF)