### PR TITLE
Add MapScript Python 3.8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,11 @@ matrix:
         - BUILD_NAME=PHP_7.3_WITH_PROJ7
         - PYTHON_VERSION=3.7
 
+    - php: 7.4
+      env:
+        - BUILD_NAME=PHP_7.4
+        - PYTHON_VERSION=3.8
+
 cache:
     apt: true
     directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,8 @@ environment:
     Python_ROOT_DIR: c:/python36-x64
   - platform: x64
     Python_ROOT_DIR: c:/python37-x64
+  - platform: x64
+    Python_ROOT_DIR: c:/python38-x64
 
 services:
   - mssql2017
@@ -82,6 +84,8 @@ build_script:
   - cmake --build . --config Release
   - cd %BUILD_FOLDER%/build
   - set PATH=%BUILD_FOLDER%/build/Release;%SDK_BIN%;%PATH%
+  # set the MapScript custom environment variable for py 3.8
+  - set MAPSERVER_DLL_PATH=%BUILD_FOLDER%/build/Release;%SDK_BIN%
   - set PROJ_LIB=%SDK_BIN%/proj/SHARE
   # check the mapserver exe can run
   - mapserv -v

--- a/mapscript/python/README.rst
+++ b/mapscript/python/README.rst
@@ -2,7 +2,7 @@ Python MapScript for MapServer README
 =====================================
 
 :Author: MapServer Team
-:Last Updated: 2021-01-16
+:Last Updated: 2021-01-29
 
 Introduction
 ------------
@@ -41,6 +41,8 @@ These are as follows at the time of writing:
 + Python 2.7 x32
 + Python 2.7 x64
 + Python 3.6 x64
++ Python 3.7 x64
++ Python 3.8 x64
 
 The mapscript wheels have been compiled using Visual Studio 2017 version 15 (``MSVC++ 14.11 _MSC_VER == 1911``). 
 Linux Wheels may also be available in the future using the `manylinux <https://github.com/pypa/manylinux>`_ project. 
@@ -58,15 +60,41 @@ Installation on Windows
 -----------------------
 
 To use mapscript you will need to add the MapServer binaries to your system path. 
-On Windows you can use the following, replacing ``C:\MapServer\bin`` with the location of your MapServer binaries. 
+
+For Python 3.8+
++++++++++++++++
+
+As of `Python 3.8 <https://docs.python.org/3/whatsnew/3.8.html#changes-in-the-python-api>`_ ``PATH`` 
+and the current working directory are no longer used when searching for the MapServer DLLs.
+A new environment variable ``MAPSERVER_DLL_PATH`` has been introduced to set the location of the MapServer DLLs.
+On Windows you can use the following, replacing ``C:\MapServer\bin`` with the location of your MapServer binaries.
+
+.. code-block:: bat
+
+    SET MAPSERVER_DLL_PATH=C:\MapServer\bin
+
+If several folders are required (e.g. GDAL DLLs) multiple paths can be provided separated by semi-colons:
+
+.. code-block:: bat
+
+    SET MAPSERVER_DLL_PATH=C:\MapServer\bin;C:\GDAL\bin
+
+For Earlier Python Versions
++++++++++++++++++++++++++++
+
+For Python 3.7 and earlier (including Python 2.7) you can use either the ``MAPSERVER_DLL_PATH`` variable documented above,
+or the system ``PATH`` variable as below, replacing ``C:\MapServer\bin`` with the location of your MapServer binaries. 
 
 .. code-block:: bat
 
     SET PATH=C:\MapServer\bin;%PATH%
 
+Windows Binaries
+++++++++++++++++
+
 Windows binary packages can be downloaded from `GIS Internals <https://www.gisinternals.com/stable.php>`_. 
-To ensure compatibility with the wheels, please use identical release packages, e.g. ``release-1911-x64-gdal-2-3-mapserver-7-4``
-for mapscript 7.4. 
+To ensure compatibility with the wheels, please use identical release packages, e.g. ``release-1928-x64-gdal-3-2-mapserver-7-6``
+for mapscript 7.6. 
 
 .. NOTE::
    `MS4W <https://www.ms4w.com>`_ (MapServer for Windows) is a full installer that contains Python & Python
