### PR TITLE
Mapscript legacy functions cleanup

### DIFF
--- a/mapscript/java/examples/DrawMap.java
+++ b/mapscript/java/examples/DrawMap.java
@@ -21,8 +21,8 @@ public class DrawMap {
     //map.getImagecolor().setRGB(153, 153, 204);
     //styleObj st = map.getLayer(1).getClass(0).getStyle(0);
     //st.getColor().setHex("#000000");
-    if( map.getLayer(1).getMetaData("hidden") != null ) {
-    	System.out.println("Layer 1 is hidden? "+map.getLayer(1).getMetaData("hidden"));
+    if( map.getLayer(1).getMetadata().get("hidden") != null ) {
+    	System.out.println("Layer 1 is hidden? "+map.getLayer(1).getMetadata().get("hidden"));
     }
     int i=0;
     //for (i=0; i<100; i++) {

--- a/mapscript/python/examples/wxs.py
+++ b/mapscript/python/examples/wxs.py
@@ -16,7 +16,7 @@ import mapscript
 def main(map_file):
 
     map = mapscript.mapObj(map_file)
-    map.setMetaData("ows_onlineresource", "http://dummy.org/")
+    map.web.metadata.set("ows_onlineresource", "http://dummy.org/")
     ows_req = mapscript.OWSRequest()
 
     ows_req.type = mapscript.MS_GET_REQUEST

--- a/mapscript/python/pyextend.i
+++ b/mapscript/python/pyextend.i
@@ -345,8 +345,8 @@ def fromstring(data, mappath=None):
 %extend imageObj {
 
     /**
-    Write image data to an open file handle. Intended to replace
-    saveToString.  See ``python/pyextend.i`` for the Python specific
+    Write image data to an open file handle. Replaces
+    the removed saveToString function.  See ``python/pyextend.i`` for the Python specific
     version of this method.
     */
     int write( PyObject *file=Py_None )

--- a/mapscript/python/pyextend.i
+++ b/mapscript/python/pyextend.i
@@ -394,26 +394,6 @@ def fromstring(data, mappath=None):
 
         return retval;
     }
-
-    /**
-    \**Deprecated** - replaced by the :func:`imageObj.write` method
-    */
-    PyObject *saveToString() {
-        int size=0;
-        unsigned char *imgbytes;
-        PyObject *imgstring; 
-
-        imgbytes = msSaveImageBuffer(self, &size, self->format);
-        if (size == 0)
-        {
-            msSetError(MS_IMGERR, "failed to get image buffer", "saveToString()");
-            return NULL;
-        }
-        imgstring = PyBytes_FromStringAndSize((const char*) imgbytes, size);
-        free(imgbytes);
-        return imgstring;
-    }
-
 }
 
 

--- a/mapscript/python/tests/cases/clone_test.py
+++ b/mapscript/python/tests/cases/clone_test.py
@@ -66,10 +66,9 @@ class MapCloningTestCase(MapCloneTestCase):
         """drawing a cloned map works properly"""
         msimg = self.mapobj_clone.draw()
         assert msimg.thisown == 1
-        data = msimg.saveToString()
         filename = 'testClone.png'
         fh = open(filename, 'wb')
-        fh.write(data)
+        msimg.write(fh)
         fh.close()
 
     def testDrawCloneJPEG(self):
@@ -78,10 +77,9 @@ class MapCloningTestCase(MapCloneTestCase):
         self.mapobj_clone.getLayerByName('INLINE-PIXMAP-RGBA').status = mapscript.MS_ON
         msimg = self.mapobj_clone.draw()
         assert msimg.thisown == 1
-        data = msimg.saveToString()
         filename = 'testClone.jpg'
         fh = open(filename, 'wb')
-        fh.write(data)
+        msimg.write(fh)
         fh.close()
 
     def testDrawClonePNG24(self):
@@ -90,10 +88,9 @@ class MapCloningTestCase(MapCloneTestCase):
         self.mapobj_clone.getLayerByName('INLINE-PIXMAP-RGBA').status = mapscript.MS_ON
         msimg = self.mapobj_clone.draw()
         assert msimg.thisown == 1
-        data = msimg.saveToString()
         filename = 'testClonePNG24.png'
         fh = open(filename, 'wb')
-        fh.write(data)
+        msimg.write(fh)
         fh.close()
 
 

--- a/mapscript/python/tests/cases/image_test.py
+++ b/mapscript/python/tests/cases/image_test.py
@@ -41,23 +41,6 @@ except ImportError:
     pass
 
 
-class SaveToStringTestCase(MapTestCase):
-    def testSaveToString(self):
-        """test that an image can be saved as a string"""
-        msimg = self.map.draw()
-        assert msimg.thisown == 1
-        data = msimg.saveToString()
-        filename = 'testSaveToString.png'
-        fh = open(filename, 'wb')
-        fh.write(data)
-        fh.close()
-        if have_image:
-            pyimg = Image.open(filename)
-            assert pyimg.format == 'PNG'
-            assert pyimg.size == (200, 200)
-            assert pyimg.mode == 'RGB'
-
-
 class ImageObjTestCase(unittest.TestCase):
 
     def testConstructor(self):

--- a/mapscript/python/tests/cases/layer_test.py
+++ b/mapscript/python/tests/cases/layer_test.py
@@ -157,11 +157,11 @@ class LayerExtentTestCase(MapTestCase):
 
 class LayerRasterProcessingTestCase(MapLayerTestCase):
 
-    def testSetProcessing(self):
-        """setting a layer's processing directive works"""
-        self.layer.setProcessing('directive0=foo')
+    def testAddProcessing(self):
+        """adding a layer's processing directive works"""
+        self.layer.addProcessing('directive0=foo')
         assert self.layer.numprocessing == 1, self.layer.numprocessing
-        self.layer.setProcessing('directive1=bar')
+        self.layer.addProcessing('directive1=bar')
         assert self.layer.numprocessing == 2, self.layer.numprocessing
         directives = [self.layer.getProcessing(i)
                       for i in range(self.layer.numprocessing)]
@@ -169,9 +169,9 @@ class LayerRasterProcessingTestCase(MapLayerTestCase):
 
     def testClearProcessing(self):
         """clearing a self.layer's processing directive works"""
-        self.layer.setProcessing('directive0=foo')
+        self.layer.addProcessing('directive0=foo')
         assert self.layer.numprocessing == 1, self.layer.numprocessing
-        self.layer.setProcessing('directive1=bar')
+        self.layer.addProcessing('directive1=bar')
         assert self.layer.numprocessing == 2, self.layer.numprocessing
         assert self.layer.clearProcessing() == mapscript.MS_SUCCESS
 

--- a/mapscript/python/tests/cases/map_test.py
+++ b/mapscript/python/tests/cases/map_test.py
@@ -196,68 +196,6 @@ class EmptyMapExceptionTestCase(unittest.TestCase):
         self.assertRaises(mapscript.MapServerError, self.map.draw)
 
 
-class MapMetaDataTestCase(MapTestCase):
-
-    def testInvalidKeyAccess(self):
-        """MapMetaDataTestCase.testInvalidKeyAccess: an invalid map metadata key returns proper error"""
-        self.assertRaises(mapscript.MapServerError, self.map.getMetaData, 'foo')
-
-    def testFirstKeyAccess(self):
-        """MapMetaDataTestCase.testFirstKeyAccess: first metadata key is correct value"""
-        key = self.map.getFirstMetaDataKey()
-        assert key == 'key1'
-        val = self.map.getMetaData(key)
-        assert val == 'value1'
-
-    def testLastKeyAccess(self):
-        """MapMetaDataTestCase.testLastKeyAccess: last metadata key is correct value"""
-        key = self.map.getFirstMetaDataKey()
-        for i in range(4):
-            key = self.map.getNextMetaDataKey(key)
-            assert key is not None
-        key = self.map.getNextMetaDataKey(key)
-        assert key is None
-
-    def testMapMetaData(self):
-        """MapMetaDataTestCase.testMapMetaData: map metadata keys are correct values"""
-        keys = []
-        key = self.map.getFirstMetaDataKey()
-        if key is not None:
-            keys.append(key)
-        while 1:
-            key = self.map.getNextMetaDataKey(key)
-            if not key:
-                break
-            keys.append(key)
-        assert keys == ['key1', 'key2', 'key3', 'key4', 'ows_enable_request'], keys
-
-    def testLayerMetaData(self):
-        """MapMetaDataTestCase.testLayerMetaData: layer metadata keys are correct values"""
-        keys = []
-        key = self.map.getLayer(1).getFirstMetaDataKey()
-        if key is not None:
-            keys.append(key)
-        while 1:
-            key = self.map.getLayer(1).getNextMetaDataKey(key)
-            if not key:
-                break
-            keys.append(key)
-        assert keys == ['key1', 'key2', 'key3', 'key4'], keys
-
-    def testClassMetaData(self):
-        """MapMetaDataTestCase.testClassMetaData: class metadata keys are correct values"""
-        keys = []
-        key = self.map.getLayer(1).getClass(0).getFirstMetaDataKey()
-        if key is not None:
-            keys.append(key)
-        while 1:
-            key = self.map.getLayer(1).getClass(0).getNextMetaDataKey(key)
-            if not key:
-                break
-            keys.append(key)
-        assert keys == ['key1', 'key2', 'key3', 'key4'], keys
-
-
 class NoFontSetTestCase(unittest.TestCase):
 
     def testNoGetFontSetFile(self):

--- a/mapscript/python/tests/cases/style_test.py
+++ b/mapscript/python/tests/cases/style_test.py
@@ -97,10 +97,9 @@ class NewStylesTestCase(MapTestCase):
         assert class0.numstyles == 3, class0.numstyles
         msimg = self.map.draw()
         assert msimg.thisown == 1
-        data = msimg.saveToString()
         filename = 'testAppendNewStyle.png'
         fh = open(filename, 'wb')
-        fh.write(data)
+        msimg.write(fh)
         fh.close()
 
     def testAppendNewStyleOldWay(self):
@@ -114,10 +113,9 @@ class NewStylesTestCase(MapTestCase):
         new_style.symbol = 1
         new_style.size = 3
         msimg = self.map.draw()
-        data = msimg.saveToString()
         filename = 'testAppendNewStyleOldWay.png'
         fh = open(filename, 'wb')
-        fh.write(data)
+        msimg.write(fh)
         fh.close()
 
     def testInsertNewStyleAtIndex0(self):
@@ -133,10 +131,9 @@ class NewStylesTestCase(MapTestCase):
         assert class0.numstyles == 2, class0.numstyles
         msimg = self.map.draw()
         assert msimg.thisown == 1
-        data = msimg.saveToString()
         filename = 'testInsertNewStyleAtIndex0.png'
         fh = open(filename, 'wb')
-        fh.write(data)
+        msimg.write(fh)
         fh.close()
 
     def testRemovePointStyle(self):

--- a/mapscript/python/tests/cases/symbolset_test.py
+++ b/mapscript/python/tests/cases/symbolset_test.py
@@ -142,10 +142,9 @@ class MapSymbolSetTestCase(MapTestCase):
         # s.size = 24
         msimg = self.map.draw()
         assert msimg.thisown == 1
-        data = msimg.saveToString()
         filename = 'testDrawNewSymbol.png'
         fh = open(filename, 'wb')
-        fh.write(data)
+        msimg.write(fh)
         fh.close()
 
 

--- a/mapscript/python/tests/runtests.py
+++ b/mapscript/python/tests/runtests.py
@@ -46,14 +46,12 @@ from cases.owstest import OWSRequestTestCase
 from cases.clonetest import MapCloningTestCase
 
 from cases.imagetest import ImageObjTestCase, ImageWriteTestCase
-from cases.imagetest import SaveToStringTestCase
 
 from cases.maptest import MapConstructorTestCase
 from cases.maptest import MapLayersTestCase
 from cases.maptest import MapExtentTestCase
 from cases.maptest import MapExceptionTestCase
 from cases.maptest import EmptyMapExceptionTestCase
-from cases.maptest import MapMetaDataTestCase
 from cases.maptest import MapSizeTestCase
 
 from cases.layertest import LayerConstructorTestCase
@@ -103,15 +101,13 @@ suite.addTests([HashTableTestCase(), WebMetadataTestCase(),
 suite.addTests([MapCloningTestCase()])
 suite.addTests([OWSRequestTestCase()])
 
-suite.addTests([ImageObjTestCase(), ImageWriteTestCase(),
-                SaveToStringTestCase()])
+suite.addTests([ImageObjTestCase(), ImageWriteTestCase()])
 
 suite.addTests([MapConstructorTestCase(),
                 MapLayersTestCase(),
                 MapExtentTestCase(),
                 MapExceptionTestCase(),
-                EmptyMapExceptionTestCase(),
-                MapMetaDataTestCase()])
+                EmptyMapExceptionTestCase()])
 
 suite.addTests([LayerConstructorTestCase(),
                 LayerExtentTestCase(),

--- a/mapscript/swiginc/class.i
+++ b/mapscript/swiginc/class.i
@@ -161,38 +161,6 @@
     return msGetExpressionString(&(self->text));
   }
 
-  /// \**To be removed in 8.0** -  use the metadata property
-  char *getMetaData(char *name) {
-    char *value = NULL;
-    if (!name) {
-      msSetError(MS_HASHERR, "NULL key", "getMetaData");
-    }
-     
-    value = (char *) msLookupHashTable(&(self->metadata), name);
-    if (!value) {
-      msSetError(MS_HASHERR, "Key %s does not exist", "getMetaData", name);
-      return NULL;
-    }
-    return value;
-  }
-
-  /// \**To be removed** -  use the metadata property
-  int setMetaData(char *name, char *value) {
-    if (msInsertHashTable(&(self->metadata), name, value) == NULL)
-        return MS_FAILURE;
-    return MS_SUCCESS;
-  }
-
-  /// \**To be removed** -  use the metadata property
-  char *getFirstMetaDataKey() {
-    return (char *) msFirstKeyFromHashTable(&(self->metadata));
-  }
-
-  /// \**To be removed** -  use the metadata property
-  char *getNextMetaDataKey(char *lastkey) {
-    return (char *) msNextKeyFromHashTable(&(self->metadata), lastkey);
-  }
-
   /// Draw the legend icon onto *image* at *dstx*, *dsty*.  Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE`
   int drawLegendIcon(mapObj *map, layerObj *layer, int width, int height, imageObj *dstImage, int dstX, int dstY) {    
     if(layer->sizeunits != MS_PIXELS) {

--- a/mapscript/swiginc/layer.i
+++ b/mapscript/swiginc/layer.i
@@ -627,89 +627,7 @@
 
         return msLayerSetExtent(self, minx, miny, maxx, maxy);
     }
-    
-    /* 
-    The following metadata methods are no longer needed since we have
-    promoted the metadata member of layerObj to a first-class mapscript
-    object.  See hashtable.i.  Not yet scheduled for deprecation but 
-    perhaps in the next major release?  --SG
-    */
 
-    /**
-    .. note::
-
-        Function is deprecated and will be removed in a future version. 
-        Replaced by direct metadata access, see :class:`hashTableObj`
-    */
-    char *getMetaData(char *name) 
-    {
-        char *value = NULL;
-        if (!name) {
-            msSetError(MS_HASHERR, "NULL key", "getMetaData");
-        }
-     
-        value = (char *) msLookupHashTable(&(self->metadata), name);
-    /*
-    Umberto, 05/17/2006
-    Exceptions should be reserved for situations when a serious error occurred
-    and normal program flow must be interrupted.
-    In this case returning null should be more that enough.
-    */
-#ifndef SWIGJAVA
-        if (!value) {
-            msSetError(MS_HASHERR, "Key %s does not exist", "getMetaData", name);
-            return NULL;
-        }
-#endif
-        return value;
-    }
-
-    /**
-    .. note::
-
-        Function is deprecated and will be removed in a future version. 
-        Replaced by direct metadata access, see :class:`hashTableObj`
-    */
-    int setMetaData(char *name, char *value) 
-    {
-        if (msInsertHashTable(&(self->metadata), name, value) == NULL)
-        return MS_FAILURE;
-        return MS_SUCCESS;
-    }
-
-    /**
-    .. note::
-
-        Function is deprecated and will be removed in a future version. 
-        Replaced by direct metadata access, see :class:`hashTableObj`
-    */
-    int removeMetaData(char *name) 
-    {
-        return(msRemoveHashTable(&(self->metadata), name));
-    }
-
-    /**
-    .. note::
-
-        Function is deprecated and will be removed in a future version. 
-        Replaced by direct metadata access, see :class:`hashTableObj`
-    */
-    char *getFirstMetaDataKey() 
-    {
-        return (char *) msFirstKeyFromHashTable(&(self->metadata));
-    }
-
-    /**
-    .. note::
-
-        Function is deprecated and will be removed in a future version. 
-        Replaced by direct metadata access, see :class:`hashTableObj`
-    */
-    char *getNextMetaDataKey(char *lastkey) 
-    {
-        return (char *) msNextKeyFromHashTable(&(self->metadata), lastkey);
-    }
-  
     %newobject getWMSFeatureInfoURL;
     /**
     Return a WMS GetFeatureInfo URL (works only for WMS layers) *clickX*, *clickY*
@@ -808,12 +726,6 @@
        msLayerSetProcessingKey( self, key, value );
     }
  
-    /// Deprecated
-    void setProcessing(const char *directive ) 
-    {
-        msLayerAddProcessing( self, directive );
-    }
-
     /// Adds a new processing directive line to a layer, similar to the PROCESSING directive 
     /// in a map file. Processing directives supported are specific to the layer type and 
     /// underlying renderer.

--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -481,43 +481,6 @@
       return msGMLWriteQuery(self, filename, ns);
     }
 
-    /// Deprecated
-    char *getMetaData(char *name) {
-      char *value = NULL;
-      if (!name) {
-        msSetError(MS_HASHERR, "NULL key", "getMetaData");
-      }
-       
-      value = (char *) msLookupHashTable(&(self->web.metadata), name);
-      if (!value) {
-        msSetError(MS_HASHERR, "Key %s does not exist", "getMetaData", name);
-        return NULL;
-      }
-      return value;
-    }
-
-    /// Deprecated
-    int setMetaData(char *name, char *value) {
-      if (msInsertHashTable(&(self->web.metadata), name, value) == NULL)
-          return MS_FAILURE;
-      return MS_SUCCESS;
-    }
-
-    /// Deprecated
-    int removeMetaData(char *name) {
-      return(msRemoveHashTable(&(self->web.metadata), name));
-    }
-
-    /// Deprecated
-    char *getFirstMetaDataKey() {
-      return (char *) msFirstKeyFromHashTable(&(self->web.metadata));
-    }
-
-    /// Deprecated
-    char *getNextMetaDataKey(char *lastkey) {
-      return (char *) msNextKeyFromHashTable(&(self->web.metadata), lastkey);
-    }
-
     /// Load symbols defined in filename into map symbolset. The existing symbolset is cleared. 
     /// Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE`
     int setSymbolSet(char *szFileName) {


### PR DESCRIPTION
This pull request removes various deprecated and legacy functions from the SWIG MapScript API. 
MapScript API docs (currently in development) will reflect these changes and are generated from the code as part of [RFC 133](https://mapserver.org/development/rfc/ms-rfc-132.html). 

Changes for 8.0 release / migration guide:

- `getMetaData` function removed from `mapObj`, `classObj`, and `layerObj` - metadata can now be accessed as a `hashObj` property on all these classes, and then modified using `hashObj` methods.

  Example:

  ```python
  map = mapscript.mapObj(map_file)
  map.setMetaData("ows_onlineresource", "http://dummy.org/")
  ```

  Should be rewritten:

  ```python
  map = mapscript.mapObj(map_file)
  map.web.metadata.set("ows_onlineresource", "http://dummy.org/")
  ```

- `setProcessing` removed from the `layerObj` - use `addProcessing` instead

- `saveToString()` removed from `imageObj` - use the `write()` method instead to write to a file handle. Example in Python:

  ```python
  msimg = self.map.draw()
  data = msimg.saveToString()
  filename = 'map.png'
  fh = open(filename, 'wb')
  fh.write(data)
  fh.close()
  ```

  Should be rewritten:

  ```python
  msimg = self.map.draw()
  filename = 'map.png'
  fh = open(filename, 'wb')
  msimg.write(fh)
  fh.close()
  ```
