### PR TITLE
Fix python module installation with alternative root/prefix

### DIFF
--- a/mapscript/python/CMakeLists.txt
+++ b/mapscript/python/CMakeLists.txt
@@ -123,7 +123,7 @@ install(
     endif()
 
     execute_process(
-      COMMAND ${Python_EXECUTABLE} setup.py install \${Python_ROOT} \${Python_PREFIX}
+      COMMAND ${Python_EXECUTABLE} setup.py install \${PYTHON_ROOT} \${PYTHON_PREFIX}
       WORKING_DIRECTORY ${OUTPUT_FOLDER}
     )
   "


### PR DESCRIPTION
Trying to package/build mapserver head before 8.0, it failed for me during install/fake, as it tried writing to the system dirs in usr/local while CMAKE_INSTALL_PREFIX and DESTDIR were properly defined - and ignored.

i think this was an oversight in the large commit done in dd310d211. Not 100% confident about all cases, but this fixes the 'install to alternate dir' problem for me. Cmake expert feedback welcome :)