### PR TITLE
WIP: Use CPLSetConfigOption/CPLGetConfigOption for some CGI/FastCGI-related env vars.

### DIFF
--- a/maphttp.c
+++ b/maphttp.c
@@ -39,7 +39,7 @@
 #include "mapthread.h"
 #include "mapows.h"
 
-
+#include "cpl_conv.h"
 
 #include <time.h>
 #ifndef _WIN32
@@ -471,7 +471,7 @@ int msHTTPExecuteRequests(httpRequestObj *pasReqInfo, int numRequests,
    * If set then the value is the full path to the ca-bundle.crt file
    * e.g. CURL_CA_BUNDLE=/usr/local/share/curl/curl-ca-bundle.crt
    */
-  pszCurlCABundle = getenv("CURL_CA_BUNDLE");
+  pszCurlCABundle = CPLGetConfigOption("CURL_CA_BUNDLE", getenv("CURL_CA_BUNDLE")); // fall back to env
 
   if (debug) {
     msDebug("HTTP: Starting to prepare HTTP requests.\n");

--- a/maphttp.c
+++ b/maphttp.c
@@ -471,7 +471,7 @@ int msHTTPExecuteRequests(httpRequestObj *pasReqInfo, int numRequests,
    * If set then the value is the full path to the ca-bundle.crt file
    * e.g. CURL_CA_BUNDLE=/usr/local/share/curl/curl-ca-bundle.crt
    */
-  pszCurlCABundle = CPLGetConfigOption("CURL_CA_BUNDLE", getenv("CURL_CA_BUNDLE")); // fall back to env
+  pszCurlCABundle = CPLGetConfigOption("CURL_CA_BUNDLE", NULL);
 
   if (debug) {
     msDebug("HTTP: Starting to prepare HTTP requests.\n");

--- a/mapserv.c
+++ b/mapserv.c
@@ -43,6 +43,8 @@
 #include "mapio.h"
 #include "maptime.h"
 
+#include "cpl_conv.h"
+
 #ifndef WIN32
 #include <signal.h>
 #endif
@@ -163,15 +165,13 @@ int main(int argc, char *argv[])
     msGettimeofday(&execstarttime, NULL);
 
   /* push high-value ENV vars into the CPL global config - primarily for IIS/FastCGI */
-  const char *value = getenv("CURL_CA_BUNDLE");
-  if(value) CPLSetConfigOption("CURL_CA_BUNDLE", value);
-
-  value = getenv("MS_MAPFILE");
-  if(value) CPLSetConfigOption("MS_MAPFILE", value);
-  value = getenv("MS_MAP_NO_PATH");
-  if(value) CPLSetConfigOption("MS_MAP_NO_PATH", value);
-  value = getenv("MS_MAP_PATTERN");
-  if(value) CPLSetConfigOption("MS_MAP_PATTERN", value);
+  const char* const apszEnvVars[] = { 
+    "CURL_CA_BUNDLE", "MS_MAPFILE", "MS_MAP_NO_PATH", "MS_MAP_PATTERN",
+     NULL /* guard */ };
+  for( int i = 0; apszEnvVars[i] != NULL; ++i ) {
+    const char* value = getenv(apszEnvVars[i]);
+    if(value) CPLSetConfigOption(apszEnvVars[i], value);
+  }
 
   /* -------------------------------------------------------------------- */
   /*      Process arguments.  In normal use as a cgi-bin there are no     */

--- a/mapserv.c
+++ b/mapserv.c
@@ -162,6 +162,17 @@ int main(int argc, char *argv[])
   if(msGetGlobalDebugLevel() >= MS_DEBUGLEVEL_TUNING)
     msGettimeofday(&execstarttime, NULL);
 
+  /* push high-value ENV vars into the CPL global config - primarily for IIS/FastCGI */
+  const char *value = getenv("CURL_CA_BUNDLE");
+  if(value) CPLSetConfigOption("CURL_CA_BUNDLE", value);
+
+  value = getenv("MS_MAPFILE");
+  if(value) CPLSetConfigOption("MS_MAPFILE", value);
+  value = getenv("MS_MAP_NO_PATH");
+  if(value) CPLSetConfigOption("MS_MAP_NO_PATH", value);
+  value = getenv("MS_MAP_PATTERN");
+  if(value) CPLSetConfigOption("MS_MAP_PATTERN", value);
+
   /* -------------------------------------------------------------------- */
   /*      Process arguments.  In normal use as a cgi-bin there are no     */
   /*      commandline switches, but we provide a few for test/debug       */

--- a/mapserv.h
+++ b/mapserv.h
@@ -41,6 +41,9 @@
 #include "maptile.h"
 
 #include "cgiutil.h"
+
+#include "cpl_conv.h"
+
 /*
 ** Defines
 */

--- a/mapserv.h
+++ b/mapserv.h
@@ -42,8 +42,6 @@
 
 #include "cgiutil.h"
 
-#include "cpl_conv.h"
-
 /*
 ** Defines
 */

--- a/mapservutil.c
+++ b/mapservutil.c
@@ -33,6 +33,8 @@
 #include "maptime.h"
 #include "mapows.h"
 
+
+
 /*
 ** Enumerated types, keep the query modes in sequence and at the end of the enumeration (mode enumeration is in maptemplate.h).
 */
@@ -197,12 +199,15 @@ mapObj *msCGILoadMap(mapservObj *mapserv)
   int i, j;
   mapObj *map = NULL;
 
+  const char *ms_mapfile = CPLGetConfigOption("MS_MAPFILE", NULL);
+  const char *ms_map_no_path = CPLGetConfigOption("MS_MAP_NO_PATH", NULL);
+  const char *ms_map_pattern = CPLGetConfigOption("MS_MAP_PATTERN", NULL);
+
   for(i=0; i<mapserv->request->NumParams; i++) /* find the mapfile parameter first */
     if(strcasecmp(mapserv->request->ParamNames[i], "map") == 0) break;
 
   if(i == mapserv->request->NumParams) {
-    char *ms_mapfile = getenv("MS_MAPFILE");
-    if(ms_mapfile) {
+    if(ms_mapfile != NULL) {
       map = msLoadMap(ms_mapfile,NULL);
     } else {
       msSetError(MS_WEBERR, "CGI variable \"map\" is not set.", "msCGILoadMap()"); /* no default, outta here */
@@ -213,12 +218,12 @@ mapObj *msCGILoadMap(mapservObj *mapserv)
       map = msLoadMap(getenv(mapserv->request->ParamValues[i]), NULL);
     else {
       /* by here we know the request isn't for something in an environment variable */
-      if(getenv("MS_MAP_NO_PATH")) {
+      if(ms_map_no_path != NULL) {
         msSetError(MS_WEBERR, "Mapfile not found in environment variables and this server is not configured for full paths.", "msCGILoadMap()");
         return NULL;
       }
 
-      if(getenv("MS_MAP_PATTERN") && msEvalRegex(getenv("MS_MAP_PATTERN"), mapserv->request->ParamValues[i]) != MS_TRUE) {
+      if(ms_map_pattern != NULL && msEvalRegex(ms_map_pattern, mapserv->request->ParamValues[i]) != MS_TRUE) {
         msSetError(MS_WEBERR, "Parameter 'map' value fails to validate.", "msCGILoadMap()");
         return NULL;
       }

--- a/mapservutil.c
+++ b/mapservutil.c
@@ -33,7 +33,7 @@
 #include "maptime.h"
 #include "mapows.h"
 
-
+#include "cpl_conv.h"
 
 /*
 ** Enumerated types, keep the query modes in sequence and at the end of the enumeration (mode enumeration is in maptemplate.h).


### PR DESCRIPTION
Potential solution for IIS/FastCGI where we push some high-value environment variables into the CPL environment (using CPLSetConfigOption) and then reference them there (CPLGetConfigOption). This is against **branch-7-6** rather than main since the config file work would replace this.

Should be ok for non-IIS/FastCGI as well.

--Steve