@@ -97,7 +125,7 @@ Now you should be able to import mapscript:
 .. code-block:: python
 
     python -c "import mapscript;print(mapscript.msGetVersion())"
-    MapServer version 7.4.0 OUTPUT=PNG OUTPUT=JPEG OUTPUT=KML SUPPORTS=PROJ SUPPORTS=AGG SUPPORTS=FREETYPE SUPPORTS=CAIRO SUPPORTS=SVG_SYMBOLS SUPPORTS=SVGCAIRO SUPPORTS=ICONV SUPPORTS=FRIBIDI SUPPORTS=WMS_SERVER SUPPORTS=WMS_CLIENT SUPPORTS=WFS_SERVER SUPPORTS=WFS_CLIENT SUPPORTS=WCS_SERVER SUPPORTS=SOS_SERVER SUPPORTS=FASTCGI SUPPORTS=THREADS SUPPORTS=GEOS SUPPORTS=PBF INPUT=JPEG INPUT=POSTGIS INPUT=OGR INPUT=GDAL INPUT=SHAPEFILE
+    MapServer version 7.6.0 OUTPUT=PNG OUTPUT=JPEG OUTPUT=KML SUPPORTS=PROJ SUPPORTS=AGG SUPPORTS=FREETYPE SUPPORTS=CAIRO SUPPORTS=SVG_SYMBOLS SUPPORTS=SVGCAIRO SUPPORTS=ICONV SUPPORTS=FRIBIDI SUPPORTS=WMS_SERVER SUPPORTS=WMS_CLIENT SUPPORTS=WFS_SERVER SUPPORTS=WFS_CLIENT SUPPORTS=WCS_SERVER SUPPORTS=SOS_SERVER SUPPORTS=FASTCGI SUPPORTS=THREADS SUPPORTS=GEOS SUPPORTS=PBF INPUT=JPEG INPUT=POSTGIS INPUT=OGR INPUT=GDAL INPUT=SHAPEFILE
 
 If you failed to add the MapServer binaries to your system path you may see one of the following errors:
 
@@ -239,8 +267,8 @@ Make sure the MapServer binaries are on the system path, and that the PROJ_LIB v
 
 .. code-block:: bat
 
-    SET PATH=C:\release-1911-x64-gdal-2-3-mapserver-7-4\bin;%PATH%
-    SET PROJ_LIB=C:\release-1911-x64-gdal-2-3-mapserver-7-4\bin\proj\SHARE
+    SET PATH=C:\release-1928-x64-gdal-3-2-mapserver-7-6\bin;%PATH%
+    SET PROJ_LIB=C:\release-1928-x64-gdal-3-2-mapserver-7-6\bin\proj\SHARE
 
 Finally run the command below to run the test suite: 
 

--- a/mapscript/python/mapscript/__init__.py
+++ b/mapscript/python/mapscript/__init__.py
@@ -1,5 +1,33 @@
+import sys
+import platform
+import os
 import inspect
+
+# As of Python 3.8 PATH can no longer be used to resolve the MapServer
+# DLLs on Windows. Instead users will be required to set a new MAPSERVER_DLL_PATH
+# environment variable.
+# See https://docs.python.org/3/whatsnew/3.8.html#changes-in-the-python-api
+
+
+def add_dll_path(pth):
+    if (3, 8) <= sys.version_info:
+        os.add_dll_directory(pth)
+    else:
+        # add the directory to the Windows path for earlier Python version
+        os.environ['PATH'] = pth + ';' + os.environ['PATH']
+
+
+if platform.system() == 'Windows':
+    mapserver_dll_path = os.getenv('MAPSERVER_DLL_PATH', '')
+    dll_paths = mapserver_dll_path.split(';')
+    # add paths in the order listed in the string
+    dll_paths.reverse()
+    for pth in dll_paths:
+        add_dll_path(pth)
+
+
 from .mapscript import *
+
 
 # change all the class module names from mapscript.mapscript to mapscript
 


### PR DESCRIPTION
As per #6101

This adds Windows support for Python MapScript 3.8, and testing under Appveyor. 
Also tests PHP 7.4 and Python 3.8 on Ubuntu with Travis. 

CI build times will increase with this pull request. Python 3.6 is EOL at the end of 2021 so perhaps this could be dropped from the CI?
