### PR TITLE
docs: fix simple typo, renrdering -> rendering

### DIFF
--- a/renderers/agg/include/agg_rendering_buffer.h
+++ b/renderers/agg/include/agg_rendering_buffer.h
@@ -128,7 +128,7 @@ namespace mapserver
 
     private:
         //--------------------------------------------------------------------
-        T*            m_buf;    // Pointer to renrdering buffer
+        T*            m_buf;    // Pointer to rendering buffer
         T*            m_start;  // Pointer to first pixel depending on stride 
         unsigned      m_width;  // Width in pixels
         unsigned      m_height; // Height in pixels
@@ -258,7 +258,7 @@ namespace mapserver
 
     private:
         //--------------------------------------------------------------------
-        T*            m_buf;        // Pointer to renrdering buffer
+        T*            m_buf;        // Pointer to rendering buffer
         pod_array<T*> m_rows;       // Pointers to each row of the buffer
         unsigned      m_width;      // Width in pixels
         unsigned      m_height;     // Height in pixels


### PR DESCRIPTION
There is a small typo in renderers/agg/include/agg_rendering_buffer.h.

Should read `rendering` rather than `renrdering`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md