### PR TITLE
Remove BACKGROUNDCOLOR from STYLE object

### DIFF
--- a/mapcopy.c
+++ b/mapcopy.c
@@ -483,7 +483,6 @@ int msCopyStyle(styleObj *dst, const styleObj *src)
 
   MS_COPYCOLOR(&(dst->color), &(src->color));
   MS_COPYCOLOR(&(dst->outlinecolor),&(src->outlinecolor));
-  MS_COPYCOLOR(&(dst->backgroundcolor), &(src->backgroundcolor));
 
   MS_COPYCOLOR(&(dst->mincolor), &(src->mincolor));
   MS_COPYCOLOR(&(dst->maxcolor), &(src->maxcolor));

--- a/mapfile.c
+++ b/mapfile.c
@@ -2366,7 +2366,6 @@ int initStyle(styleObj *style)
   int i;
   MS_REFCNT_INIT(style);
   MS_INIT_COLOR(style->color, -1,-1,-1,255); /* must explictly set colors */
-  MS_INIT_COLOR(style->backgroundcolor, -1,-1,-1,255);
   MS_INIT_COLOR(style->outlinecolor, -1,-1,-1,255);
   /* New Color Range fields*/
   MS_INIT_COLOR(style->mincolor, -1,-1,-1,255);
@@ -2457,9 +2456,6 @@ int loadStyle(styleObj *style)
             style->antialiased = MS_FALSE;
         }
         break;
-      case(BACKGROUNDCOLOR):
-        if(loadColor(&(style->backgroundcolor), NULL) != MS_SUCCESS) return(MS_FAILURE);
-        break;
       case(COLOR):
         if(loadColor(&(style->color), &(style->bindings[MS_STYLE_BINDING_COLOR])) != MS_SUCCESS) return(MS_FAILURE);
         if(style->bindings[MS_STYLE_BINDING_COLOR].item) style->numbindings++;
@@ -2476,7 +2472,6 @@ int loadStyle(styleObj *style)
 
           style->color.alpha = alpha;
           style->outlinecolor.alpha = alpha;
-          style->backgroundcolor.alpha = alpha;
 
           style->mincolor.alpha = alpha;
           style->maxcolor.alpha = alpha;
@@ -2743,8 +2738,6 @@ void writeStyle(FILE *stream, int indent, styleObj *style)
   if(style->numbindings > 0 && style->bindings[MS_STYLE_BINDING_ANGLE].item)
     writeAttributeBinding(stream, indent, "ANGLE", &(style->bindings[MS_STYLE_BINDING_ANGLE]));
   else writeNumberOrKeyword(stream, indent, "ANGLE", 0, style->angle, style->autoangle, 1, MS_TRUE, "AUTO");
-
-  writeColor(stream, indent, "BACKGROUNDCOLOR", NULL, &(style->backgroundcolor));
 
   if(style->numbindings > 0 && style->bindings[MS_STYLE_BINDING_COLOR].item)
     writeAttributeBinding(stream, indent, "COLOR", &(style->bindings[MS_STYLE_BINDING_COLOR]));

--- a/mapogcsld.c
+++ b/mapogcsld.c
@@ -1395,7 +1395,6 @@ int msSLDParseOgcExpression(CPLXMLNode *psRoot, void *psObj, int binding,
             int alpha = MS_NINT(psStyle->opacity*2.55);
             psStyle->color.alpha = alpha;
             psStyle->outlinecolor.alpha = alpha;
-            psStyle->backgroundcolor.alpha = alpha;
             psStyle->mincolor.alpha = alpha;
             psStyle->maxcolor.alpha = alpha;
           }

--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -4519,6 +4519,7 @@ static int msOGRUpdateStyleParseBrush(mapObj *map, layerObj *layer, styleObj *s,
                                       OGRStyleToolH hBrushStyle, int* pbIsBrush, int* pbPriority);
 static int msOGRUpdateStyleParseSymbol(mapObj *map, styleObj *s,
                                        OGRStyleToolH hSymbolStyle, int* pbPriority);
