### PR TITLE
Issue #6239. If pg_config is found, cmake searches paths specified by pg_config.

### DIFF
--- a/cmake/FindPostgreSQL.cmake
+++ b/cmake/FindPostgreSQL.cmake
@@ -17,36 +17,45 @@ find_program(PG_CONFIG NAMES pg_config
 if (PG_CONFIG)
    exec_program( ${PG_CONFIG} ARGS "--includedir" OUTPUT_VARIABLE PG_INC_PATH )
    exec_program( ${PG_CONFIG} ARGS "--libdir" OUTPUT_VARIABLE PG_LIB_PATH )
+   find_path(POSTGRESQL_INCLUDE_DIR libpq-fe.h
+      PATHS
+      ${PG_INC_PATH}
+      NO_DEFAULT_PATH
+   )
+   find_library(POSTGRESQL_LIBRARY NAMES pq libpq
+      PATHS
+      ${PG_LIB_PATH}
+      NO_DEFAULT_PATH
+   )
 else()
    message(WARNING "pg_config not found, will try some defaults")
+   find_path(POSTGRESQL_INCLUDE_DIR libpq-fe.h
+     ${PG_INC_PATH}
+     /usr/include/server
+     /usr/include/postgresql
+     /usr/include/pgsql/server
+     /usr/local/include/pgsql/server
+     /usr/include/postgresql/server
+     /usr/include/postgresql/*/server
+     /usr/local/include/postgresql/server
+     /usr/local/include/postgresql/*/server
+     $ENV{ProgramFiles}/PostgreSQL/*/include/server
+     $ENV{SystemDrive}/PostgreSQL/*/include/server
+   )
+   
+   find_library(POSTGRESQL_LIBRARY NAMES pq libpq
+     PATHS
+     ${PG_LIB_PATH}
+     /usr/lib
+     /usr/local/lib
+     /usr/lib/postgresql
+     /usr/lib64
+     /usr/local/lib64
+     /usr/lib64/postgresql
+     $ENV{ProgramFiles}/PostgreSQL/*/lib/ms
+     $ENV{SystemDrive}/PostgreSQL/*/lib/ms
+   )
 endif()
-
-find_path(POSTGRESQL_INCLUDE_DIR libpq-fe.h
-  ${PG_INC_PATH}
-  /usr/include/server
-  /usr/include/postgresql
-  /usr/include/pgsql/server
-  /usr/local/include/pgsql/server
-  /usr/include/postgresql/server
-  /usr/include/postgresql/*/server
-  /usr/local/include/postgresql/server
-  /usr/local/include/postgresql/*/server
-  $ENV{ProgramFiles}/PostgreSQL/*/include/server
-  $ENV{SystemDrive}/PostgreSQL/*/include/server
-)
-
-find_library(POSTGRESQL_LIBRARY NAMES pq libpq
-  PATHS
-  ${PG_LIB_PATH}
-  /usr/lib
-  /usr/local/lib
-  /usr/lib/postgresql
-  /usr/lib64
-  /usr/local/lib64
-  /usr/lib64/postgresql
-  $ENV{ProgramFiles}/PostgreSQL/*/lib/ms
-  $ENV{SystemDrive}/PostgreSQL/*/lib/ms
-)
 
 set(POSTGRESQL_INCLUDE_DIRS ${POSTGRESQL_INCLUDE_DIR})
 set(POSTGRESQL_LIBRARIES ${POSTGRESQL_LIBRARY})


### PR DESCRIPTION
Issue #6239. This changes the IF block for PG_CONFIG.  When pg_config is found, cmake searches only the libraries and include paths output by pg_config.  If pg_config is not found, then it searches the defaults and other listed paths in the find_path and find_library commands.