### PR TITLE
Update mapObj comments and docstring fixes

### DIFF
--- a/mapscript/python/pyextend.i
+++ b/mapscript/python/pyextend.i
@@ -240,9 +240,9 @@ def fromstring(data, mappath=None):
 
 %extend mapObj {
   
-    /* getLayerOrder() extension returns the map layerorder as a native
-     sequence */
-
+    /**
+    \**Python MapScript only**  - returns the map layer order as a native sequence
+    */
     PyObject *getLayerOrder() {
         int i;
         PyObject *order;
@@ -253,6 +253,9 @@ def fromstring(data, mappath=None):
         return order;
     } 
 
+    /**
+    \**Python MapScript only** - sets the map layer order using a native sequence
+    */
     int setLayerOrder(PyObject *order) {
         int i;
         Py_ssize_t size = PyTuple_Size(order);
@@ -262,6 +265,9 @@ def fromstring(data, mappath=None):
         return MS_SUCCESS;
     }
     
+    /**
+    \**Python MapScript only** - gets the map size as a tuple
+    */
     PyObject* getSize()
     {
         PyObject* output ;
@@ -274,19 +280,35 @@ def fromstring(data, mappath=None):
 %pythoncode %{
 
     def get_height(self):
+        """
+        **Python MapScript only**
+        Return the map height from the map size
+        """
         return self.getSize()[1] # <-- second member is the height
 
     def get_width(self):
+        """
+        **Python MapScript only**
+        Return the map width from the map size
+        """
         return self.getSize()[0] # <-- first member is the width
 
     def set_height(self, value):
+        """
+        **Python MapScript only**
+        Set the map height value of the map size
+        """
         return self.setSize(self.getSize()[0], value)
 
     def set_width(self, value):
+        """
+        **Python MapScript only**
+        Set the map width value of the map size
+        """
         return self.setSize(value, self.getSize()[1])
 
-    width = property(get_width, set_width)
-    height = property(get_height, set_height)
+    width = property(get_width, set_width, doc="See :ref:`SIZE <mapfile-map-size>`")
+    height = property(get_height, set_height, doc = "See :ref:`SIZE <mapfile-map-size>`")
 
 %}
 }

--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -210,7 +210,7 @@
       return msGetSymbolIndex(&self->symbolset, name, MS_TRUE);
     }
 
