### PR TITLE
WFS: avoid accidental modification of element type in DescribeFeature…

### DIFF
--- a/mapwfs.cpp
+++ b/mapwfs.cpp
@@ -1501,9 +1501,8 @@ this request. Check wfs/ows_enable_request settings.", "msWFSDescribeFeatureType
           else
             layer_namespace_prefix = user_namespace_prefix;
 
-          /* value = msOWSLookupMetadata(&(lp->metadata), "OFG", "layername"); */
           encoded_name = msEncodeHTMLEntities( lp->name );
-          value = msOWSLookupMetadata(&(lp->metadata), "OFG", "layer_type");
+          value = msOWSLookupMetadata(&(lp->metadata), "F", "layer_type");
           if(value) {
             encoded_type = msEncodeHTMLEntities(value);
           } else {


### PR DESCRIPTION
…Type response,

when using gml_types=auto with a layer that has a field 'layer' (fixes #5902)

Restrict the ``layer_type`` item to the ``wfs`` namespace (added
initially per c09434154f01b0ba05b5bebaf3154cf0d16de7a6)

Analysis and suggested fix by:
Co-authored-by: Seth G <sethg@geographika.co.uk>