### PR TITLE
Document various MapServer structs

### DIFF
--- a/maperror.h
+++ b/maperror.h
@@ -104,15 +104,20 @@ extern "C" {
 #endif
 #endif
 
+/**
+This class allows inspection of the MapServer error stack. 
+Instances of errorObj are created internally by MapServer as errors happen. 
+Errors are managed as a chained list with the first item being the most recent error.
+*/
   typedef struct errorObj {
-    int code;
-    char routine[ROUTINELENGTH];
-    char message[MESSAGELENGTH];
-    int isreported;
-    int errorcount; /* number of subsequent errors */
 #ifndef SWIG
-    struct errorObj *next;
+      struct errorObj *next;
 #endif
+    int code; ///< MapServer error code such as :data:`MS_IMGERR`
+    char routine[ROUTINELENGTH]; ///< MapServer function in which the error was set
+    char message[MESSAGELENGTH]; ///< Context-dependent error message
+    int isreported; ///< :data:`MS_TRUE` or :data:`MS_FALSE` flag indicating if the error has been output
+    int errorcount; ///< Number of subsequent errors
   } errorObj;
 
   /*

--- a/maperror.h
+++ b/maperror.h
@@ -110,14 +110,14 @@ Instances of errorObj are created internally by MapServer as errors happen.
 Errors are managed as a chained list with the first item being the most recent error.
 */
   typedef struct errorObj {
-#ifndef SWIG
-      struct errorObj *next;
-#endif
     int code; ///< MapServer error code such as :data:`MS_IMGERR`
     char routine[ROUTINELENGTH]; ///< MapServer function in which the error was set
     char message[MESSAGELENGTH]; ///< Context-dependent error message
     int isreported; ///< :data:`MS_TRUE` or :data:`MS_FALSE` flag indicating if the error has been output
     int errorcount; ///< Number of subsequent errors
+#ifndef SWIG
+    struct errorObj *next;
+#endif
   } errorObj;
 
   /*

--- a/mapscript/swiginc/resultcache.i
+++ b/mapscript/swiginc/resultcache.i
@@ -29,7 +29,7 @@
 
 %extend resultCacheObj
 {
-    /// Returns the result at index i, like :method:`layerObj.getResult`,
+    /// Returns the result at index i, like :meth:`layerObj.getResult`,
     /// or ``NULL`` if index is outside the range of results.
     resultObj *getResult(int i)
     {

--- a/mapserver.h
+++ b/mapserver.h
@@ -1470,26 +1470,35 @@ The :ref:`REFERENCE <reference>` object
   /************************************************************************/
   /*                             scalebarObj                              */
   /************************************************************************/
+
+  /**
+  The :ref:`SCALEBAR <scalebar>` object
+  */
   typedef struct {
-    colorObj imagecolor;
-    int height, width;
-    int style;
-    int intervals;
-    labelObj label;
-    colorObj color;
-    colorObj backgroundcolor;
-    colorObj outlinecolor;
-    int units;
-    int status; /* ON, OFF or EMBED */
-    int position; /* for embeded scalebars */
+
 #ifndef SWIG
-    int transparent;
-    int interlace;
+      int transparent; // TODO deprecated since 4.6 - remove
+      int interlace; // TODO deprecated since 4.6 - remove
 #endif /* not SWIG */
-    int postlabelcache;
-    int align;
-    int offsetx;
-    int offsety;
+
+      colorObj imagecolor; ///< Background color of scalebar - see :ref:`IMAGECOLOR <mapfile-scalebar-imagecolor>`
+      int height; ///< Height in pixels - see :ref:`SIZE <mapfile-scalebar-size>`
+      int width; ///< Height in pixels - see :ref:`SIZE <mapfile-scalebar-size>`
+      int style; ///< 0 or 1 - see :ref:`STYLE <mapfile-scalebar-style>`
+      int intervals; ///< Number of intervals - see :ref:`INTERVALS <mapfile-scalebar-intervals>`
+      labelObj label; ///< Scalebar label - see :ref:`LABEL <mapfile-scalebar-label>`
+      colorObj color; ///< Scalebar foreground color - see :ref:`COLOR <mapfile-scalebar-color>`
+      colorObj backgroundcolor; ///< Scalebar background color - see :ref:`BACKGROUNDCOLOR <mapfile-scalebar-backgroundcolor>`
+      colorObj outlinecolor; ///< Foreground outline color - see :ref:`OUTLINECOLOR <mapfile-scalebar-outlinecolor>`
+      int units; ///< See :ref:`UNITS <mapfile-scalebar-units>`
+      int status; ///< ON, OFF or EMBED - see :ref:`STATUS <mapfile-scalebar-status>` - :data:`MS_ON`, :data:`MS_OFF`, or :data:`MS_EMBED`.
+      int position; ///< For embeded scalebars - see :ref:`POSITION <mapfile-scalebar-position>` - 
+                    ///< :data:`MS_UL`, :data:`MS_UC`, :data:`MS_UR`, :data:`MS_LL`, :data:`MS_LC`, or :data:`MS_LR`
+
+      int postlabelcache; ///< See :ref:`POSTLABELCACHE <mapfile-scalebar-postlabelcache>` - :data:`MS_TRUE` or :data:`MS_FALSE`
+      int align; ///< See :ref:`ALIGN <mapfile-scalebar-align>`
+      int offsetx; ///< See :ref:`OFFSET <mapfile-scalebar-offset>`
+      int offsety; ///< See :ref:`OFFSET <mapfile-scalebar-offset>`
   } scalebarObj;
 
   /************************************************************************/

--- a/mapserver.h
+++ b/mapserver.h
@@ -1372,19 +1372,18 @@ typedef struct labelObj labelObj;
   /************************************************************************/
   /*                         resultObj                                    */
   /************************************************************************/
+  /**
+  The result object is a handle, of sorts, for a feature of the layer
+  */
   typedef struct {
-    long shapeindex;
-    int tileindex;
-    int resultindex;
-    int classindex;
 #ifndef SWIG
-    shapeObj* shape;
+      shapeObj* shape;
 #endif
+    long shapeindex; ///< The shape index of the result
+    int tileindex; ///< The tile index of the result
+    int resultindex; ///< The index of the result
+    int classindex; ///< The class index of the result
   } resultObj;
-#ifdef SWIG
-  %mutable;
-#endif /* SWIG */
-
 
   /************************************************************************/
   /*                            resultCacheObj                            */

--- a/mapserver.h
+++ b/mapserver.h
@@ -1096,22 +1096,23 @@ The :ref:`STYLE <style>` object. An instance of styleObj is associated with one 
   /*  offsetted from its original position                            */
   /********************************************************************/
 
+/**
+The :ref:`LEADER <leader>` object
+*/
   typedef struct {
-    int maxdistance;
-    int gridstep;
 #ifndef SWIG
     styleObj **styles;
     int maxstyles;
 #endif
-
 #ifdef SWIG
     %immutable;
 #endif
-    int numstyles;
+    int numstyles; ///< Number of styles used
 #ifdef SWIG
     %mutable;
 #endif
-
+    int maxdistance; ///< See :ref:`MAXDISTANCE <mapfile-leader-maxdistance>`
+    int gridstep; ///< See :ref:`GRIDSTEP <mapfile-leader-gridstep>`
   } labelLeaderObj;
 
 

--- a/mapserver.h
+++ b/mapserver.h
@@ -1389,28 +1389,31 @@ typedef struct labelObj labelObj;
   /************************************************************************/
   /*                            resultCacheObj                            */
   /************************************************************************/
+  /**
+  A cached result object
+  */
   typedef struct {
 
 #ifndef SWIG
     resultObj *results;
     int cachesize;
+    rectObj previousBounds; /* bounds at previous iteration */
 #endif /* not SWIG */
 
 #ifdef SWIG
     %immutable;
 #endif /* SWIG */
-    int numresults;
-    rectObj bounds;
-#ifndef SWIG
-    rectObj previousBounds; /* bounds at previous iteration */
-#endif
+    int numresults; ///< Length of result set
+    rectObj bounds; ///< Bounding box of query results
+
 #ifdef SWIG
     %mutable;
 #endif /* SWIG */
 
-    /* TODO: remove for 6.0, confirm with Assefa */
-    /*used to force the result retreiving to use getshape instead of resultgetshape*/
-    int usegetshape;
+    /* TODO: remove for 6.0, confirm with Assefa  - unused in codebase
+    Used to force the result retrieving to use getshape instead of resultgetshape
+    */
+    int usegetshape; ///< \**TODO** Unused - remove
 
   } resultCacheObj;
 
@@ -1418,24 +1421,30 @@ typedef struct labelObj labelObj;
   /************************************************************************/
   /*                             symbolSetObj                             */
   /************************************************************************/
+  /**
+  A :class:`symbolSetObj` is an attribute of a :class:`mapObj` and is associated with instances of :class:`symbolObj`.
+  */
   typedef struct {
-    char *filename;
-    int imagecachesize;
+#ifndef SWIG
+      int refcount;
+      symbolObj** symbol;
+      struct mapObj *map;
+      fontSetObj *fontset; /* a pointer to the main mapObj version */
+      struct imageCacheObj *imagecache;
+#endif /* not SWIG */
+
 #ifdef SWIG
     %immutable;
 #endif /* SWIG */
-    int numsymbols;
-    int maxsymbols;
+    int numsymbols; ///< Number of symbols in the set
+    int maxsymbols; ///< Maximum number of allowed symbols
 #ifdef SWIG
     %mutable;
 #endif /* SWIG */
-#ifndef SWIG
-    int refcount;
-    symbolObj** symbol;
-    struct mapObj *map;
-    fontSetObj *fontset; /* a pointer to the main mapObj version */
-    struct imageCacheObj *imagecache;
-#endif /* not SWIG */
+
+    char *filename; ///< Symbolset filename
+    int imagecachesize; ///< Symbols in the cache
+
   } symbolSetObj;
 
   /************************************************************************/

--- a/mapsymbol.h
+++ b/mapsymbol.h
@@ -151,67 +151,68 @@ struct imageCacheObj {
 
 #endif /* SWIG */
 
-
+/**
+The :ref:`SYMBOL <symbol>` object
+*/
 struct symbolObj{
-  char *name;
-  int type;
-  int inmapfile; /* boolean value for writing */
 
+    /*
+    ** MS_SYMBOL_PIXMAP options
+    */
 #ifndef SWIG
-  /*
-  ** Pointer to his map
-  */
-  struct mapObj *map;
+    rendererVTableObj *renderer;
+    void(*renderer_free_func)(symbolObj *self);
+    rasterBufferObj *pixmap_buffer;
+    void *renderer_cache;
+    char *full_pixmap_path;
+
+    /*
+    ** Pointer to his map
+    */
+    struct mapObj *map;
+
+    pointObj points[MS_MAXVECTORPOINTS];
+
 #endif /* SWIG */
+
+#ifdef SWIG
+    %immutable;
+#endif /* SWIG */
+    int refcount; ///< Reference counter
+    int numpoints; ///< Number of points of a vector symbol
+    char *imagepath; ///< Path to pixmap file - see :ref:`IMAGE <mapfile-symbol-image>`
+
+#ifdef SWIG
+    %mutable;
+#endif /* SWIG */
+
+  char *name; ///< Symbol name - see :ref:`NAME <mapfile-symbol-name>`
+  int type; ///< See :ref:`TYPE <mapfile-symbol-type>`
+  int inmapfile; ///< Boolean value for writing - if set to :data:`TRUE`, the symbol will be saved inside the Mapfile. Added in MapServer 5.6.1
+
   /*
   ** MS_SYMBOL_VECTOR and MS_SYMBOL_ELLIPSE options
   */
-  double sizex, sizey;
-  double minx,miny,maxx,maxy;
+  double sizex; ///< :data:`MS_SYMBOL_VECTOR` and :data:`MS_SYMBOL_ELLIPSE` option
+  double sizey; ///< :data:`MS_SYMBOL_VECTOR` and :data:`MS_SYMBOL_ELLIPSE` option
 
-#ifndef SWIG
-  pointObj points[MS_MAXVECTORPOINTS];
-#endif
+  double minx; ///< :data:`MS_SYMBOL_VECTOR` and :data:`MS_SYMBOL_ELLIPSE` option
+  double miny; ///< :data:`MS_SYMBOL_VECTOR` and :data:`MS_SYMBOL_ELLIPSE` option
+  double maxx; ///< :data:`MS_SYMBOL_VECTOR` and :data:`MS_SYMBOL_ELLIPSE` option
+  double maxy; ///< :data:`MS_SYMBOL_VECTOR` and :data:`MS_SYMBOL_ELLIPSE` option
 
-#ifdef SWIG
-  %immutable;
-#endif /* SWIG */
-  int refcount;
-  int numpoints;
-#ifdef SWIG
-  %mutable;
-#endif /* SWIG */
-  int filled;
+  int filled; ///< :data:`MS_TRUE` or :data:`MS_FALSE` - see :ref:`FILLED <mapfile-symbol-filled>`
+  double anchorpoint_x; ///< See :ref:`ANCHORPOINT <mapfile-symbol-anchorpoint>`
+  double anchorpoint_y; ///< See :ref:`ANCHORPOINT <mapfile-symbol-anchorpoint>`
 
-  double anchorpoint_x, anchorpoint_y;
-
-  /*
-  ** MS_SYMBOL_PIXMAP options
-  */
-#ifndef SWIG
-  rendererVTableObj *renderer;
-  void (*renderer_free_func)(symbolObj *self);
-  rasterBufferObj *pixmap_buffer;
-  void *renderer_cache;
-  char *full_pixmap_path;
-#endif /* SWIG */
-
-#ifdef SWIG
-  %immutable;
-#endif /* SWIG */
-  char *imagepath;
-#ifdef SWIG
-  %mutable;
-#endif /* SWIG */
-
-  int transparent;
-  int transparentcolor;
+  int transparent; ///< \**TODO** Remove
+  int transparentcolor; ///< \**TODO** Remove
 
   /*
   ** MS_SYMBOL_TRUETYPE options
   */
-  char *character;
-  char *font;
+  char *character; ///< For TrueType symbols - see :ref:`CHARACTER <mapfile-symbol-character>`
+  char *font; ///< For TrueType symbols - see :ref:`FONT <mapfile-symbol-font>`
 } ;
 
 #endif /* MAPSYMBOL_H */


### PR DESCRIPTION
Document the following structs as part of https://mapserver.org/development/rfc/ms-rfc-132.html

- scalebarObj
- resultCacheObj
- symbolSetObj
- labelLeaderObj
- errorObj
- symbolObj