### PR TITLE
Improve WMS Filter performance

### DIFF
--- a/maplayer.c
+++ b/maplayer.c
@@ -32,7 +32,7 @@
 #include "mapogcfilter.h"
 #include "mapthread.h"
 #include "mapfile.h"
-
+#include "mapows.h"
 #include "mapparser.h"
 
 #include <assert.h>
@@ -969,7 +969,7 @@ int msLayerWhichItems(layerObj *layer, int get_all, const char *metadata)
     nt += msCountChars(layer->utfdata.string, '[');
 
   // if we are using a GetMap request with a WMS filter we don't need to return all items
-  if (msOWSLookupMetadata(&(layer->metadata), "G", "wms_filter_flag") != NULL) {
+  if (msOWSLookupMetadata(&(layer->metadata), "G", "wmsfilter_flag") != NULL) {
       get_all = MS_FALSE;
   }
 

--- a/maplayer.c
+++ b/maplayer.c
@@ -968,15 +968,20 @@ int msLayerWhichItems(layerObj *layer, int get_all, const char *metadata)
   if(layer->utfdata.type == MS_EXPRESSION || (layer->utfdata.string && strchr(layer->utfdata.string,'[') != NULL && strchr(layer->utfdata.string,']') != NULL))
     nt += msCountChars(layer->utfdata.string, '[');
 
-  /*
-  ** allocate space for the item list (worse case size)
-  */
+  // if we are using a GetMap request with a WMS filter we don't need to return all items
+  if (msOWSLookupMetadata(&(layer->metadata), "G", "wms_filter_flag") != NULL) {
+      get_all = MS_FALSE;
+  }
 
   /* always retrieve all items in some cases */
   if(layer->connectiontype == MS_INLINE ||
       (layer->map->outputformat && layer->map->outputformat->renderer == MS_RENDER_WITH_KML)) {
     get_all = MS_TRUE;
   }
+
+  /*
+  ** allocate space for the item list (worse case size)
+  */
   if( get_all ) {
     rv = msLayerGetItems(layer);
     if(nt > 0) /* need to realloc the array to accept the possible new items*/

--- a/mapwms.cpp
+++ b/mapwms.cpp
@@ -452,7 +452,12 @@ int msWMSApplyFilter(mapObj *map, int version, const char *filter,
         }
     }
 
+    msInsertHashTable(&(lp->metadata), "gml_wms_filter_flag", "true");
+
     int ret = FLTApplyFilterToLayer(psNode, map, lp->index);
+
+    msRemoveHashTable(&(lp->metadata), "gml_wms_filter_flag");
+
     if( !old_value_wfs_use_default_extent_for_getfeature.empty() )
     {
         msInsertHashTable(&(lp->metadata), "wfs_use_default_extent_for_getfeature",

--- a/mapwms.cpp
+++ b/mapwms.cpp
@@ -452,11 +452,11 @@ int msWMSApplyFilter(mapObj *map, int version, const char *filter,
         }
     }
 
-    msInsertHashTable(&(lp->metadata), "gml_wms_filter_flag", "true");
+    msInsertHashTable(&(lp->metadata), "gml_wmsfilter_flag", "true");
 
     int ret = FLTApplyFilterToLayer(psNode, map, lp->index);
 
-    msRemoveHashTable(&(lp->metadata), "gml_wms_filter_flag");
+    msRemoveHashTable(&(lp->metadata), "gml_wmsfilter_flag");
 
     if( !old_value_wfs_use_default_extent_for_getfeature.empty() )
     {


### PR DESCRIPTION
Fix for #6258

All works fine in my setup and all tests are passing in CI, but I'd appreciate any reviews prior to merging, in case there are unforeseen implications of the update. 

- It does add a new `#include "mapows.h"` to `maplayer.c`. 
- `gml_wmsfilter_flag` was the best I could come up with for this temporary metadata item. It is added and then removed once the query has run. 

Note the metadata is only updated in the `msWMSApplyFilter` which is only used when filters are run on WMS so other code paths should be unaffected. 
