### PR TITLE
Set locator and exception code so CITE WFS2 test will pass

### DIFF
--- a/mapwfs.cpp
+++ b/mapwfs.cpp
@@ -2126,7 +2126,7 @@ static int msWFSRunFilter(mapObj* map,
     if( FLTCheckFeatureIdFilters(psNode, map, lp->index) == MS_FAILURE)
     {
         FLTFreeFilterEncodingNode( psNode );
-        return msWFSException(map, "mapserv", MS_OWS_ERROR_NO_APPLICABLE_CODE, paramsObj->pszVersion);
+        return msWFSException(map, "resourceid", MS_OWS_ERROR_INVALID_PARAMETER_VALUE, paramsObj->pszVersion);
     }
 
     /* FIXME?: could probably apply to WFS 1.1 too */

--- a/msautotest/wxs/expected/wfs_200_exception_getfeature_resourceid_filter_invalid_typename.xml
+++ b/msautotest/wxs/expected/wfs_200_exception_getfeature_resourceid_filter_invalid_typename.xml
@@ -1,9 +1,9 @@
-Status: 400 Internal Server Error
+Status: 400 Bad request
 Content-Type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">
-   <ows:Exception exceptionCode="InvalidParameterValue" locator="resourceid">
+  <ows:Exception exceptionCode="InvalidParameterValue" locator="resourceid">
     <ows:ExceptionText>FLTPreParseFilterForAlias(): General error message. Feature id foo.977 not consistent with feature type name province.</ows:ExceptionText>
   </ows:Exception>
 </ows:ExceptionReport>

--- a/msautotest/wxs/expected/wfs_200_exception_getfeature_resourceid_filter_invalid_typename.xml
+++ b/msautotest/wxs/expected/wfs_200_exception_getfeature_resourceid_filter_invalid_typename.xml
@@ -3,7 +3,7 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">
-  <ows:Exception exceptionCode="NoApplicableCode" locator="mapserv">
+   <ows:Exception exceptionCode="InvalidParameterValue" locator="resourceid">
     <ows:ExceptionText>FLTPreParseFilterForAlias(): General error message. Feature id foo.977 not consistent with feature type name province.</ows:ExceptionText>
   </ows:Exception>
 </ows:ExceptionReport>


### PR DESCRIPTION
Sets the locator to "resourceid" and exception code to InvalidParameterValue when requested featureid is inconsistent with feature in TYPENAMES. 

From the CITE WFS2.0 test description: 
>If a feature instance identified by the RESOURCEID parameter is not of the type specified by the TYPENAMES parameter, the server shall raise an InvalidParameterValue exception where the "locator" attribute value shall be set to "RESOURCEID".

http://opengeospatial.github.io/ets-wfs20/apidocs/org/opengis/cite/iso19142/basic/filter/ResourceIdFilterTests.html#inconsistentFeatureIdentifierAndType-javax.xml.namespace.QName-