### PR TITLE
WFS GetFeaureById return HTTP 404 when not found and not HTTP 403

### DIFF
--- a/mapowscommon.h
+++ b/mapowscommon.h
@@ -151,6 +151,8 @@ extern "C" {
 #define MS_OWS_ERROR_OPTION_NOT_SUPPORTED       "OptionNotSupported"
 #define MS_OWS_ERROR_NO_APPLICABLE_CODE         "NoApplicableCode"
 
+#define MS_OWS_ERROR_NOT_FOUND                  "NotFound"
+
 #define MS_WFS_ERROR_OPERATION_PROCESSING_FAILED "OperationProcessingFailed"
 
 #ifdef USE_LIBXML2

--- a/mapwfs.cpp
+++ b/mapwfs.cpp
@@ -3384,7 +3384,8 @@ int msWFSGetFeature(mapObj *map, wfsParamsObj *paramsObj, cgiRequestObj *req,
 
   /* Is it a WFS 2.0 GetFeatureById stored query with an unknown id ? */
   /* If so, CITE interprets the spec as requesting to issue a OperationProcessingFailed */
-  /* exception. A bit strange when a similar request but with RESOURCEID= should */
+  /* exception. But it only checks that the HTTP error code is 403 or 404. So emit 404. */
+  /* A bit strange when a similar request but with RESOURCEID= should */
   /* produce an empty FeatureCollection */
   if( nWFSVersion >= OWS_2_0_0 &&
       paramsObj->pszTypeName != NULL && strcmp(paramsObj->pszTypeName, "?") == 0 &&
@@ -3403,7 +3404,7 @@ int msWFSGetFeature(mapObj *map, wfsParamsObj *paramsObj, cgiRequestObj *req,
         {
             msSetError(MS_WFSERR, "Invalid rid '%s'", "msWFSGetFeature()", rid);
             CPLDestroyXMLNode(psDoc);
-            return msWFSException(map, NULL, MS_WFS_ERROR_OPERATION_PROCESSING_FAILED,
+            return msWFSException(map, NULL, MS_OWS_ERROR_NOT_FOUND,
                                   paramsObj->pszVersion );
         }
         CPLDestroyXMLNode(psDoc);
@@ -4112,7 +4113,7 @@ int msWFSGetFeature(mapObj *map, wfsParamsObj *paramsObj, cgiRequestObj *req,
             }
             else
             {
-                status = msWFSException(map, NULL, MS_WFS_ERROR_OPERATION_PROCESSING_FAILED,
+                status = msWFSException(map, NULL, MS_OWS_ERROR_NOT_FOUND,
                                         paramsObj->pszVersion );
             }
         }

--- a/mapwfs20.c
+++ b/mapwfs20.c
@@ -94,6 +94,9 @@ int msWFSException20(mapObj *map, const char *locator,
   else if( EQUAL(exceptionCode, MS_WFS_ERROR_OPERATION_PROCESSING_FAILED) ) {
     status = "403 Server processing failed";
   }
+  else if( EQUAL(exceptionCode, MS_OWS_ERROR_NOT_FOUND) ) {
+    status = "404 Not Found";
+  }
   else if( EQUAL(exceptionCode, MS_OWS_ERROR_NO_APPLICABLE_CODE) ) {
     status = "400 Internal Server Error";
   }

--- a/msautotest/wxs/expected/wfs_200_exception_getfeaturebyid_invalid_id.xml
+++ b/msautotest/wxs/expected/wfs_200_exception_getfeaturebyid_invalid_id.xml
@@ -1,9 +1,9 @@
-Status: 403 Server processing failed
+Status: 404 Not Found
 Content-Type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">
-  <ows:Exception exceptionCode="OperationProcessingFailed">
+  <ows:Exception exceptionCode="NotFound">
     <ows:ExceptionText>msWFSGetFeature(): WFS server error. Invalid rid 'foo'</ows:ExceptionText>
   </ows:Exception>
 </ows:ExceptionReport>

--- a/msautotest/wxs/expected/wfs_200_exception_getfeaturebyid_nofeature.xml
+++ b/msautotest/wxs/expected/wfs_200_exception_getfeaturebyid_nofeature.xml
@@ -1,7 +1,7 @@
-Status: 403 Server processing failed
+Status: 404 Not Found
 Content-Type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">
-  <ows:Exception exceptionCode="OperationProcessingFailed"/>
+  <ows:Exception exceptionCode="NotFound"/>
 </ows:ExceptionReport>


### PR DESCRIPTION
Pull request to add in the changes from https://github.com/rouault/mapserver/commit/89919a719ea2bb8a477590e0fb4d2e04f65ad2d6 as discussed in #4852

Currently for WFS requests by FID if no feature is found a HTTP 403 error is returned with a `OperationProcessingFailed`.
This pull request chnages it to HTTP 404 and a `NotFound` exception code. 
Also discussed / related to #6268. 
