### PR TITLE
Metadata: use attribution_title if available (#6166)

### DIFF
--- a/mapmetadata.c
+++ b/mapmetadata.c
@@ -528,6 +528,11 @@ xmlNodePtr _msMetadataGetIdentificationInfo(xmlNsPtr namespace, mapObj *map, lay
 
   psDNode = xmlNewChild(psCINode, namespace, BAD_CAST "date", NULL);
 
+  value = (char *)msOWSLookupMetadata(&(layer->metadata), "MCFGO", "attribution_title");
+  if (value) {
+      xmlAddChild(psCINode, _msMetadataGetCharacterString(namespace, "otherCitationDetails", value, ppsNsGco));
+  }
+
   xmlAddChild(psDNode, _msMetadataGetDate(namespace, "CI_Date", "publication", "2011", ppsNsGco));
 
   value = (char *)msOWSLookupMetadata(&(layer->metadata), "MCFGO", "abstract");
@@ -691,7 +696,7 @@ xmlNodePtr msMetadataGetExceptionReport(mapObj *map, char *code, char *locator, 
 /************************************************************************/
 /*                   msMetadataGetLayerMetadata                         */
 /*                                                                      */
-/*      Generate an ISO 19139:2007 representation of layer metadata     */
+/*      Generate an ISO 19139-1:2019 representation of layer metadata   */
 /************************************************************************/
 
 static

--- a/mapmetadata.c
+++ b/mapmetadata.c
@@ -249,35 +249,6 @@ xmlNodePtr _msMetadataGetCodeList(xmlNsPtr namespace, const char *parent_element
 
 
 /************************************************************************/
-/*                   _msMetadataGetDate                                 */
-/*                                                                      */
-/*      Create a gmd:date or gmd:dateStamp element pattern              */
-/************************************************************************/
-
-static
-xmlNodePtr _msMetadataGetDate(xmlNsPtr namespace, const char *parent_element, const char *date_type, const char *value, xmlNsPtr* ppsNsGco) {
-  xmlNodePtr psNode = NULL;
-  xmlNodePtr psNode2 = NULL;
-
-  if( *ppsNsGco == NULL )
-    *ppsNsGco = xmlNewNs(NULL, BAD_CAST "http://www.isotc211.org/2005/gmd", BAD_CAST "gco");
-
-  psNode = xmlNewNode(namespace, BAD_CAST parent_element);
-
-  if (date_type == NULL) {  /* it's a gmd:dateStamp */
-      xmlNewChild(psNode, *ppsNsGco, BAD_CAST "Date", BAD_CAST value);
-      return psNode;
-  }
-
-  psNode2 = xmlNewChild(psNode, namespace, BAD_CAST "date", NULL);
-  xmlNewChild(psNode2, *ppsNsGco, BAD_CAST "Date", BAD_CAST value);
-  xmlAddChild(psNode, _msMetadataGetCodeList(namespace, "dateType", "CI_DateTypeCode", date_type));
-
-  return psNode;
-}
-
-
-/************************************************************************/
 /*                   _msMetadataGetGMLTimePeriod                        */
 /*                                                                      */
 /*      Create a gml:TimePeriod element pattern                         */
@@ -527,13 +498,12 @@ xmlNodePtr _msMetadataGetIdentificationInfo(xmlNsPtr namespace, mapObj *map, lay
   xmlAddChild(psCINode, _msMetadataGetCharacterString(namespace, "title", value, ppsNsGco));
 
   psDNode = xmlNewChild(psCINode, namespace, BAD_CAST "date", NULL);
+  xmlNewNsProp(psDNode, *ppsNsGco, BAD_CAST "nilReason", BAD_CAST "missing");
 
   value = (char *)msOWSLookupMetadata(&(layer->metadata), "MCFGO", "attribution_title");
   if (value) {
       xmlAddChild(psCINode, _msMetadataGetCharacterString(namespace, "otherCitationDetails", value, ppsNsGco));
   }
-
-  xmlAddChild(psDNode, _msMetadataGetDate(namespace, "CI_Date", "publication", "2011", ppsNsGco));
 
   value = (char *)msOWSLookupMetadata(&(layer->metadata), "MCFGO", "abstract");
   if (!value)

--- a/msautotest/wxs/expected/ows_metadata_layer_raster.xml
+++ b/msautotest/wxs/expected/ows_metadata_layer_raster.xml
@@ -111,16 +111,7 @@ Content-type: text/xml
           <gmd:title>
             <gco:CharacterString>Toronto</gco:CharacterString>
           </gmd:title>
-          <gmd:date>
-            <gmd:CI_Date>
-              <gmd:date>
-                <gco:Date>2011</gco:Date>
-              </gmd:date>
-              <gmd:dateType>
-                <gmd:CI_DateTypeCode codeSpace="ISOTC211/19115" codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
-              </gmd:dateType>
-            </gmd:CI_Date>
-          </gmd:date>
+          <gmd:date gco:nilReason="missing"/>
         </gmd:CI_Citation>
       </gmd:citation>
       <gmd:abstract>

--- a/msautotest/wxs/expected/ows_metadata_layer_vector.xml
+++ b/msautotest/wxs/expected/ows_metadata_layer_vector.xml
@@ -113,16 +113,7 @@ Content-type: text/xml
           <gmd:title>
             <gco:CharacterString>province</gco:CharacterString>
           </gmd:title>
-          <gmd:date>
-            <gmd:CI_Date>
-              <gmd:date>
-                <gco:Date>2011</gco:Date>
-              </gmd:date>
-              <gmd:dateType>
-                <gmd:CI_DateTypeCode codeSpace="ISOTC211/19115" codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication">publication</gmd:CI_DateTypeCode>
-              </gmd:dateType>
-            </gmd:CI_Date>
-          </gmd:date>
+          <gmd:date gco:nilReason="missing"/>
           <gmd:otherCitationDetails>
             <gco:CharacterString>MapServer</gco:CharacterString>
           </gmd:otherCitationDetails>

--- a/msautotest/wxs/expected/ows_metadata_layer_vector.xml
+++ b/msautotest/wxs/expected/ows_metadata_layer_vector.xml
@@ -123,6 +123,9 @@ Content-type: text/xml
               </gmd:dateType>
             </gmd:CI_Date>
           </gmd:date>
+          <gmd:otherCitationDetails>
+            <gco:CharacterString>MapServer</gco:CharacterString>
+          </gmd:otherCitationDetails>
         </gmd:CI_Citation>
       </gmd:citation>
       <gmd:abstract>

--- a/msautotest/wxs/expected/ows_metadata_wms_capabilities111.xml
+++ b/msautotest/wxs/expected/ows_metadata_wms_capabilities111.xml
@@ -163,6 +163,9 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
         <Title>province</Title>
         <Abstract>province</Abstract>
         <LatLonBoundingBox minx="-66.7243" miny="41.7705" maxx="-57.7217" maxy="48.4773" />
+    <Attribution>
+        <Title>MapServer</Title>
+    </Attribution>
         <MetadataURL type="TC211">
           <Format>text/xml</Format>
           <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://localhost/ows?request=GetMetadata&amp;layer=province"/>

--- a/msautotest/wxs/expected/ows_metadata_wms_capabilities130.xml
+++ b/msautotest/wxs/expected/ows_metadata_wms_capabilities130.xml
@@ -174,6 +174,9 @@ Content-Type: text/xml; charset=UTF-8
             <southBoundLatitude>41.7705</southBoundLatitude>
             <northBoundLatitude>48.4773</northBoundLatitude>
         </EX_GeographicBoundingBox>
+    <Attribution>
+        <Title>MapServer</Title>
+    </Attribution>
         <MetadataURL type="TC211">
           <Format>text/xml</Format>
           <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://localhost/ows?request=GetMetadata&amp;layer=province"/>

--- a/msautotest/wxs/ows_metadata.map
+++ b/msautotest/wxs/ows_metadata.map
@@ -128,6 +128,7 @@ LAYER
     "ows_title" "province"
     "ows_abstract" "province"
     "wfs_featureid" "NAME_E"
+    "ows_attribution_title" "MapServer"
   END
   TYPE POINT
   STATUS ON


### PR DESCRIPTION
Implements #6166 

In addition, removes erroneous default date output.