-    /// **TODO** this function only calculates the scale or am I missing something?
+    /// \**TODO** this function only calculates the scale or am I missing something?
     void prepareQuery() {
       int status;
 

--- a/mapscript/swiginc/mapzoom.i
+++ b/mapscript/swiginc/mapzoom.i
@@ -11,7 +11,7 @@
 
 %extend mapObj {
 
-    /*
+    /**
     Zoom by the given factor to a pixel position within the width
     and height bounds. If max_extent is not NULL, the zoom is 
     constrained to the max_extents
@@ -202,7 +202,7 @@
         return MS_SUCCESS;
     }
 
-    /*
+    /**
     Set the map extents to a given extents. 
     Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE` on error
     */
@@ -370,7 +370,7 @@
         return MS_SUCCESS;
     }
 
-    /*
+    /**
      Zoom by the given factor to a pixel position within the width
      and height bounds.  If max_extent is not NULL, the zoom is 
      constrained to the max_extents

--- a/mapserver.h
+++ b/mapserver.h
@@ -1845,125 +1845,89 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   /*      application.                                                    */
   /************************************************************************/
 
-  /* MAP OBJECT -  */
+  /**
+  The :ref:`MAP <map>` object
+  */
   struct mapObj { /* structure for a map */
-    char *name; /* small identifier for naming etc. */
-    int status; /* is map creation on or off */
-    int height, width;
-    int maxsize;
 
 #ifndef SWIG
-    layerObj **layers;
+      layerObj **layers;
+      geotransformObj gt; /* rotation / geotransform */
+      rectObj saved_extent;
+      paletteObj palette; /* holds a map palette */
+      outputFormatObj **outputformatlist;
+      projectionObj projection; /* projection information for output map */
+      projectionObj latlon; /* geographic projection definition */
+
+      /* Private encryption key information - see mapcrypto.c */
+      int encryption_key_loaded;        /* MS_TRUE once key has been loaded */
+      unsigned char encryption_key[MS_ENCRYPTION_KEY_SIZE]; /* 128bits encryption key */
+      queryObj query;
+      projectionContext* projContext;
+
 #endif /* SWIG */
 
 #ifdef SWIG
-    %immutable;
+      %immutable;
 #endif /* SWIG */
-    /* reference counting, RFC24 */
-    int refcount;
-    int numlayers; /* number of layers in mapfile */
-    int maxlayers; /* allocated size of layers[] array */
+      int refcount; ///< Used for reference counting see RFC24
+      int numlayers; ///< Number of layers in mapfile
+      int maxlayers; ///< Allocated size of layers[] array
 
-    symbolSetObj symbolset;
-    fontSetObj fontset;
+      hashTableObj configoptions; ///< A hash table of configuration options from CONFIG keywords in the map - see :ref:`CONFIG <mapfile-map-config>`
 
-    labelCacheObj labelcache; /* we need this here so multiple feature processors can access it */
+      symbolSetObj symbolset; ///< See :ref:`SYMBOLSET <mapfile-map-symbolset>`
+      fontSetObj fontset; ///< See :ref:`FONTSET <mapfile-map-fontset>`
+
+      labelCacheObj labelcache; ///< We need this here so multiple feature processors can access it
+      int numoutputformats; ///< Number of output formats available in the map
+      outputFormatObj *outputformat; ///< See :ref:`OUTPUTFORMAT <mapfile-map-outputformat>`
+      char *imagetype; ///< Name of current outputformat
+
+      referenceMapObj reference; ///< See :ref:`SCALEBAR <mapfile-map-scalebar>`
+      scalebarObj scalebar; ///< See :ref:`SCALEBAR <mapfile-map-scalebar>`
+      legendObj legend; ///< See :ref:`LEGEND <mapfile-map-legend>`
+      queryMapObj querymap; ///< See :ref:`QUERYMAP <mapfile-map-querymap>`
+      webObj web; ///< See :ref:`WEB <mapfile-map-web>`
+
 #ifdef SWIG
     %mutable;
 #endif /* SWIG */
 
-    int transparent; /* TODO - Deprecated */
-    int interlace; /* TODO - Deprecated */
-    int imagequality; /* TODO - Deprecated */
+    int transparent; ///< TODO - Deprecated
+    int interlace; ///< TODO - Deprecated
+    int imagequality; ///< TODO - Deprecated
+    char *datapattern; ///< TODO - Deprecated use VALIDATION ... END block instead
+    char *templatepattern; ///< TODO - Deprecated use VALIDATION ... END block instead
 
-    rectObj extent; /* map extent array */
-    double cellsize; /* in map units */
+    char *name; ///< Small identifier for naming etc - see :ref:`NAME <mapfile-map-name>`
+    int status;  ///< Is map creation on or off - see :ref:`STATUS <mapfile-map-status>`
+    int height; ///< See :ref:`SIZE <mapfile-map-size>`
+    int width; ///< See :ref:`SIZE <mapfile-map-size>`
+    int maxsize; ///< See :ref:`MAXSIZE  <mapfile-map-maxsize>`
 
+    rectObj extent; ///< Map extent array - see :ref:`EXTENT <mapfile-map-extent>`
+    double cellsize; ///< Pixel size in map units
 
-#ifndef SWIG
-    geotransformObj gt; /* rotation / geotransform */
-    rectObj saved_extent;
-#endif /*SWIG*/
+    enum MS_UNITS units; ///< Units of the projection - see :ref:`UNITS <mapfile-map-units>`
+    double scaledenom; ///< The nominal map scale, a value of 25000 means 1:25000 scale - see :ref:`SCALEDENOM  <mapfile-map-scaledenom>`
+    double resolution; ///< See :ref:`RESOLUTION <mapfile-map-resolution>`
+    double defresolution; ///< Default resolution - used to calculate the scalefactor, see :ref:`DEFRESOLUTION <mapfile-map-defresolution>`
 
-    enum MS_UNITS units; /* units of the projection */
-    double scaledenom; /* scale of the output image */
-    double resolution;
-    double defresolution; /* default resolution: used for calculate the scalefactor */
+    char *shapepath; ///< Where are the shape files located - see :ref:`SHAPEPATH <mapfile-map-shapepath>`
+    char *mappath; ///< Path of the mapfile, all paths are relative to this path
+    char *sldurl; ///< URL of SLD document as specified with "&SLD=..." WMS parameter d- currently this reference is used only in mapogcsld.c 
+                  ///< and has a NULL value outside that context
 
-    char *shapepath; /* where are the shape files located */
-    char *mappath; /* path of the mapfile, all path are relative to this path */
-    char *sldurl; // URL of SLD document as specified with "&SLD=..."
-                  // WMS parameter.  Currently this reference is used
-                  // only in mapogcsld.c and has a NULL value
-                  // outside that context.
+    colorObj imagecolor; ///< Holds the initial image color value - see :ref:`IMAGECOLOR <mapfile-map-imagecolor>`
 
-#ifndef SWIG
-    paletteObj palette; /* holds a map palette */
-#endif /*SWIG*/
-    colorObj imagecolor; /* holds the initial image color value */
-
-#ifdef SWIG
-    %immutable;
-#endif /* SWIG */
-    int numoutputformats;
-#ifndef SWIG
-    outputFormatObj **outputformatlist;
-#endif /*SWIG*/
-    outputFormatObj *outputformat;
-
-    char *imagetype; /* name of current outputformat */
-#ifdef SWIG
-    %mutable;
-#endif /* SWIG */
-
-#ifndef SWIG
-    projectionObj projection; /* projection information for output map */
-    projectionObj latlon; /* geographic projection definition */
-#endif /* not SWIG */
-
-#ifdef SWIG
-    %immutable;
-#endif /* SWIG */
-    referenceMapObj reference;
-    scalebarObj scalebar;
-    legendObj legend;
-
-    queryMapObj querymap;
-
-    webObj web;
-#ifdef SWIG
-    %mutable;
-#endif /* SWIG */
-
-    int *layerorder;
-
-    int debug;
-
-    char *datapattern, *templatepattern; /* depricated, use VALIDATION ... END block instead */
-
-#ifdef SWIG
-    %immutable;
-#endif /* SWIG */
-    hashTableObj configoptions;
-#ifdef SWIG
-    %mutable;
-#endif /* SWIG */
-
-#ifndef SWIG
-    /* Private encryption key information - see mapcrypto.c */
-    int encryption_key_loaded;        /* MS_TRUE once key has been loaded */
-    unsigned char encryption_key[MS_ENCRYPTION_KEY_SIZE]; /* 128bits encryption key */
-
-    queryObj query;
-#endif
+    int *layerorder; ///< Used to modify the order in which the layers are drawn - TODO should be immutable?
+    int debug; ///< See :ref:`DEBUG <mapfile-map-debug>`
 
 #ifdef USE_V8_MAPSCRIPT
     void *v8context;
 #endif
 
-#ifndef SWIG
-    projectionContext* projContext;
-#endif
   };
 
   /************************************************************************/


### PR DESCRIPTION
Documents the mapObj struct to make available for autogenerated SWIG docs as part of https://mapserver.org/development/rfc/ms-rfc-132.html
Reorders properties to reduce the `#ifdef SWIG` occurrences. 

Also fixes a few of the method docstrings in the .i SWIG files. 

No changes to immutable etc. as part of this pull request, although a few properties should be investigated further:

- `height` and `width` can be set by SWIG. However the Python bindings have custom methods added to set these by the size property: https://github.com/MapServer/MapServer/blob/e0372c34f5bfb3f539d2737fd98c9f68f9de7d2a/mapscript/python/pyextend.i#L276
- `int *layerorder;` can be set via SWIG but I think should be at least immutable and propbably accessed via methods - again this is the case for the Python bindings: https://github.com/MapServer/MapServer/blob/e0372c34f5bfb3f539d2737fd98c9f68f9de7d2a/mapscript/python/pyextend.i#L256