### PR TITLE
Another batch of coverity scan fixes

### DIFF
--- a/maplabel.c
+++ b/maplabel.c
@@ -89,7 +89,12 @@ void freeTextPath(textPathObj *tp) {
     free(tp->bounds.poly);
   }
 }
+
 void freeTextSymbol(textSymbolObj *ts) {
+    freeTextSymbolEx(ts, MS_TRUE);
+}
+
+void freeTextSymbolEx(textSymbolObj *ts, int doFreeLabel) {
   if(ts->textpath) {
     freeTextPath(ts->textpath);
     free(ts->textpath);
@@ -110,7 +115,7 @@ void freeTextSymbol(textSymbolObj *ts) {
     }
   }
   free(ts->annotext);
-  if(freeLabel(ts->label) == MS_SUCCESS) {
+  if(doFreeLabel && freeLabel(ts->label) == MS_SUCCESS) {
     free(ts->label);
   }
 }

--- a/maplegend.c
+++ b/maplegend.c
@@ -764,7 +764,10 @@ imageObj *msDrawLegend(mapObj *map, int scale_independent, map_hittest *hittest)
       ret = msDrawTextSymbol(map,image,textPnt,&cur->ts);
       if(MS_UNLIKELY(ret == MS_FAILURE))
         goto cleanup;
-      freeTextSymbol(&cur->ts);
+      /* Coverity Scan is confused by label refcount, and wrongly believe we */
+      /* might free &map->legend.label, so make it clear we won't */
+      freeTextSymbolEx(&cur->ts, MS_FALSE);
+      MS_REFCNT_DECR(cur->ts.label);
     }
     
     pnt.y += map->legend.keyspacingy; /* bump y for next label */
