### PR TITLE
spatialindex for sqlite sources in filter

### DIFF
--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -2253,66 +2253,6 @@ static int msOGRFileWhichShapes(layerObj *layer, rectObj rect, msOGRFileInfo *ps
 
         bool bSpatialiteOrGPKGAddOrderByFID = false;
 
-        if( psInfo->dialect && psInfo->pszMainTableName != NULL && 
-            ( (EQUAL(psInfo->dialect, "Spatialite") && psInfo->bHasSpatialIndex)
-              || EQUAL(psInfo->dialect, "GPKG") ) &&
-            bIsValidRect )
-        {
-            select = msStringConcatenate(select, " JOIN ");
-
-            char szSpatialIndexName[256];
-            snprintf( szSpatialIndexName, sizeof(szSpatialIndexName),
-                        "%s_%s_%s",
-                        EQUAL(psInfo->dialect, "Spatialite") ? "idx" : "rtree",
-                        psInfo->pszSpatialFilterTableName,
-                        psInfo->pszSpatialFilterGeometryColumn );
-            char* pszEscapedSpatialIndexName = msLayerEscapePropertyName(
-                                            layer, szSpatialIndexName);
-            select = msStringConcatenate(select, "\"");
-            select = msStringConcatenate(select, pszEscapedSpatialIndexName);
-            msFree(pszEscapedSpatialIndexName);
-            select = msStringConcatenate(select, "\" ms_spat_idx ON \"");
-            char* pszEscapedMainTableName = msLayerEscapePropertyName(
-                                            layer, psInfo->pszMainTableName);
-            select = msStringConcatenate(select, pszEscapedMainTableName);
-            msFree(pszEscapedMainTableName);
-            select = msStringConcatenate(select, "\".");
-            if( psInfo->pszRowId )
-            {
-                char* pszEscapedRowId = msLayerEscapePropertyName(
-                                                    layer, psInfo->pszRowId);
-                select = msStringConcatenate(select, "\"");
-                select = msStringConcatenate(select, pszEscapedRowId);
-                select = msStringConcatenate(select, "\"");
-                msFree(pszEscapedRowId);
-            }
-            else
-                select = msStringConcatenate(select, "ROWID");
-            if( EQUAL(psInfo->dialect, "Spatialite") )
-                select = msStringConcatenate(select, " = ms_spat_idx.pkid AND ");
-            else
-                select = msStringConcatenate(select, " = ms_spat_idx.id AND ");
-
-            char szCond[256];
-            if( EQUAL(psInfo->dialect, "Spatialite") )
-            {
-                snprintf(szCond, sizeof(szCond),
-                        "ms_spat_idx.xmin <= %.15g AND ms_spat_idx.xmax >= %.15g AND "
-                        "ms_spat_idx.ymin <= %.15g AND ms_spat_idx.ymax >= %.15g",
-                        rect.maxx, rect.minx, rect.maxy, rect.miny);
-            }
-            else
-            {
-                snprintf(szCond, sizeof(szCond),
-                        "ms_spat_idx.minx <= %.15g AND ms_spat_idx.maxx >= %.15g AND "
-                        "ms_spat_idx.miny <= %.15g AND ms_spat_idx.maxy >= %.15g",
-                        rect.maxx, rect.minx, rect.maxy, rect.miny);
-            }
-            select = msStringConcatenate(select, szCond);
-
-            bSpatialiteOrGPKGAddOrderByFID = true;
-        }
-
         const char *sql = layer->filter.native_string;
         if (psInfo->dialect && sql && *sql != '\0' &&
             (EQUAL(psInfo->dialect, "Spatialite") ||
@@ -2353,6 +2293,68 @@ static int msOGRFileWhichShapes(layerObj *layer, rectObj rect, msOGRFileInfo *ps
                       EQUAL(psInfo->dialect, "GPKG")) &&
                      psInfo->pszMainTableName != NULL )
             {
+
+                if( psInfo->dialect && psInfo->pszMainTableName != NULL && 
+                    ( (EQUAL(psInfo->dialect, "Spatialite") && psInfo->bHasSpatialIndex)
+                      || EQUAL(psInfo->dialect, "GPKG") ) &&
+                    bIsValidRect )
+                {
+                    char* pszEscapedMainTableName = msLayerEscapePropertyName(
+                                                    layer, psInfo->pszMainTableName);
+                    filter = msStringConcatenate(filter, "\"");
+                    filter = msStringConcatenate(filter, pszEscapedMainTableName);
+                    filter = msStringConcatenate(filter, "\".");
+                    msFree(pszEscapedMainTableName);            
+                    filter = msStringConcatenate(filter, "ROWID");
+                    
+                    filter = msStringConcatenate(filter, " IN ");
+                    filter = msStringConcatenate(filter, "(");        
+                    filter = msStringConcatenate(filter, "SELECT ");
+
+                    if( EQUAL(psInfo->dialect, "Spatialite") )
+                        filter = msStringConcatenate(filter, "ms_spat_idx.pkid");
+                    else
+                        filter = msStringConcatenate(filter, "ms_spat_idx.id");          
+
+                    filter = msStringConcatenate(filter, " FROM ");              
+
+                    char szSpatialIndexName[256];
+                    snprintf( szSpatialIndexName, sizeof(szSpatialIndexName),
+                                "%s_%s_%s",
+                                EQUAL(psInfo->dialect, "Spatialite") ? "idx" : "rtree",
+                                psInfo->pszSpatialFilterTableName,
+                                psInfo->pszSpatialFilterGeometryColumn );        
+                    char* pszEscapedSpatialIndexName = msLayerEscapePropertyName(
+                                                    layer, szSpatialIndexName);
+
+                    filter = msStringConcatenate(filter, "\"");
+                    filter = msStringConcatenate(filter, pszEscapedSpatialIndexName);
+                    msFree(pszEscapedSpatialIndexName);
+                    
+                    filter = msStringConcatenate(filter, "\" ms_spat_idx WHERE ");
+        
+                    char szCond[256];
+                    if( EQUAL(psInfo->dialect, "Spatialite") )
+                    {
+                        snprintf(szCond, sizeof(szCond),
+                                "ms_spat_idx.xmin <= %.15g AND ms_spat_idx.xmax >= %.15g AND "
+                                "ms_spat_idx.ymin <= %.15g AND ms_spat_idx.ymax >= %.15g",
+                                rect.maxx, rect.minx, rect.maxy, rect.miny);
+                    }
+                    else
+                    {
+                        snprintf(szCond, sizeof(szCond),
+                                "ms_spat_idx.minx <= %.15g AND ms_spat_idx.maxx >= %.15g AND "
+                                "ms_spat_idx.miny <= %.15g AND ms_spat_idx.maxy >= %.15g",
+                                rect.maxx, rect.minx, rect.maxy, rect.miny);
+                    }
+                    filter = msStringConcatenate(filter, szCond);
+        
+                    filter = msStringConcatenate(filter, ")");
+
+                    bSpatialiteOrGPKGAddOrderByFID = true;
+                }
+
                 const bool isGPKG = EQUAL(psInfo->dialect, "GPKG");
                 if (filter) filter = msStringConcatenate(filter, " AND");
                 const char *col = OGR_L_GetGeometryColumn(psInfo->hLayer); // which geom field??

--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -2299,6 +2299,7 @@ static int msOGRFileWhichShapes(layerObj *layer, rectObj rect, msOGRFileInfo *ps
                       || EQUAL(psInfo->dialect, "GPKG") ) &&
                     bIsValidRect )
                 {
+                    if (filter) filter = msStringConcatenate(filter, " AND ");
                     char* pszEscapedMainTableName = msLayerEscapePropertyName(
                                                     layer, psInfo->pszMainTableName);
                     filter = msStringConcatenate(filter, "\"");

--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -2293,10 +2293,8 @@ static int msOGRFileWhichShapes(layerObj *layer, rectObj rect, msOGRFileInfo *ps
                       EQUAL(psInfo->dialect, "GPKG")) &&
                      psInfo->pszMainTableName != NULL )
             {
-                if( psInfo->dialect && psInfo->pszMainTableName != NULL && 
-                    ( (EQUAL(psInfo->dialect, "Spatialite") && psInfo->bHasSpatialIndex)
-                      || EQUAL(psInfo->dialect, "GPKG") ) &&
-                    bIsValidRect )
+                if( (EQUAL(psInfo->dialect, "Spatialite") && psInfo->bHasSpatialIndex)
+                      || EQUAL(psInfo->dialect, "GPKG") )
                 {
                     if (filter) filter = msStringConcatenate(filter, " AND ");
                     char* pszEscapedMainTableName = msLayerEscapePropertyName(


### PR DESCRIPTION
## Description

(Like described in pull request [#6356](https://github.com/MapServer/MapServer/pull/6356), but now the code is also updated to include Spatialite.)

Hi, we are running a multitute of MapServer+GPKG stacks and we recently upgraded our MapServers to 7.6.3 (+ cherrypicked [#6325](https://github.com/MapServer/MapServer/issues/6325)). With this new stack we noticed significant performance degradation, request that took +/-300ms now took up to 3.3sec with SQLite datasources.

After some investigation we looked at the SQL that is being generated for the GeoPackage & Spatialite and noticed that the query used with JOIN on the rtree tables incombination with the Intersects() and the ORDER BY causes the long running queries. Removing one of those 3 makes the queries run "fast" again but with of couse degradation in the quality of the resultset. Futher investigation on the result of the QUERY PLAN for the sql revealed the use of "USE TEMP B-TREE FOR ORDER BY" (note this was also already the case with the pre 7.6.3 queries, but those didn't have the Intersect() in their query). Using a TEMP B-TREE FOR ORDER BY can lead to performance issue (at least that is how we interpret the google/stackoverflow searches 😄 ), how this can be solved is by "rewriting" the SQL. Instead of making a JOIN but using a SUBQUERY the performance is uplifted to the "old" situation, while maintaining the Intersect() and ORDER BY.

So the JOIN that was build in the 'select' is moved to the 'filter' for Geopackage and Spatialite.

## Notes

Like stated we are running multiple MapServer+GPKG stackes where the GPKG vary in size from quite small (couple of megabytes)) to large (multple gigabytes). We noticed this with GPKG of around 100 megabytes.

## Query

### old sql

```sql
SELECT "pb_multipolygon"."identificatie" AS "identificatie", "pb_multipolygon"."domein" AS "domein", "pb_multipolygon"."grondslag_code" AS "grondslag_code", "pb_multipolygon"."grondslag_omschrijving" AS "grondslag_omschrijving", "pb_multipolygon"."type_beperkingsgebied" AS "type_beperkingsgebied", "pb_multipolygon"."datum_in_werking" AS "datum_in_werking", "pb_multipolygon"."datum_beeindiging" AS "datum_beeindiging", "pb_multipolygon"."datum_aanbieden_bestuursorgaan" AS "datum_aanbieden_bestuursorgaan","pb_multipolygon"."tijdstip_inschrijven_kadaster" AS "tijdstip_inschrijven_kadaster", "pb_multipolygon"."gebaseerd_op_stuk" AS "gebaseerd_op_stuk", "pb_multipolygon"."datum_kenbaarheid" AS "datum_kenbaarheid", "pb_multipolygon"."meerdere_brondocumenten_ingeschreven" AS "meerdere_brondocumenten_ingeschreven", "pb_multipolygon"."statutaire_naam_bestuursorgaan" AS "statutaire_naam_bestuursorgaan", "pb_multipolygon"."organisatie_informatie_nummer_oin" AS "organisatie_informatie_nummer_oin", "pb_multipolygon"."puuid" AS "puuid", "pb_multipolygon"."fuuid" AS "fuuid", "pb_multipolygon"."geom" AS "geom"
  FROM "pb_multipolygon" JOIN "rtree_pb_multipolygon_geom" ms_spat_idx ON "pb_multipolygon".ROWID = ms_spat_idx.id AND ms_spat_idx.minx <= 280000.00001 AND ms_spat_idx.maxx >= -25000.00001 AND ms_spat_idx.miny <= 860000.00001 AND ms_spat_idx.maxy >= 249999.99999 
 WHERE Intersects(GeomFromGPB("geom"), BuildMbr(-25000.000010,249999.999990,280000.000010,860000.000010))
 ORDER BY "pb_multipolygon".ROWID 
 LIMIT 2 OFFSET 0 
```

### new sql

```sql
SELECT "pb_multipolygon"."identificatie" AS "identificatie", "pb_multipolygon"."domein" AS "domein", "pb_multipolygon"."grondslag_code" AS "grondslag_code", "pb_multipolygon"."grondslag_omschrijving" AS "grondslag_omschrijving", "pb_multipolygon"."type_beperkingsgebied" AS "type_beperkingsgebied", "pb_multipolygon"."datum_in_werking" AS "datum_in_werking", "pb_multipolygon"."datum_beeindiging" AS "datum_beeindiging", "pb_multipolygon"."datum_aanbieden_bestuursorgaan" AS "datum_aanbieden_bestuursorgaan","pb_multipolygon"."tijdstip_inschrijven_kadaster" AS "tijdstip_inschrijven_kadaster", "pb_multipolygon"."gebaseerd_op_stuk" AS "gebaseerd_op_stuk", "pb_multipolygon"."datum_kenbaarheid" AS "datum_kenbaarheid", "pb_multipolygon"."meerdere_brondocumenten_ingeschreven" AS "meerdere_brondocumenten_ingeschreven", "pb_multipolygon"."statutaire_naam_bestuursorgaan" AS "statutaire_naam_bestuursorgaan", "pb_multipolygon"."organisatie_informatie_nummer_oin" AS "organisatie_informatie_nummer_oin", "pb_multipolygon"."puuid" AS "puuid", "pb_multipolygon"."fuuid" AS "fuuid", "pb_multipolygon"."geom" AS "geom" 
  FROM "pb_multipolygon"
 WHERE "pb_multipolygon".ROWID IN (SELECT ms_spat_idx.id 
                                     FROM "rtree_pb_multipolygon_geom" ms_spat_idx 
                                    WHERE ms_spat_idx.minx <= 280000.00001 AND ms_spat_idx.maxx >= -25000.00001 AND ms_spat_idx.miny <= 860000.00001 AND ms_spat_idx.maxy >= 249999.99999 )
   AND Intersects(GeomFromGPB("geom"), BuildMbr(-25000.000010,249999.999990,280000.000010,860000.000010))  
 ORDER BY "pb_multipolygon".ROWID 
 LIMIT 2 OFFSET 0
```

## QUERY PLAN

The EXPLAIN QUERY PLAN now looks like this.

### old plan

| id | parent | notused | detail |
| --- | --- | --- | --- |
| 8 | 0 | 0 | SCAN TABLE rtree_pb_multipolygon_geom AS ms_spat_idx VIRTUAL TABLE INDEX 2:B0D1B2D3 |
| 16 | 0 | 0 | SEARCH TABLE pb_multipolygon USING INTEGER PRIMARY KEY (rowid=?) |
| 55 | 0 | 0 | USE TEMP B-TREE FOR ORDER BY |

### new plan

| id | parent | notused | detail |
| --- | --- | --- | --- |
| 7 | 0 | 0 |  SEARCH TABLE pb_multipolygon USING INTEGER PRIMARY KEY (rowid=?) |
| 11 | 0 | 0 | LIST SUBQUERY 1 |
| 13 | 11 | 0 | SCAN TABLE rtree_pb_multipolygon_geom AS ms_spat_idx VIRTUAL TABLE INDEX 2:B0D1B2D3 |

## Tests

Some quick test regarding the old en new QUERY performance

### Geopackage old

```sh
time ogrinfo wkpb-multipolygon.gpkg -sql "SELECT COUNT(*) FROM "pb_multipolygon" JOIN "rtree_pb_multipolygon_geom" ms_spat_idx ON "pb_multipolygon".ROWID = ms_spat_idx.id AND ms_spat_idx.minx <= 280000.00001 AND ms_spat_idx.maxx >= -25000.00001 AND ms_spat_idx.miny <= 860000.00001 AND ms_spat_idx.maxy >= 249999.99999   WHERE Intersects(GeomFromGPB("geom"), BuildMbr(-25000.000010,249999.999990,280000.000010,860000.000010))  ORDER BY "pb_multipolygon".ROWID LIMIT 2 OFFSET 0"
```

```sh
real    0m1.152s
user    0m0.971s
sys     0m0.181s
```

### Geopackage new

```sh
time ogrinfo wkpb.gpkg -sql "SELECT COUNT(*) FROM "pb_multipolygon"  WHERE "pb_multipolygon".ROWID IN (SELECT ms_spat_idx.id  FROM "rtree_pb_multipolygon_geom" ms_spat_idx  WHERE ms_spat_idx.minx <= 280000.00001 AND ms_spat_idx.maxx >= -25000.00001 AND ms_spat_idx.miny <= 860000.00001 AND ms_spat_idx.maxy >= 249999.99999 ) AND Intersects(GeomFromGPB("geom"), BuildMbr(-25000.000010,249999.999990,280000.000010,860000.000010))    ORDER BY "pb_multipolygon".ROWID LIMIT 2 OFFSET 0"
```

```sh
real    0m0.571s
user    0m0.550s
sys     0m0.020s
```

### Spatialite old

```sh
time ogrinfo wkpb-multipolygon.sqlite -sql "SELECT COUNT(*) FROM "pb_multipolygon" JOIN "idx_pb_multipolygon_geom" ms_spat_idx ON "pb_multipolygon".ROWID = ms_spat_idx.pkid AND ms_spat_idx.xmin <= 280000.00001 AND ms_spat_idx.xmax >= -25000.00001 AND ms_spat_idx.ymin <= 860000.00001 AND ms_spat_idx.ymax >= 249999.99999 WHERE  Intersects("geom", BuildMbr(-25000.000010,249999.999990,280000.000010,860000.000010)) ORDER BY "pb_multipolygon".ROWID LIMIT 2 OFFSET 0"
```

```sh
real    0m0.896s
user    0m0.716s
sys     0m0.180s
```

### Spatialite new

```sh
time ogrinfo wkpb-multipolygon.sqlite -sql "SELECT COUNT(*) FROM "pb_multipolygon" WHERE "pb_multipolygon".ROWID IN (SELECT ms_spat_idx.pkid FROM "idx_pb_multipolygon_geom" ms_spat_idx WHERE ms_spat_idx.xmin <= 280000.00001 AND ms_spat_idx.xmax >= -25000.00001 AND ms_spat_idx.ymin <= 860000.00001 AND ms_spat_idx.ymax >= 249999.99999) AND Intersects("geom", BuildMbr(-25000.000010,249999.999990,280000.000010,860000.000010)) ORDER BY "pb_multipolygon".ROWID LIMIT 2 OFFSET 0"
```

```sh
real    0m0.417s
user    0m0.388s
sys     0m0.030s
```

## This pull request

Like stated we replaced the JOIN with a SUBQUERY, when a GeoPackage or Spatialite is used, by moving the rtree part in the code from the 'select' to the 'filter'.

## Resources

Used resources for the tests:

* <https://s3.delivery.pdok.nl/test/wkpb/wkpb-sqlite.map>
* <https://s3.delivery.pdok.nl/test/wkpb/wkpb-multipolygon.gpkg>
* <https://s3.delivery.pdok.nl/test/wkpb/wkpb-multipolygon.sqlite>
