### PR TITLE
Document labelCacheObj and associated objects (RFC 132)

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -6042,10 +6042,6 @@ int msFreeLabelCacheSlot(labelCacheSlotObj *cacheslot)
       }
       msFree(cacheslot->labels[i].textsymbols);
 
-#ifdef include_deprecated
-      for(j=0; j<cacheslot->labels[i].numstyles; j++) freeStyle(&(cacheslot->labels[i].styles[j]));
-      msFree(cacheslot->labels[i].styles);
-#endif
       if(cacheslot->labels[i].leaderline) {
         msFree(cacheslot->labels[i].leaderline->point);
         msFree(cacheslot->labels[i].leaderline);

--- a/maplabel.c
+++ b/maplabel.c
@@ -485,14 +485,6 @@ int msAddLabel(mapObj *map, imageObj *image, labelObj *label, int layerindex, in
 
   cachePtr->layerindex = layerindex; /* so we can get back to this *raw* data if necessary */
   cachePtr->classindex = classindex;
-#ifdef include_deprecated
-  if(shape) {
-    cachePtr->shapetype = shape->type;
-  } else {
-    cachePtr->shapetype = MS_SHAPE_POINT;
-  }
-#endif
-
   cachePtr->leaderline = NULL;
   cachePtr->leaderbbox = NULL;
 

--- a/mapserver.h
+++ b/mapserver.h
@@ -1314,13 +1314,13 @@ typedef struct labelObj labelObj;
   attribute of a mapObj. Associated with labelCacheMemberObj and markerCacheMemberObj.
   */
   typedef struct {
+    int num_rendered_members; ///< Number of rendered labels
 #ifndef SWIG
     /* One labelCacheSlotObj for each priority level */
     labelCacheSlotObj slots[MS_MAX_LABEL_PRIORITY];
     int gutter; /* space in pixels around the image where labels cannot be placed */
     labelCacheMemberObj **rendered_text_symbols;
     int num_allocated_rendered_members;
-    int num_rendered_members;
 #endif
   } labelCacheObj;
 

--- a/mapserver.h
+++ b/mapserver.h
@@ -1261,62 +1261,67 @@ typedef struct labelObj labelObj;
 #ifdef SWIG
   %immutable;
 #endif /* SWIG */
+  /**
+  An individual feature label. The labelCacheMemberObj class is associated with labelCacheObj.
+  */
   typedef struct {
-#ifdef include_deprecated
-    styleObj *styles; /* copied from the classObj, only present if there is a marker to be drawn */
-    int numstyles;
-#endif
+    int numtextsymbols; ///< Number of text symbols found in textsymbols
+    int layerindex; ///< The index of the layer of the labelled feature
+    int classindex; ///< Index of the class of the labelled feature
+    int status; ///< Has this label been drawn or not?
+    int markerid;  ///< Corresponding marker (POINT layers only)
 
+    pointObj point; ///< Label point
+    rectObj bbox; ///< Bounds of the whole cachePtr. Individual text and symbol sub bounds are found in textsymbols
+
+    lineObj *leaderline; ///< Leader lineObj
+    rectObj *leaderbbox; ///< Leader rectObj
+
+#ifndef SWIG
     textSymbolObj **textsymbols;
-    int numtextsymbols;
-
-    int layerindex; /* indexes */
-    int classindex;
-
-#ifdef include_deprecated
-    int shapetype; /* source geometry type, can be removed once annotation layers are dropped */
 #endif
 
-    pointObj point; /* label point */
-    rectObj bbox; /* bounds of the whole cachePtr. Individual text and symbol sub bounds are found in the textsymbols */
-
-    int status; /* has this label been drawn or not */
-
-    int markerid; /* corresponding marker (POINT layers only) */
-    lineObj *leaderline;
-    rectObj *leaderbbox;
   } labelCacheMemberObj;
 
   /************************************************************************/
   /*                         markerCacheMemberObj                         */
   /************************************************************************/
+  /**
+  An individual marker. The markerCacheMemberObj class is associated with labelCacheObj.
+  */
   typedef struct {
-    int id; /* corresponding label */
-    rectObj bounds;
+    int id; ///< Corresponding label
+    rectObj bounds; ///< Bounds of the markerCacheMemberObj
   } markerCacheMemberObj;
 
   /************************************************************************/
   /*                          labelCacheSlotObj                           */
   /************************************************************************/
   typedef struct {
+    int numlabels; ///< Number of label members
+    int cachesize; ///< TODO
+    int nummarkers; ///< Number of marker members
+    int markercachesize; ///< TODO
     labelCacheMemberObj *labels;
-    int numlabels;
-    int cachesize;
     markerCacheMemberObj *markers;
-    int nummarkers;
-    int markercachesize;
   } labelCacheSlotObj;
 
   /************************************************************************/
   /*                            labelCacheObj                             */
   /************************************************************************/
+  /**
+  Set of a map's cached labels. Has no other existence other than as a labelcache
+  attribute of a mapObj. Associated with labelCacheMemberObj and markerCacheMemberObj.
+  */
   typedef struct {
+#ifndef SWIG
     /* One labelCacheSlotObj for each priority level */
     labelCacheSlotObj slots[MS_MAX_LABEL_PRIORITY];
     int gutter; /* space in pixels around the image where labels cannot be placed */
     labelCacheMemberObj **rendered_text_symbols;
     int num_allocated_rendered_members;
     int num_rendered_members;
+#endif
   } labelCacheObj;
 
   /************************************************************************/


### PR DESCRIPTION
This pull request documents labelCacheObj and associated objects properties, which can then be used to generate SWIG API docs as part of [RFC 132](https://mapserver.org/development/rfc/ms-rfc-132.html)

Other changes are as follows:

- The current MapScript API docs don't currently reflect changes made to the labelling related objects  since the [RFC98 changes](https://github.com/MapServer/MapServer/issues/4673). There is a 'new' (from 2013) `labelCacheSlotObj` which now has several of the properties previously associated with `labelCacheObj`: cachesize, markercachesize, numlabels, nummarkers. 

- A deprecated property of `labelCacheMemberObj` and related code has been removed as annotation layers were dropped several versions ago. There is mention of the [include_deprecated](https://github.com/MapServer/MapServer/search?q=include_deprecated) anywhere else in build scripts or the codebase. 

```
#ifdef include_deprecated
    int shapetype; /* source geometry type, can be removed once annotation layers are dropped */
#endif
```

- labelCacheMemberObj > textSymbolObj - hidden as array would need typemaps for access

