### PR TITLE
Update Appveyor builds to Visual Studio 2019

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ branches:
   except:
     - /(cherry-pick-)?backport-\d+-to-/
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 cache:
   - '%LOCALAPPDATA%\pip\Cache'
@@ -18,7 +18,7 @@ environment:
       secure: mHoJHeXdXbBNoDf7MA4ZEg==
 
   # VS 2017
-  VS_VERSION: Visual Studio 15 2017
+  VS_VERSION: Visual Studio 16 2019
   matrix:
   - platform: x86
     Python_ROOT_DIR: c:/python27
@@ -32,9 +32,6 @@ environment:
   - platform: x64
     Python_ROOT_DIR: c:/python38-x64
 
-services:
-  - mssql2017
-
 matrix:
   fast_finish: true
 
@@ -42,6 +39,7 @@ shallow_clone: false
 clone_depth: 5
 
 init:
+  - net start MSSQL$SQL2019
   - ps: |
         if ($env:APPVEYOR_REPO_TAG -ne $TRUE) {
             if ("c:/python27-x64","c:/python36-x64" -contains $env:Python_ROOT_DIR -eq $TRUE) {
@@ -53,12 +51,14 @@ init:
 build_script:
   - ps: Write-Host "Build tags - $env:APPVEYOR_REPO_TAG $env:APPVEYOR_REPO_TAG_NAME"
   - set "BUILD_FOLDER=%APPVEYOR_BUILD_FOLDER:\=/%"
-  - if "%platform%" == "x64" SET VS_FULL=%VS_VERSION% Win64
+  - if "%platform%" == "x64" SET VS_FULL=%VS_VERSION%
+  - if "%platform%" == "x64" SET VS_ARCH=x64
   - if "%platform%" == "x86" SET VS_FULL=%VS_VERSION%
-  - if "%platform%" == "x86" SET SDK=release-1911
-  - if "%platform%" == "x64" SET SDK=release-1911-x64
-  - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars64.bat"
-  - if "%platform%" == "x86" call "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvars32.bat"
+  - if "%platform%" == "x86" SET VS_ARCH=Win32 
+  - if "%platform%" == "x86" SET SDK=release-1928
+  - if "%platform%" == "x64" SET SDK=release-1928-x64
+  - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
+  - if "%platform%" == "x86" call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars32.bat"
   - echo "%VS_FULL%"
   - if not exist %SWIG_VER%.zip appveyor DownloadFile https://sourceforge.net/projects/swig/files/swigwin/%SWIG_VER%/%SWIG_VER%.zip
   - set SDK_ZIP=%SDK%-dev.zip
@@ -75,18 +75,18 @@ build_script:
   - set SDK_LIB=%BUILD_FOLDER%/sdk/%SDK%/lib
   - set SDK_BIN=%BUILD_FOLDER%/sdk/%SDK%/bin
   - set SWIG_EXECUTABLE=%BUILD_FOLDER%/sdk/%SWIG_VER%/swig.exe
-  - set REGEX_DIR=%BUILD_FOLDER%/sdk/regex-0.12
+  - set REGEX_DIR=%BUILD_FOLDER%/sdk/support/regex-0.12
   - cd %BUILD_FOLDER%
   - mkdir build
   - cd build
+  - set PATH=%BUILD_FOLDER%/build/Release;%SDK_BIN%;%PATH%  
   - set "PROJECT_BINARY_DIR=%BUILD_FOLDER%/build"
-  - cmake -G "%VS_FULL%" .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%SDK_PREFIX% -DFREETYPE_INCLUDE_DIR_freetype2=%SDK_INC%/freetype -DFREETYPE_INCLUDE_DIR_ft2build=%SDK_INC%/freetype -DFREETYPE_LIBRARY=%SDK_LIB%/freetype.lib -DZLIB_INCLUDE_DIR=%SDK_INC% -DZLIB_LIBRARY=%SDK_LIB%/zlib.lib -DPNG_PNG_INCLUDE_DIR=%SDK_INC% -DPNG_LIBRARY=%SDK_LIB%/libpng.lib -DPNG_LIBRARIES=%SDK_LIB%/libpng.lib -DJPEG_INCLUDE_DIR=%SDK_INC% -DJPEG_LIBRARY=%SDK_LIB%/libjpeg.lib -DPROJ_INCLUDE_DIR=%SDK_INC% -DPROJ_LIBRARY=%SDK_LIB%/proj_i.lib -DFRIBIDI_INCLUDE_DIR=%SDK_INC% -DFRIBIDI_LIBRARY=%SDK_LIB%/fribidi.lib -DHARFBUZZ_INCLUDE_DIR=%SDK_INC%/harfbuzz -DHARFBUZZ_LIBRARY=%SDK_LIB%/harfbuzz.lib -DICONV_INCLUDE_DIR=%SDK_INC% -DICONV_LIBRARY=%SDK_LIB%/iconv.lib -DICONV_DLL=%SDK_BIN%/iconv.dll -DCAIRO_INCLUDE_DIR=%SDK_INC% -DCAIRO_LIBRARY=%SDK_LIB%/cairo.lib -DFCGI_INCLUDE_DIR=%SDK_INC% -DFCGI_LIBRARY=%SDK_LIB%/libfcgi.lib -DGEOS_INCLUDE_DIR=%SDK_INC% -DGEOS_LIBRARY=%SDK_LIB%/geos_c.lib -DPOSTGRESQL_INCLUDE_DIR=%SDK_INC% -DPOSTGRESQL_LIBRARY=%SDK_LIB%/libpqdll.lib -DGDAL_INCLUDE_DIR=%SDK_INC% -DGDAL_LIBRARY=%SDK_LIB%/gdal_i.lib -DLIBXML2_INCLUDE_DIR=%SDK_INC%/libxml -DLIBXML2_LIBRARIES=%SDK_LIB%/libxml2.lib -DGIF_INCLUDE_DIR=%SDK_INC% -DGIF_LIBRARY=%SDK_LIB%/giflib.lib -DWITH_CURL=1 -DCURL_INCLUDE_DIR=%SDK_INC% -DCURL_LIBRARY=%SDK_LIB%/libcurl_imp.lib -DMS_EXTERNAL_LIBS=wsock32.lib -DWITH_SOS=1 -DWITH_CLIENT_WFS=1 -DWITH_CLIENT_WMS=1 -DSVG_INCLUDE_DIR=%SDK_INC% -DSVG_LIBRARY=%SDK_LIB%/libsvg.lib -DSVGCAIRO_INCLUDE_DIR=%SDK_INC% -DSVGCAIRO_LIBRARY=%SDK_LIB%/libsvg-cairo.lib -DWITH_SVGCAIRO=1 -DREGEX_DIR=%REGEX_DIR% -DWITH_KML=1 -DWITH_THREAD_SAFETY=1 -DSWIG_EXECUTABLE=%SWIG_EXECUTABLE% -DWITH_PYTHON=1 -DWITH_CSHARP=1 -DWITH_MSSQL2008=1 -DPROTOBUFC_COMPILER=%SDK_BIN%/protoc.exe -DPROTOBUFC_LIBRARY=%SDK_LIB%/protobuf-c.lib -DPROTOBUFC_INCLUDE_DIR=%SDK_INC%/include/protobuf-c -DWITH_PROTOBUFC=1 -DCMAKE_C_FLAGS="/WX" -DCMAKE_CXX_FLAGS="/WX"
+  - cmake -G "%VS_FULL%" -A %VS_ARCH% .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%SDK_PREFIX% -DPNG_LIBRARY=%SDK_LIB%/libpng16_static.lib -DHARFBUZZ_INCLUDE_DIR=%SDK_INC%/harfbuzz -DICONV_DLL=%SDK_BIN%/iconv.dll -DFRIBIDI_INCLUDE_DIR=%SDK_INC%/fribidi -DMS_EXTERNAL_LIBS=%SDK_LIB%/harfbuzz.lib;%SDK_LIB%/uriparser.lib -DSVG_LIBRARY=%SDK_LIB%/libsvg.lib -DSVGCAIRO_LIBRARY=%SDK_LIB%/libsvg-cairo.lib -DREGEX_DIR=%REGEX_DIR% -DSWIG_EXECUTABLE=%SWIG_EXECUTABLE% -DPROTOBUFC_COMPILER=%SDK_BIN%/protoc.exe -DPROTOBUFC_LIBRARY=%SDK_LIB%/protobuf-c.lib -DPROTOBUFC_INCLUDE_DIR=%SDK_INC%/protobuf-c -DWITH_CURL=1 -DWITH_KML=1 -DWITH_SVGCAIRO=1 -DWITH_THREAD_SAFETY=1 -DWITH_SOS=1 -DWITH_CLIENT_WFS=1 -DWITH_CLIENT_WMS=1-DWITH_CSHARP=1 -DWITH_PROTOBUFC=1 -DWITH_POSTGIS=0 -DWITH_PERL=0 -DWITH_MSSQL2008=1 -DWITH_PYTHON=1 -DWITH_PHPNG=0 -DWITH_HARFBUZZ=1
   - cmake --build . --config Release
   - cd %BUILD_FOLDER%/build
-  - set PATH=%BUILD_FOLDER%/build/Release;%SDK_BIN%;%PATH%
   # set the MapScript custom environment variable for py 3.8
   - set MAPSERVER_DLL_PATH=%BUILD_FOLDER%/build/Release;%SDK_BIN%
-  - set PROJ_LIB=%SDK_BIN%/proj/SHARE
+  - set PROJ_LIB=%SDK_BIN%/proj7/SHARE
   # check the mapserver exe can run
   - mapserv -v
   - cmake --build . --target pythonmapscript-wheel --config Release
@@ -94,13 +94,13 @@ build_script:
 before_test:
   - set PATH=%PATH%;%SDK_BIN%/gdal/apps
   - cd %BUILD_FOLDER%/msautotest
-  - set PROJ_LIB=%SDK_BIN%/proj6/share
+  #- set PROJ_LIB=%SDK_BIN%/proj7/share
   - "./mssql/create_mssql_db.bat"
   - "%Python_ROOT_DIR%/python -m pip install -U -r requirements.txt"
   - "%Python_ROOT_DIR%/python -m pip install --no-index --find-links=file://%BUILD_FOLDER%/build/mapscript/python/Release/dist mapscript"
 
 test_script:
-  - set PROJ_LIB=%SDK_BIN%/proj/SHARE
+  - set PROJ_LIB=%SDK_BIN%/proj7/SHARE
   - cd %BUILD_FOLDER%/msautotest/mssql
   - "%Python_ROOT_DIR%/python run_test.py"
   - cd %BUILD_FOLDER%/msautotest/mspython
@@ -111,7 +111,7 @@ after_test:
   - 7z a mapserver.zip ./build/* > nul
 
 # Uncomment to enable debugging on the server
-# on_finish:
+#on_finish:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))  
 
 artifacts:

--- a/msautotest/mssql/create_mssql_db.bat
+++ b/msautotest/mssql/create_mssql_db.bat
@@ -1,5 +1,5 @@
 set SQLPASSWORD=Password12!
-set SERVER=(local)\SQL2017
+set SERVER=(local)\SQL2019
 
 sqlcmd -S "%SERVER%" -Q "USE [master]; CREATE DATABASE msautotest;"
 

--- a/msautotest/mssql/expected/line.json
+++ b/msautotest/mssql/expected/line.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "line",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": { "type": "LineString", "coordinates": [ [ 30.0, 10.0 ], [ 10.0, 30.0 ], [ 40.0, 40.0 ] ] } }
 ]

--- a/msautotest/mssql/expected/multiline.json
+++ b/msautotest/mssql/expected/multiline.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "multiline",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": { "type": "MultiLineString", "coordinates": [ [ [ 10.0, 10.0 ], [ 20.0, 20.0 ], [ 10.0, 40.0 ] ], [ [ 40.0, 40.0 ], [ 30.0, 30.0 ], [ 40.0, 20.0 ], [ 30.0, 10.0 ] ] ] } }
 ]

--- a/msautotest/mssql/expected/multipoint.json
+++ b/msautotest/mssql/expected/multipoint.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "multipoint",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": { "type": "MultiPoint", "coordinates": [ [ 10.0, 40.0 ], [ 40.0, 30.0 ], [ 20.0, 20.0 ], [ 30.0, 10.0 ] ] } }
 ]

--- a/msautotest/mssql/expected/multipolygon.json
+++ b/msautotest/mssql/expected/multipolygon.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "multipolygon",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 30.0, 20.0 ], [ 45.0, 40.0 ], [ 10.0, 40.0 ], [ 30.0, 20.0 ] ] ], [ [ [ 15.0, 5.0 ], [ 40.0, 10.0 ], [ 10.0, 20.0 ], [ 5.0, 10.0 ], [ 15.0, 5.0 ] ] ] ] } }
 ]

--- a/msautotest/mssql/expected/multipolygon_with_hole.json
+++ b/msautotest/mssql/expected/multipolygon_with_hole.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "multipolygon_with_hole",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 40.0, 40.0 ], [ 20.0, 45.0 ], [ 45.0, 30.0 ], [ 40.0, 40.0 ] ] ], [ [ [ 20.0, 35.0 ], [ 10.0, 30.0 ], [ 10.0, 10.0 ], [ 30.0, 5.0 ], [ 45.0, 20.0 ], [ 20.0, 35.0 ] ], [ [ 30.0, 20.0 ], [ 20.0, 15.0 ], [ 20.0, 25.0 ], [ 30.0, 20.0 ] ] ] ] } }
 ]

--- a/msautotest/mssql/expected/null_line.json
+++ b/msautotest/mssql/expected/null_line.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "null_line",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": null }
 ]

--- a/msautotest/mssql/expected/null_multiline.json
+++ b/msautotest/mssql/expected/null_multiline.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "null_multiline",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": null }
 ]

--- a/msautotest/mssql/expected/null_multipoint.json
+++ b/msautotest/mssql/expected/null_multipoint.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "null_multipoint",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": null }
 ]

--- a/msautotest/mssql/expected/null_multipolygon.json
+++ b/msautotest/mssql/expected/null_multipolygon.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "null_multipolygon",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": null }
 ]

--- a/msautotest/mssql/expected/null_point.json
+++ b/msautotest/mssql/expected/null_point.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "null_point",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": null }
 ]

--- a/msautotest/mssql/expected/null_polygon.json
+++ b/msautotest/mssql/expected/null_polygon.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "null_polygon",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": null }
 ]

--- a/msautotest/mssql/expected/point.json
+++ b/msautotest/mssql/expected/point.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "point",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": { "type": "Point", "coordinates": [ 30.0, 10.0 ] } }
 ]

--- a/msautotest/mssql/expected/polygon.json
+++ b/msautotest/mssql/expected/polygon.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "polygon",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 30.0, 10.0 ], [ 40.0, 40.0 ], [ 20.0, 40.0 ], [ 10.0, 20.0 ], [ 30.0, 10.0 ] ] ] } }
 ]

--- a/msautotest/mssql/expected/polygon_with_hole.json
+++ b/msautotest/mssql/expected/polygon_with_hole.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 1,
 "name": "polygon_with_hole",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "fid": 1 }, "geometry": { "type": "Polygon", "coordinates": [ [ [ 35.0, 10.0 ], [ 45.0, 45.0 ], [ 15.0, 40.0 ], [ 10.0, 20.0 ], [ 35.0, 10.0 ] ], [ [ 20.0, 30.0 ], [ 35.0, 35.0 ], [ 30.0, 20.0 ], [ 20.0, 30.0 ] ] ] } }
 ]

--- a/msautotest/mssql/expected/wfs_mssql_maxfeatures.json
+++ b/msautotest/mssql/expected/wfs_mssql_maxfeatures.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 6994,
 "name": "cities",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "ogr_fid": 1, "name": "崇州市", "name_ar": "", "name_hi": "" }, "geometry": { "type": "Point", "coordinates": [ 11540741.500531593337655, 3584222.176282715518028 ] } },
 { "type": "Feature", "properties": { "ogr_fid": 2, "name": "江油市", "name_ar": "", "name_hi": "" }, "geometry": { "type": "Point", "coordinates": [ 11658983.416123732924461, 3734167.308027575723827 ] } },

--- a/msautotest/mssql/expected/wfs_mssql_maxfeatures_order.json
+++ b/msautotest/mssql/expected/wfs_mssql_maxfeatures_order.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 6994,
 "name": "cities_with_order",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "ogr_fid": 6994, "name": "Heroica Nogales", "name_ar": "", "name_hi": "" }, "geometry": { "type": "Point", "coordinates": [ -12351166.251028399914503, 3674840.854894261341542 ] } },
 { "type": "Feature", "properties": { "ogr_fid": 6993, "name": "Puerto Peñasco", "name_ar": "", "name_hi": "" }, "geometry": { "type": "Point", "coordinates": [ -12639224.034942869096994, 3673296.088174171745777 ] } },

--- a/msautotest/mssql/expected/wfs_mssql_maxfeatures_qs.json
+++ b/msautotest/mssql/expected/wfs_mssql_maxfeatures_qs.json
@@ -2,6 +2,7 @@
 "type": "FeatureCollection",
 "numberMatched": 6994,
 "name": "cities",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },
 "features": [
 { "type": "Feature", "properties": { "ogr_fid": 1, "name": "崇州市", "name_ar": "", "name_hi": "" }, "geometry": { "type": "Point", "coordinates": [ 11540741.500531593337655, 3584222.176282715518028 ] } },
 { "type": "Feature", "properties": { "ogr_fid": 2, "name": "江油市", "name_ar": "", "name_hi": "" }, "geometry": { "type": "Point", "coordinates": [ 11658983.416123732924461, 3734167.308027575723827 ] } }

--- a/msautotest/mssql/include/bdry_counpy2_mssql.map
+++ b/msautotest/mssql/include/bdry_counpy2_mssql.map
@@ -1,6 +1,4 @@
-  CONNECTIONTYPE PLUGIN
-  PLUGIN "C:\projects\mapserver\build\Release\msplugin_mssql2008.dll"
-  CONNECTION "SERVER=(local)\SQL2017;DATABASE=msautotest;uid=sa;pwd=Password12!;"
+  INCLUDE 'include/mssql_connection.map'
   DATA "ogr_geometry from (select * from bdry_counpy2) as foo USING UNIQUE ogr_fid USING SRID=26915"
   STATUS OFF
   TYPE POLYGON

--- a/msautotest/mssql/include/mssql_connection.map
+++ b/msautotest/mssql/include/mssql_connection.map
@@ -1,4 +1,4 @@
   CONNECTIONTYPE PLUGIN
   PLUGIN "C:\projects\mapserver\build\Release\msplugin_mssql2008.dll"
-  CONNECTION "SERVER=(local)\SQL2017;DATABASE=msautotest;uid=sa;pwd=Password12!;"
+  CONNECTION "SERVER=(local)\SQL2019;DATABASE=msautotest;uid=sa;pwd=Password12!;"
   STATUS OFF

--- a/msautotest/pymod/mstestlib.py
+++ b/msautotest/pymod/mstestlib.py
@@ -160,6 +160,11 @@ def demime_file( filename ):
     if version_info >= (3,0,0):
         data = str(data, 'iso-8859-1')
 
+    # remove any double CR which will crash the following code
+    extension = os.path.splitext(filename)[1]
+    if extension in (".xml", ".json"):
+        data = data.replace("\r\r", "\r")
+
     offset = -1
     for i in range(len(data)-1):
         if data[i] == '\r' and data[i+1] == '\n' and data[i+2] == '\r' and data[i+3] == '\n':


### PR DESCRIPTION
Updates the Appveyor Windows CI to use Visual Studio 2019, and the new MSVC 2019 release-1928-x64-dev buildkit from https://www.gisinternals.com/sdk.php

- update to MSSQL 2019
- updated to use PROJ7
- test JSON results now all updated to include `"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::3857" } },` - likey due to updates to the GDAL dependencies in the buildkit

One strange issue is that for JSON responses, there is now an additional `\r` in the break between the header output and the rest of the JSON response body. This broke the Python code to DEMIME a response in `mapserver\msautotest\pymod\mstestlib.py`
A fix was added to the Python code to get this working again, but an upstream fix would be better. 

![image](https://user-images.githubusercontent.com/490840/124436354-26b1d480-dd76-11eb-9670-0c0ad6d0b19d.png)
