### PR TITLE
Cache Calculated Layer Extents

### DIFF
--- a/maplayer.c
+++ b/maplayer.c
@@ -569,6 +569,10 @@ int msLayerGetExtent(layerObj *layer, rectObj *extent)
   cppcheck_assert(layer->vtable);
   status = layer->vtable->LayerGetExtent(layer, extent);
 
+  if (status == MS_SUCCESS) {
+      layer->extent = *extent;
+  }
+
   if (need_to_close)
     msLayerClose(layer);
 


### PR DESCRIPTION
When debugging the `GetMetadata` request I noticed `msLayerGetExtent` was called 3 times when generating the layer metadata. If an extent is not set for the layer then (with the MSSQL driver - and probably the other database drivers) a SQL request is made to find the extent of the layer based on the data. 

As noted in the comments for `msLayerGetExtent`:

> ** If layer->extent is set then this value is used, otherwise the
> ** driver-specific implementation is called (this can be expensive).
> **
> ** If layer is not already opened then it is opened and closed (so this
> ** function can be called on both opened or closed layers).
> 

This pull request caches the extent on the layer object on the first call, so all subsequent calls return this value instantly. 
It speeds up the `GetMetadata` in this use case by 3. 

All msautotest tests are passing, but I'm unsure if I'm missing any unforeseen side-effects. 