### PR TITLE
Document outputFormatObj, projectionObj and map primitives

### DIFF
--- a/mapprimitive.h
+++ b/mapprimitive.h
@@ -30,9 +30,15 @@
 #ifndef MAPPRIMITIVE_H
 #define MAPPRIMITIVE_H
 
-/* feature primitives */
+ /**
+ A rectObj represents a rectangle or bounding box.
+ A rectObj may be a lone object or an attribute of another object and has no other associations.
+ */
 typedef struct {
-  double minx, miny, maxx, maxy;
+  double minx; ///< Minimum easting
+  double miny; ///< Minimum northing
+  double maxx; ///< Maximum easting
+  double maxy; ///< Maximum northing
 } rectObj;
 
 #ifndef SWIG
@@ -42,17 +48,21 @@ typedef struct {
 } vectorObj;
 #endif /*SWIG*/
 
+/**
+A :class:`pointObj` has an x, y and optionally z and m values.
+A :class:`pointObj` instance may be associated with a :class:`lineObj`.
+*/
 typedef struct {
-  double x;
-  double y;
+  double x; ///< The x coordinate of the point
+  double y; ///< The y coordinate of the point
 #ifdef USE_POINT_Z_M
-  double z;
-  double m;
+  double z; ///< The z (height) coordinate of the point
+  double m; ///< The m (measure) of the point, used for linear referencing
 #endif
 } pointObj;
 
 /**
-A lineObj is composed of one or more pointObj instances
+A :class:`lineObj` is composed of one or more :class:`pointObj` instances
 */
 typedef struct {
 #ifdef SWIG
@@ -67,38 +77,43 @@ typedef struct {
 #endif
 } lineObj;
 
+/**
+Each feature of a layer's data is a :class:`shapeObj`. Each part of the shape is a closed :class:`lineObj`.
+*/
 typedef struct {
+
+#ifndef SWIG
+    lineObj *line;
+    char **values;
+    void *geometry;
+    void *renderer_cache;
+#endif
+
 #ifdef SWIG
   %immutable;
 #endif
-  int numlines;
-  int numvalues;
-#ifndef SWIG
-  lineObj *line;
-  char **values;
-  void *geometry;
-  void *renderer_cache;
-#endif
+  int numlines; ///< Number of parts
+  int numvalues; ///< Number of shape attributes
 
 #ifdef SWIG
   %mutable;
 #endif
 
-  rectObj bounds;
-  int type; /* MS_SHAPE_TYPE */
-  long index;
-  int tileindex;
-  int classindex;
-  char *text;
+  rectObj bounds; ///< Bounding box of shape
+  int type; ///< MS_SHAPE_POINT, MS_SHAPE_LINE, MS_SHAPE_POLYGON, or MS_SHAPE_NULL
+  long index; ///< Feature index within the layer
+  int tileindex; ///< Index of tiled file for tile-indexed layers
+  int classindex; ///< The class index for features of a classified layer
+  char *text; ///< Shape annotation
 
   int scratch;
-  int resultindex; /* index within a query result set */
+  int resultindex; ///< Index within a query result set
 } shapeObj;
 
 typedef lineObj multipointObj;
 
 #ifndef SWIG
-/* attribute primatives */
+/* attribute primitives */
 typedef struct {
   char *name;
   long type;

--- a/mapproject.h
+++ b/mapproject.h
@@ -55,29 +55,36 @@ extern "C" {
 
 typedef struct projectionContext projectionContext;
 
+/**
+The :ref:`PROJECTION <projection>` object
+MapServer's Maps and Layers have Projection attributes, and these are C projectionObj structures, 
+but are not directly exposed by the mapscript module
+*/
   typedef struct {
+#ifndef SWIG
+      char **args; /* variable number of projection args */
+#if PROJ_VERSION_MAJOR >= 6
+      PJ* proj;
+      projectionContext* proj_ctx;
+#else
+      projPJ proj; /* a projection structure for the PROJ package */
+#if PJ_VERSION >= 480
+      projCtx proj_ctx;
+#endif
+#endif
+      geotransformObj gt; /* extra transformation to apply */
+#endif
+
 #ifdef SWIG
     %immutable;
 #endif
-    int numargs; /* actual number of projection args */
-    int automatic; /* projection object was to fetched from the layer */
+    int numargs; ///< Actual number of projection args
+    int automatic; ///< Projection object was to fetched from the layer
 #ifdef SWIG
     %mutable;
 #endif
-#ifndef SWIG
-    char **args; /* variable number of projection args */
-#if PROJ_VERSION_MAJOR >= 6
-    PJ* proj;
-    projectionContext* proj_ctx;
-#else
-    projPJ proj; /* a projection structure for the PROJ package */
-#if PJ_VERSION >= 480
-    projCtx proj_ctx;
-#endif
-#endif
-    geotransformObj gt; /* extra transformation to apply */
-#endif
-    int wellknownprojection;
+
+    int wellknownprojection; ///< One of ``wkp_none 0``, ``wkp_lonlat 1``, or ``wkp_gmerc 2``
   } projectionObj;
 
 #ifndef SWIG

--- a/mapserver.h
+++ b/mapserver.h
@@ -844,32 +844,35 @@ The :ref:`CLUSTER <cluster>` object. See :ref:`RFC 69 <rfc69>`.
   /*                                                                      */
   /*      see mapoutput.c for most related code.                          */
   /************************************************************************/
-
+ 
+/**
+The :ref:`OUTPUTFORMAT <outputformat>` object
+*/
   typedef struct {
 #ifndef SWIG
     int refcount;
     char **formatoptions;
+    rendererVTableObj *vtable;
+    void *device; /* for supporting direct rendering onto a device context */
 #endif /* SWIG */
 #ifdef SWIG
     %immutable;
 #endif /* SWIG */
-    int  numformatoptions;
+    int  numformatoptions; ///< The number of option values set on this format - can be used to 
+                           ///< iterate over the options array in conjunction with ``getOptionAt``
 #ifdef SWIG
     %mutable;
 #endif /* SWIG */
-    char *name;
-    char *mimetype;
-    char *driver;
-    char *extension;
-    int  renderer;  /* MS_RENDER_WITH_* */
-    int  imagemode; /* MS_IMAGEMODE_* value. */
-    int  transparent;
-    int  bands;
-    int inmapfile; /* boolean value for writing */
-#ifndef SWIG
-    rendererVTableObj *vtable;
-    void *device; /* for supporting direct rendering onto a device context */
-#endif
+    char *name; ///< See :ref:`NAME <mapfile-outputformat-name>`
+    char *mimetype; ///< See :ref:`MIMETYPE <mapfile-outputformat-mimetype>`
+    char *driver; ///< See :ref:`DRIVER <mapfile-outputformat-driver>`
+    char *extension; ///< See :ref:`EXTENSION <mapfile-outputformat-extension>`
+    int  renderer;  ///< ``MS_RENDER_WITH_*`` value - normally set internally based on the driver and some other setting in the constructor.
+    int  imagemode; ///< ``MS_IMAGEMODE_*`` value - see :ref:`IMAGEMODE <mapfile-outputformat-imagemode>`
+    int  transparent; ///< See :ref:`TRANSPARENT <mapfile-outputformat-transparent>`
+    int  bands; ///< The number of bands in the raster, normally set via the BAND_COUNT formatoption - this field should be considered read-only
+                ///< Only used for the "raw" modes, MS_IMAGEMODE_BYTE, MS_IMAGEMODE_INT16, and MS_IMAGEMODE_FLOAT32
+    int inmapfile; ///< Boolean value indicating if the format is in the Mapfile
   } outputFormatObj;
 
   /* The following is used for "don't care" values in transparent, interlace and


### PR DESCRIPTION
Documents properties for `outputFormatObj`,`projectionObj`, and the map primitives `rectObj`, `lineObj`, `pointObj` and `shapeObj` as part of https://mapserver.org/development/rfc/ms-rfc-132.html