+static int msOGRAddBgColorStyleParseBrush(styleObj* s, OGRStyleToolH hSymbolStyle);
 
 static int msOGRUpdateStyleCheckPenBrushOnly(OGRStyleMgrH hStyleMgr)
 {
@@ -4637,9 +4638,9 @@ static int msOGRUpdateStyle(OGRStyleMgrH hStyleMgr, mapObj *map, layerObj *layer
         if (bIsBrush || layer->type == MS_LAYER_POLYGON)
             // This is a multipart symbology, so pen defn goes in the
             // overlaysymbol params
-          nIndex = 1;
+            nIndex = c->numstyles + 1;
         else
-          nIndex = 0;
+            nIndex = c->numstyles;
       }
       else
         nIndex = c->numstyles;
@@ -4654,8 +4655,33 @@ static int msOGRUpdateStyle(OGRStyleMgrH hStyleMgr, mapObj *map, layerObj *layer
       msOGRUpdateStyleParsePen(map, layer, s, hStylePart, bIsBrush, &nPriority);
 
     } else if (eStylePartType == OGRSTCBrush) {
+
       styleObj* s;
-      int nIndex = ( bIsPenBrushOnly ) ? 0 : c->numstyles;
+      int nIndex = 0;
+
+      GBool bBgColorIsNull = MS_TRUE;
+      OGR_ST_GetParamStr(hStylePart, OGRSTBrushBColor, &bBgColorIsNull);
+
+      if (!bBgColorIsNull) {
+
+       if (msMaybeAllocateClassStyle(c, 0)) {
+            OGR_ST_Destroy(hStylePart);
+            msFree(pasSortStruct);
+            return(MS_FAILURE);
+        }
+
+        // add a backgroundcolor as a separate style
+        s = c->styles[nIndex];
+        msOGRAddBgColorStyleParseBrush(s, hStylePart);
+      }
+
+
+      nIndex = ( bIsPenBrushOnly ) ? 0 : c->numstyles;
+
+      if (!bBgColorIsNull) {
+          nIndex += 1;
+      }
+
       /* We need 1 style */
       if (msMaybeAllocateClassStyle(c, nIndex)) {
         OGR_ST_Destroy(hStylePart);
@@ -5018,6 +5044,21 @@ static int msOGRUpdateStyleParsePen(mapObj *map, layerObj *layer, styleObj *s,
       return MS_SUCCESS;
 }
 
+static int msOGRAddBgColorStyleParseBrush(styleObj* s, OGRStyleToolH hBrushStyle)
+{
+    GBool bIsNull;
+    int r = 0, g = 0, b = 0, t = 0;
+    const char* pszColor = OGR_ST_GetParamStr(hBrushStyle,
+        OGRSTBrushBColor, &bIsNull);
+
+    if (!bIsNull && OGR_ST_GetRGBFromString(hBrushStyle,
+        pszColor,
+        &r, &g, &b, &t)) {
+        MS_INIT_COLOR(s->color, r, g, b, t);
+    }
+    return MS_SUCCESS;
+}
+
 static int msOGRUpdateStyleParseBrush(mapObj *map, layerObj *layer, styleObj *s,
                                       OGRStyleToolH hBrushStyle, int* pbIsBrush,
                                       int* pbPriority)
@@ -5046,14 +5087,6 @@ static int msOGRUpdateStyleParseBrush(mapObj *map, layerObj *layer, styleObj *s,
 
           if (layer->debug >= MS_DEBUGLEVEL_VVV)
             msDebug("** BRUSH COLOR = %d %d %d **\n", r,g,b);
-        }
-
-        pszColor = OGR_ST_GetParamStr(hBrushStyle,
-                                      OGRSTBrushBColor, &bIsNull);
-        if (!bIsNull && OGR_ST_GetRGBFromString(hBrushStyle,
-                                                pszColor,
-                                                &r, &g, &b, &t)) {
-          MS_INIT_COLOR(s->backgroundcolor, r, g, b, t);
         }
 
         // Symbol name mapping:

--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -4664,7 +4664,7 @@ static int msOGRUpdateStyle(OGRStyleMgrH hStyleMgr, mapObj *map, layerObj *layer
 
       if (!bBgColorIsNull) {
 
-       if (msMaybeAllocateClassStyle(c, 0)) {
+       if (msMaybeAllocateClassStyle(c, nIndex)) {
             OGR_ST_Destroy(hStylePart);
             msFree(pasSortStruct);
             return(MS_FAILURE);
@@ -4676,9 +4676,10 @@ static int msOGRUpdateStyle(OGRStyleMgrH hStyleMgr, mapObj *map, layerObj *layer
       }
 
 
-      nIndex = ( bIsPenBrushOnly ) ? 0 : c->numstyles;
+      nIndex = ( bIsPenBrushOnly ) ? nIndex : c->numstyles;
 
       if (!bBgColorIsNull) {
+          // if we have a bgcolor style we need to increase the index
           nIndex += 1;
       }
 

--- a/maprendering.c
+++ b/maprendering.c
@@ -59,11 +59,6 @@ void computeSymbolStyle(symbolStyleObj *s, styleObj *src, symbolObj *symbol, dou
     s->color = NULL;
   }
 
-
-  if(MS_VALID_COLOR(src->backgroundcolor)) {
-    s->backgroundcolor = &(src->backgroundcolor);
-  }
-
   target_size = style_size * scalefactor;
   target_size = MS_MAX(target_size, src->minsize*resolutionfactor);
   target_size = MS_MIN(target_size, src->maxsize*resolutionfactor);
@@ -177,7 +172,6 @@ tileCacheObj *addTileCache(imageObj *img,
   cachep->rotation = style->rotation;
   if(style->color) MS_COPYCOLOR(&cachep->color,style->color);
   if(style->outlinecolor) MS_COPYCOLOR(&cachep->outlinecolor,style->outlinecolor);
-  if(style->backgroundcolor) MS_COPYCOLOR(&cachep->backgroundcolor,style->backgroundcolor);
   cachep->width = width;
   cachep->height = height;
   cachep->symbol = symbol;
@@ -743,10 +737,6 @@ int msDrawShadeSymbol(mapObj *map, imageObj *image, shapeObj *p, styleObj *style
         double pattern[MS_MAXPATTERNLENGTH];
         int i;
 
-        if(MS_VALID_COLOR(style->backgroundcolor)) {
-          ret = renderer->renderPolygon(image,offsetPolygon, &style->backgroundcolor);
-          if(ret != MS_SUCCESS) goto cleanup;
-        }
         width = (style->width <= 0)?scalefactor:style->width*scalefactor;
         width = MS_MIN(width, style->maxwidth*image->resolutionfactor);
         width = MS_MAX(width, style->minwidth*image->resolutionfactor);

--- a/mapscript/php/style.c
+++ b/mapscript/php/style.c
@@ -176,12 +176,11 @@ PHP_METHOD(styleObj, __get)
                                                           else IF_GET_LONG("opacity", php_style->style->opacity)
                                                             else IF_GET_OBJECT("color", mapscript_ce_color, php_style->color, &php_style->style->color)
                                                               else IF_GET_OBJECT("outlinecolor", mapscript_ce_color, php_style->outlinecolor, &php_style->style->outlinecolor)
-                                                                else IF_GET_OBJECT("backgroundcolor", mapscript_ce_color, php_style->backgroundcolor, &php_style->style->backgroundcolor)
-                                                                  else IF_GET_OBJECT("mincolor", mapscript_ce_color, php_style->mincolor, &php_style->style->mincolor)
-                                                                    else IF_GET_OBJECT("maxcolor", mapscript_ce_color, php_style->maxcolor, &php_style->style->maxcolor)
-                                                                      else {
-                                                                        mapscript_throw_exception("Property '%s' does not exist in this object." TSRMLS_CC, property);
-                                                                        }
+                                                                else IF_GET_OBJECT("mincolor", mapscript_ce_color, php_style->mincolor, &php_style->style->mincolor)
+                                                                  else IF_GET_OBJECT("maxcolor", mapscript_ce_color, php_style->maxcolor, &php_style->style->maxcolor)
+                                                                    else {
+                                                                      mapscript_throw_exception("Property '%s' does not exist in this object." TSRMLS_CC, property);
+                                                                      }
 }
 
 PHP_METHOD(styleObj, __set)
@@ -247,7 +246,6 @@ PHP_METHOD(styleObj, __set)
 
                                                         php_style->style->color.alpha = alpha;
                                                         php_style->style->outlinecolor.alpha = alpha;
-                                                        php_style->style->backgroundcolor.alpha = alpha;
                                                         php_style->style->mincolor.alpha = alpha;
                                                         php_style->style->maxcolor.alpha = alpha;
                                                       } else if (STRING_EQUAL("symbolname", property)) {
@@ -496,7 +494,6 @@ PHP_METHOD(styleObj, free)
 
   MAPSCRIPT_DELREF(php_style->color);
   MAPSCRIPT_DELREF(php_style->outlinecolor);
-  MAPSCRIPT_DELREF(php_style->backgroundcolor);
 }
 /* }}} */
 
@@ -675,7 +672,6 @@ static zend_object *mapscript_style_create_object(zend_class_entry *ce TSRMLS_DC
   MAPSCRIPT_INIT_PARENT(php_style->parent);
   ZVAL_UNDEF(&php_style->color);
   ZVAL_UNDEF(&php_style->outlinecolor);
-  ZVAL_UNDEF(&php_style->backgroundcolor);
 
   return &php_style->zobj;
 }
@@ -689,7 +685,6 @@ static void mapscript_style_free_object(zend_object *object)
   MAPSCRIPT_FREE_PARENT(php_style->parent);
   MAPSCRIPT_DELREF(php_style->color);
   MAPSCRIPT_DELREF(php_style->outlinecolor);
-  MAPSCRIPT_DELREF(php_style->backgroundcolor);
 
   /* We don't need to free the styleObj, the mapObj will do it */
 
@@ -741,7 +736,6 @@ static void mapscript_style_object_destroy(void *object TSRMLS_DC)
   MAPSCRIPT_FREE_PARENT(php_style->parent);
   MAPSCRIPT_DELREF(php_style->color);
   MAPSCRIPT_DELREF(php_style->outlinecolor);
-  MAPSCRIPT_DELREF(php_style->backgroundcolor);
 
   /* We don't need to free the styleObj, the mapObj will do it */
   efree(object);
@@ -764,7 +758,6 @@ static zend_object_value mapscript_style_object_new_ex(zend_class_entry *ce, php
   MAPSCRIPT_INIT_PARENT(php_style->parent);
   php_style->color = NULL;
   php_style->outlinecolor = NULL;
-  php_style->backgroundcolor = NULL;
 
   return retval;
 }

--- a/mapserver.h
+++ b/mapserver.h
@@ -1047,7 +1047,6 @@ The :ref:`STYLE <style>` object. An instance of styleObj is associated with one 
     int antialiased; ///< See :ref:`ANTIALIAS <mapfile-style-antialias>`
 
     colorObj color; ///< Foreground or fill pen color - see :ref:`COLOR <mapfile-style-color>`
-    colorObj backgroundcolor; ///< See :ref:`BACKGROUNDCOLOR <mapfile-style-backgroundcolor>`
     colorObj outlinecolor; ///< Outline pen color - see :ref:`OUTLINECOLOR <mapfile-style-outlinecolor>`
 
     int opacity; ///< See :ref:`OPACITY <mapfile-style-opacity>`

--- a/maptemplate.c
+++ b/maptemplate.c
@@ -2451,8 +2451,8 @@ int processIcon(mapObj *map, int nIdxLayer, int nIdxClass, char** pszInstr, char
         pszSymbolNameHash = msHashString(style->symbolname);
 
       snprintf(szStyleCode+strlen(szStyleCode), 255,
-               "s%d_%x_%x_%x_%d_%s_%g",
-               i, MS_COLOR_GETRGB(style->color), MS_COLOR_GETRGB(style->backgroundcolor), MS_COLOR_GETRGB(style->outlinecolor),
+               "s%d_%x_%x_%d_%s_%g",
+               i, MS_COLOR_GETRGB(style->color),MS_COLOR_GETRGB(style->outlinecolor),
                style->symbol, pszSymbolNameHash?pszSymbolNameHash:"",
                style->angle);
       msFree(pszSymbolNameHash);

--- a/maputil.c
+++ b/maputil.c
@@ -247,7 +247,6 @@ static void bindStyle(layerObj *layer, shapeObj *shape, styleObj *style, int dra
     alpha = MS_NINT(style->opacity*2.55);
     style->color.alpha = alpha;
     style->outlinecolor.alpha = alpha;
-    style->backgroundcolor.alpha = alpha;
     style->mincolor.alpha = alpha;
     style->maxcolor.alpha = alpha;
   }

--- a/xmlmapfile/mapfile.xsl
+++ b/xmlmapfile/mapfile.xsl
@@ -809,8 +809,6 @@
       <xsl:with-param name="indent" select="$indent"/>
       <xsl:with-param name="node" select="'ms:antialias'"/>
     </xsl:call-template>
-    <xsl:apply-templates select="ms:backgroundColor">
-      <xsl:with-param name="indent" select="$indent"/>
     </xsl:apply-templates>
     <xsl:apply-templates select="ms:color">
       <xsl:with-param name="indent" select="$indent"/>


### PR DESCRIPTION
Removes [STYLE>BACKGROUNDCOLOR](https://mapserver.org/mapfile/style.html#mapfile-style-backgroundcolor) as part of [RFC 133](https://mapserver.org/development/rfc/ms-rfc-133.html)

Remaining usage of `BACKGROUNDCOLOR` was in the autogeneration of styles from OGR in `mapogr.cpp`. This required reworking the function to produce 2 style objects, and keep the current ordering logic for `PenBrush` styles. msautotests all passing with same results as previously. 