@@ -777,7 +780,10 @@ imageObj *msDrawLegend(mapObj *map, int scale_independent, map_hittest *hittest)
 
 cleanup:
   while(cur) {
-    freeTextSymbol(&cur->ts);
+    /* Coverity Scan is confused by label refcount, and wrongly believe we */
+    /* might free &map->legend.label, so make it clear we won't */
+    freeTextSymbolEx(&cur->ts, MS_FALSE);
+    MS_REFCNT_DECR(cur->ts.label);
     head = cur;
     cur = cur->pred;
     free(head);

--- a/mapogcsld.c
+++ b/mapogcsld.c
@@ -1486,6 +1486,7 @@ int msSLDParseOgcExpression(CPLXMLNode *psRoot, void *psObj, int binding,
         status = MS_SUCCESS;
       }
       else if (strcasecmp(psRoot->pszValue,"Function") == 0
+          && psRoot->psChild
           && CPLGetXMLValue(psRoot,"name",NULL)
           && psRoot->psChild->psNext)
       {

--- a/mapserver.h
+++ b/mapserver.h
@@ -1879,6 +1879,7 @@ void msCopyTextPath(textPathObj *dst, textPathObj *src);
 void freeTextPath(textPathObj *tp);
 void initTextSymbol(textSymbolObj *ts);
 void freeTextSymbol(textSymbolObj *ts);
+void freeTextSymbolEx(textSymbolObj *ts, int doFreeLabel);
 void copyLabelBounds(label_bounds *dst, label_bounds *src);
 void msCopyTextSymbol(textSymbolObj *dst, textSymbolObj *src);
 void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char *string, double scalefactor, double resolutionfactor, label_cache_mode cache);

--- a/mapserver.h
+++ b/mapserver.h
@@ -3223,6 +3223,10 @@ shapeObj *msGEOSOffsetCurve(shapeObj *p, double offset);
 
 int msOGRIsSpatialite(layerObj* layer);
 
+#ifdef NEED_IGNORE_RET_VAL
+static inline void IGNORE_RET_VAL(int x) { (void)x; }
+#endif
+
 #endif /* SWIG */
 
 #ifdef __cplusplus

--- a/mapshape.c
+++ b/mapshape.c
@@ -34,6 +34,8 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
+#define NEED_IGNORE_RET_VAL
+
 #include <limits.h>
 #include <assert.h>
 #include "mapserver.h"
@@ -1897,7 +1899,7 @@ static const char* msTiledSHPLoadEntry(layerObj *layer, int i, char* tilename, s
     {
         int idx = msDBFGetItemIndex(tSHP->tileshpfile->hDBF, layer->tilesrs);
         const char* pszWKT = msDBFReadStringAttribute(tSHP->tileshpfile->hDBF, i, idx);
-        msOGCWKT2ProjectionObj(pszWKT, &(tSHP->sTileProj), layer->debug );
+        IGNORE_RET_VAL(msOGCWKT2ProjectionObj(pszWKT, &(tSHP->sTileProj), layer->debug ));
     }
 
     if(!layer->data) /* assume whole filename is in attribute field */

--- a/mapshape.c
+++ b/mapshape.c
@@ -992,20 +992,24 @@ int msSHPWriteShape(SHPHandle psSHP, shapeObj *shape )
 static int msSHPReadAllocateBuffer( SHPHandle psSHP, int hEntity, const char* pszCallingFunction)
 {
 
-  int nEntitySize = msSHXReadSize(psSHP, hEntity) + 8;
+  int nEntitySize = msSHXReadSize(psSHP, hEntity);
+  if( nEntitySize > INT_MAX - 8 ) {
+      msSetError(MS_MEMERR, "Out of memory. Cannot allocate %d bytes. Probably broken shapefile at feature %d",
+                 pszCallingFunction, nEntitySize, hEntity);
+      return(MS_FAILURE);
+  }
+  nEntitySize += 8;
   /* -------------------------------------------------------------------- */
   /*      Ensure our record buffer is large enough.                       */
   /* -------------------------------------------------------------------- */
   if( nEntitySize > psSHP->nBufSize ) {
-    psSHP->pabyRec = (uchar *) SfRealloc(psSHP->pabyRec,nEntitySize);
-    if (psSHP->pabyRec == NULL) {
-      /* Reallocate previous successfull size for following features */
-      psSHP->pabyRec = msSmallMalloc(psSHP->nBufSize);
-
+    uchar* pabyRec = (uchar *) SfRealloc(psSHP->pabyRec,nEntitySize);
+    if (pabyRec == NULL) {
       msSetError(MS_MEMERR, "Out of memory. Cannot allocate %d bytes. Probably broken shapefile at feature %d",
                  pszCallingFunction, nEntitySize, hEntity);
       return(MS_FAILURE);
     }
+    psSHP->pabyRec = pabyRec;
     psSHP->nBufSize = nEntitySize;
   }
   if (psSHP->pabyRec == NULL) {

--- a/maptemplate.c
+++ b/maptemplate.c
@@ -37,6 +37,7 @@
 #include <sys/stat.h>
 #include <time.h>
 
+#include <assert.h>
 #include <ctype.h>
 
 
@@ -4012,6 +4013,8 @@ static char *processLine(mapservObj *mapserv, char *instr, FILE *stream, int mod
       return(NULL);
     }
   } else { /* return shape and/or values */
+
+    assert(mapserv->resultlayer);
 
     snprintf(repstr, sizeof(repstr), "%f %f", (mapserv->resultshape.bounds.maxx + mapserv->resultshape.bounds.minx)/2, (mapserv->resultshape.bounds.maxy + mapserv->resultshape.bounds.miny)/2);
     outstr = msReplaceSubstring(outstr, "[shpmid]", repstr);

--- a/mapuvraster.c
+++ b/mapuvraster.c
@@ -511,8 +511,8 @@ int msUVRASTERLayerWhichShapes(layerObj *layer, rectObj rect, int isQuery)
       atoi(CSLFetchNameValue( layer->processing, "UV_SPACING" ));
   }
 
-  width = (int)ceil(layer->map->width/spacing);
-  height = (int)ceil(layer->map->height/spacing);
+  width = (int)(layer->map->width/spacing);
+  height = (int)(layer->map->height/spacing);
 
   /* Initialize our dummy map */
   MS_INIT_COLOR(map_tmp->imagecolor, 255,255,255,255);

--- a/mapwcs20.cpp
+++ b/mapwcs20.cpp
@@ -4767,14 +4767,7 @@ this request. Check wcs/ows_enable_request settings.", "msWCSGetCoverage20()", p
   }
 
   /* create the image object  */
-  if (!map->outputformat) {
-    msWCSClearCoverageMetadata20(&cm);
-    msFree(bandlist);
-    msSetError(MS_WCSERR, "The map outputformat is missing!",
-               "msWCSGetCoverage20()");
-    msDrawRasterLayerLowCloseDataset(layer, hDS);
-    return msWCSException(map, NULL, NULL, params->version);
-  } else if (MS_RENDERER_PLUGIN(map->outputformat)) {
+  if (MS_RENDERER_PLUGIN(map->outputformat)) {
     image = msImageCreate(map->width, map->height, map->outputformat,
                           map->web.imagepath, map->web.imageurl, map->resolution,
                           map->defresolution, &map->imagecolor);

--- a/mapwfs.cpp
+++ b/mapwfs.cpp
@@ -1018,7 +1018,7 @@ static void msWFSWriteGeometryElement(FILE *stream, gmlGeometryListObj *geometry
   gmlGeometryObj *geometry=NULL;
 
   if(!stream || !tab) return;
-  if(geometryList && geometryList->numgeometries == 1 && strcasecmp(geometryList->geometries[0].name, "none") == 0) return;
+  if(geometryList->numgeometries == 1 && strcasecmp(geometryList->geometries[0].name, "none") == 0) return;
 
   if(geometryList->numgeometries == 1) {
     geometry = &(geometryList->geometries[0]);

--- a/mapwms.cpp
+++ b/mapwms.cpp
@@ -44,6 +44,7 @@
 #include "maptime.h"
 #include "mapproject.h"
 
+#include <cassert>
 #include <stdarg.h>
 #include <time.h>
 #include <string.h>
@@ -364,6 +365,8 @@ int msWMSApplyFilter(mapObj *map, int version, const char *filter,
     const int curfilter = ows_request->layerwmsfilterindex[lp->index];
 
     /* Skip empty filters */
+    assert(paszFilters);
+    assert(curfilter >= 0 && curfilter < numfilters);
     if (paszFilters[curfilter][0] == '\0') {
       continue;
     }

--- a/mapwms.cpp
+++ b/mapwms.cpp
@@ -27,6 +27,8 @@
  * DEALINGS IN THE SOFTWARE.
  *****************************************************************************/
 
+#define NEED_IGNORE_RET_VAL
+
 #include "mapserver.h"
 #include "maperror.h"
 #include "mapthread.h"
@@ -3757,7 +3759,7 @@ int msWMSGetMap(mapObj *map, int nVersion, char **names, char **values, int nume
       }
 
       else
-        msDrawLayer(map, GET_LAYER(map, i), img);
+        IGNORE_RET_VAL(msDrawLayer(map, GET_LAYER(map, i), img));
     }
 
   } else {

--- a/mapwmslayer.c
+++ b/mapwmslayer.c
@@ -994,6 +994,7 @@ int msPrepareWMSLayerRequest(int nLayerId, mapObj *map, layerObj *lp,
   int bbox_width = 0, bbox_height = 0;
   int nTimeout, bOkToMerge, bForceSeparateRequest, bCacheToDisk;
   wmsParamsObj sThisWMSParams;
+  int ret = MS_FAILURE;
 
   if (lp->connectiontype != MS_WMS)
     return MS_FAILURE;
@@ -1005,34 +1006,38 @@ int msPrepareWMSLayerRequest(int nLayerId, mapObj *map, layerObj *lp,
    * compute BBOX in that projection.
    * ------------------------------------------------------------------ */
 
-
-  if (nRequestType == WMS_GETMAP &&
-      ( msBuildWMSLayerURL(map, lp, WMS_GETMAP,
+  switch( nRequestType )
+  {
+      case WMS_GETMAP:
+          ret = msBuildWMSLayerURL(map, lp, WMS_GETMAP,
                            0, 0, 0, NULL, &bbox, &bbox_width, &bbox_height,
-                           &sThisWMSParams) != MS_SUCCESS) ) {
-    /* an error was already reported. */
-    msFreeWmsParamsObj(&sThisWMSParams);
-    return MS_FAILURE;
-  }
+                           &sThisWMSParams);
+          break;
 
-  else if (nRequestType == WMS_GETFEATUREINFO &&
-           msBuildWMSLayerURL(map, lp, WMS_GETFEATUREINFO,
+      case WMS_GETFEATUREINFO:
+          ret = msBuildWMSLayerURL(map, lp, WMS_GETFEATUREINFO,
                               nClickX, nClickY, nFeatureCount, pszInfoFormat,
                               NULL, NULL, NULL,
-                              &sThisWMSParams) != MS_SUCCESS ) {
-    /* an error was already reported. */
-    msFreeWmsParamsObj(&sThisWMSParams);
-    return MS_FAILURE;
-  } else if (nRequestType == WMS_GETLEGENDGRAPHIC &&
-             msBuildWMSLayerURL(map, lp, WMS_GETLEGENDGRAPHIC,
+                              &sThisWMSParams);
+          break;
+
+      case WMS_GETLEGENDGRAPHIC:
+          ret = msBuildWMSLayerURL(map, lp, WMS_GETLEGENDGRAPHIC,
                                 0, 0, 0, NULL,
                                 NULL, NULL, NULL,
-                                &sThisWMSParams) != MS_SUCCESS ) {
+                                &sThisWMSParams);
+          break;
+
+      default:
+          assert(FALSE);
+          break;
+  }
+
+  if( ret != MS_SUCCESS) {
     /* an error was already reported. */
     msFreeWmsParamsObj(&sThisWMSParams);
     return MS_FAILURE;
   }
-
 
   /* ------------------------------------------------------------------
    * Check if the request is empty, perhaps due to reprojection problems

--- a/renderers/agg/src/agg_font_freetype.cpp
+++ b/renderers/agg/src/agg_font_freetype.cpp
@@ -624,10 +624,10 @@ namespace mapserver
                 {
                     delete [] m_face_names[0];
                     FT_Done_Face(m_faces[0]);
-                    memcpy(m_faces, 
+                    memmove(m_faces, 
                            m_faces + 1, 
                            (m_max_faces - 1) * sizeof(FT_Face));
-                    memcpy(m_face_names, 
+                    memmove(m_face_names, 
                            m_face_names + 1, 
                            (m_max_faces - 1) * sizeof(char*));
                     m_num_faces = m_max_faces - 1;


### PR DESCRIPTION
Should hopefully fix the false positive about the last remaining one in 'high' category and a few 'medium' ones. Most of them are false positives or without any real consequence (dead code, useless check etc), except the "agg_font_freetype.cpp: fix incorrect use of memcpy() (CID 1503528)" commit 