### PR TITLE
drop PHP 7.1 + Python 2.7 from TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ language: php
 matrix:
   include:
 
-    - php: 7.1
-      env:
-        - BUILD_NAME=PHP_7.1
-        - PYTHON_VERSION=2.7
-
     - php: 7.2
       env:
         - BUILD_NAME=PHP_7.2_WITH_ASAN


### PR DESCRIPTION
- PHP 7.1 was end-of-life in 2018, and ended security fixes at end of 2019
- Python 2.7 ended security releases at end of 2019

Remaining tests are:
- PHP 7.4, 7.3, 7.2
- Python 3.8, 3.7, 3.6