### PR TITLE
revert backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,6 +1,6 @@
 name: Backport
 on:
-  pull_request_target:
+  pull_request:
     types:
       - closed
       - labeled
@@ -11,8 +11,10 @@ jobs:
     name: Backport
     steps:
       - name: Backport Bot
-        id: backport
         if: github.event.pull_request.merged && ( ( github.event.action == 'closed' && contains( join( github.event.pull_request.labels.*.name ), 'backport') ) || contains( github.event.label.name, 'backport' ) )
-        uses: m-kuhn/backport@v1.1.1
+        uses: Gaurav0/backport@v1.0.26
         with:
+          bot_username: MapServer-backport-bot
+          bot_token: 0cba09450792aa8130ae6ef3de09915654afc8cb
+          bot_token_key: 665c2358a46ddf0589de5e24a316cdcc64820b2e
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- go back to our working workflow for backports (as it has been working for 13 months smoothly)
- will continue to monitor m-kuhn/backport and its comparisons to Gaurav0/backport (following both for activity)