### PR TITLE
pytest.ini: explicitly exclude php and myssql sub directories

### DIFF
--- a/msautotest/pytest.ini
+++ b/msautotest/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 python_files = *.py
 testpaths = misc gdal query renderers wxs sld mspython
-
+norecursedirs = php mssql


### PR DESCRIPTION
For some unknown reason, they are attempted to be accessed when
running 'pytest msautotest' within Vagrant, despite not being
in the white list of ``testpaths``