### PR TITLE
Fix Vagrant config to fetch get-pip.py for Python 2.7 since Python 2 support was dropped in pip 21.0

### DIFF
--- a/scripts/vagrant/packages.sh
+++ b/scripts/vagrant/packages.sh
@@ -22,6 +22,6 @@ apt-get install -q -y git build-essential pkg-config cmake3 libgeos-dev rake \
     libprotobuf-dev libprotobuf-c0-dev protobuf-c-compiler libharfbuzz-dev gdal-bin \
     curl sqlite3
 
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
 python get-pip.py
 pip install -U -r /vagrant/msautotest/requirements.txt


### PR DESCRIPTION
Launching a brand new Vagrant VM fails with the following error:

> default: ERROR: This script does not work on Python 2.7 The minimum supported Python version is 3.6. Please use https://bootstrap.pypa.io/pip/2.7/get-pip.py instead.

We get this because the default version of get-pip.py at https://bootstrap.pypa.io/get-pip.py no longer supports Python 2, so we either have to fetch the version for Python 2.7 (what this PR does), or call get-pip.py with `python3`.  However the latter probably won't work out of the box anyway since the bionic Vagrant VM contains Python 3.4 and the message above says that the new script requires 3.6+.

I defer to those of you who know our Vagrant config better than me to tell me if this PR is the right fix, or if instead we should switch the Vagrant setup to use Python3 by default, and how to proceed.

Note that I already committed this change to the `main` branch by accident (doh!), so if this is not the right fix we will have to revert my change in `main` as well.