### PR TITLE
update IRC channel for build notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,6 @@ after_success:
 notifications:
   irc:
     channels:
-      - "irc.freenode.org#mapserver"
+      - "irc.libera.chat#mapserver"
     use_notice: true
 


### PR DESCRIPTION
- most communities have moved to irc.libera.chat
- recently Freenode servers & channels were reset. Future there is unknown.
