### PR TITLE
Allow POST requests from MapsScript

### DIFF
--- a/cgiutil.c
+++ b/cgiutil.c
@@ -144,13 +144,18 @@ int loadParams(cgiRequestObj *request,
     int data_len;
     request->type = MS_POST_REQUEST;
 
-    s = getenv2("CONTENT_TYPE", thread_context);
-    if (s != NULL)
-      request->contenttype = msStrdup(s);
-    /* we've to set default Content-Type which is
-     * application/octet-stream according to
-     * W3 RFC 2626 section 7.2.1 */
-    else request->contenttype = msStrdup("application/octet-stream");
+    if (request->contenttype == NULL){
+        s = getenv2("CONTENT_TYPE", thread_context);
+        if (s != NULL){
+          request->contenttype = msStrdup(s);
+        }
+        else {
+            /* we've to set default Content-Type which is
+             * application/octet-stream according to
+             * W3 RFC 2626 section 7.2.1 */
+            request->contenttype = msStrdup("application/octet-stream");
+        }
+    }
 
     if (raw_post_data) {
       post_data = msStrdup(raw_post_data);

--- a/mapows.c
+++ b/mapows.c
@@ -175,8 +175,8 @@ static int msOWSPreParseRequest(cgiRequestObj *request,
     }
 
     /* Get service, version and request from root */
-    ows_request->service = (char *) xmlGetProp(root, BAD_CAST "service");
-    ows_request->version = (char *) xmlGetProp(root, BAD_CAST "version");
+    ows_request->service = msStrdup((char *) xmlGetProp(root, BAD_CAST "service"));
+    ows_request->version = msStrdup((char *) xmlGetProp(root, BAD_CAST "version"));
     ows_request->request = msStrdup((char *) root->name);
 
 #else

--- a/mapows.c
+++ b/mapows.c
@@ -175,11 +175,17 @@ static int msOWSPreParseRequest(cgiRequestObj *request,
     }
 
     /* Get service, version and request from root */
-    char* tmp = NULL;
-    if ((tmp = (char*)xmlGetProp(root, BAD_CAST "service")) != NULL)
-        ows_request->service = msStrdup(tmp);
-    if ((tmp = (char*)xmlGetProp(root, BAD_CAST "version")) != NULL)
-        ows_request->version = msStrdup(tmp);
+    xmlChar* serviceTmp = xmlGetProp(root, BAD_CAST "service");
+    if (serviceTmp != NULL) {
+        ows_request->service = msStrdup((char *) serviceTmp);
+        xmlFree(serviceTmp);
+    }
+
+    xmlChar* versionTmp = xmlGetProp(root, BAD_CAST "version");
+    if (versionTmp != NULL) {
+        ows_request->version = msStrdup((char *) versionTmp);
+        xmlFree(versionTmp);
+    }
 
     ows_request->request = msStrdup((char *) root->name);
 

--- a/mapows.c
+++ b/mapows.c
@@ -175,8 +175,12 @@ static int msOWSPreParseRequest(cgiRequestObj *request,
     }
 
     /* Get service, version and request from root */
-    ows_request->service = msStrdup((char *) xmlGetProp(root, BAD_CAST "service"));
-    ows_request->version = msStrdup((char *) xmlGetProp(root, BAD_CAST "version"));
+    char* tmp = NULL;
+    if ((tmp = (char*)xmlGetProp(root, BAD_CAST "service")) != NULL)
+        ows_request->service = msStrdup(tmp);
+    if ((tmp = (char*)xmlGetProp(root, BAD_CAST "version")) != NULL)
+        ows_request->version = msStrdup(tmp);
+
     ows_request->request = msStrdup((char *) root->name);
 
 #else

--- a/mapscript/python/tests/cases/ows_test.py
+++ b/mapscript/python/tests/cases/ows_test.py
@@ -25,6 +25,7 @@
 # ===========================================================================
 
 import unittest
+import xml.dom.minidom
 import mapscript
 from .testing import MapTestCase
 
@@ -89,13 +90,12 @@ class OWSRequestTestCase(MapTestCase):
 
     def testWFSPostRequest(self):
         """OWSRequestTestCase.testLoadWMSRequest: OWS can POST a WFS request"""
-        
+
         self.map.web.metadata.set("ows_onlineresource", "http://dummy.org/")
         request = mapscript.OWSRequest()
         request.contenttype = "application/xml"
 
-
-        post_data = """<wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" service="WFS" 
+        post_data = """<wfs:GetFeature xmlns:wfs="http://www.opengis.net/wfs" xmlns:ogc="http://www.opengis.net/ogc" service="WFS"
         version="1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
         <wfs:Query typeName="*:POINT" xmlns:feature="http://www.openplans.org/topp">
             <ogc:Filter>
@@ -108,13 +108,12 @@ class OWSRequestTestCase(MapTestCase):
         </wfs:GetFeature>
         """
 
-        qs = "" # additional parameters can be passed via the querystring
+        qs = ""  # additional parameters can be passed via the querystring
         request.loadParamsFromPost(post_data, qs)
         mapscript.msIO_installStdoutToBuffer()
         status = map.OWSDispatch(request)
         assert status == mapscript.MS_SUCCESS, status
 
-        content_type = mapscript.msIO_stripStdoutBufferContentType()
         mapscript.msIO_stripStdoutBufferContentHeaders()
         result = mapscript.msIO_getStdoutBufferBytes()
         dom = xml.dom.minidom.parseString(result)

--- a/mapscript/python/tests/cases/ows_test.py
+++ b/mapscript/python/tests/cases/ows_test.py
@@ -111,7 +111,7 @@ class OWSRequestTestCase(MapTestCase):
         qs = ""  # additional parameters can be passed via the querystring
         request.loadParamsFromPost(post_data, qs)
         mapscript.msIO_installStdoutToBuffer()
-        status = map.OWSDispatch(request)
+        status = self.map.OWSDispatch(request)
         assert status == mapscript.MS_SUCCESS, status
 
         mapscript.msIO_stripStdoutBufferContentHeaders()

--- a/mapscript/swiginc/owsrequest.i
+++ b/mapscript/swiginc/owsrequest.i
@@ -31,6 +31,10 @@
 
 
 %{
+/**
+The following functions are used to simulate the CGI environment for a request
+and return default values when a environment key is passed in
+*/
 static char *msGetEnvURL( const char *key, void *thread_context )
 {
     if( strcmp(key,"REQUEST_METHOD") == 0 )
@@ -38,6 +42,17 @@ static char *msGetEnvURL( const char *key, void *thread_context )
 
     if( strcmp(key,"QUERY_STRING") == 0 )
         return (char *) thread_context;
+
+    return NULL;
+}
+
+static char *msPostEnvURL(const char *key, void *thread_context)
+{
+    if (strcmp(key, "REQUEST_METHOD") == 0)
+        return "POST";
+
+    if (strcmp(key, "QUERY_STRING") == 0)
+        return (char *)thread_context;
 
     return NULL;
 }
@@ -87,7 +102,6 @@ static char *msGetEnvURL( const char *key, void *thread_context )
         return self->NumParams;
     }
 
-
     /**
     Initializes the OWSRequest object from the provided URL which is 
     treated like a ``QUERY_STRING``. 
@@ -96,6 +110,18 @@ static char *msGetEnvURL( const char *key, void *thread_context )
     int loadParamsFromURL( const char *url )
     {
         self->NumParams = loadParams( self, msGetEnvURL, NULL, 0, (void*)url );
+        return self->NumParams;
+    }
+
+    /**
+    Initializes the OWSRequest object with POST data, along with a the provided URL which is
+    treated like a ``QUERY_STRING``.
+    Note that ``REQUEST_METHOD=POST`` and the caller is responsible for setting the correct
+    content type e.g. ``req.contenttype = "application/xml"``
+    */
+    int loadParamsFromPost( char *postData, const char *url)
+    {
+        self->NumParams = loadParams( self, msPostEnvURL, msStrdup(postData), (ms_uint32) strlen(postData), (void*)url);
         return self->NumParams;
     }
 


### PR DESCRIPTION
The following adds in POST request functionality from within MapScript via a new `loadParamsFromPost` method. Related to #6344.
Note - this will allow POST data to be passed as a string via MapScript, but does not support reading from a buffer. 

The only change to existing CGI functionality is allowing `request->contenttype` to be set directly on a request object rather than always reading from the CGI environment. 

Associated Python test added to the test suite, which can also serve as an example. 