### PR TITLE
MVT generation: fix writing of point/multipoint geometries

### DIFF
--- a/mapmvt.c
+++ b/mapmvt.c
@@ -318,7 +318,7 @@ int mvtWriteShape( layerObj *layer, shapeObj *shape, VectorTile__Tile__Layer *mv
 
   if(layer->type == MS_LAYER_POINT) {
     int idx=0, lastx=0, lasty=0;
-    mvt_feature->geometry[idx++] = COMMAND(MOVETO, mvt_feature->n_geometry-1);
+    mvt_feature->geometry[idx++] = COMMAND(MOVETO, (mvt_feature->n_geometry-1) / 2);
     for(i=0;i<shape->numlines;i++) {
       for(j=0;j<shape->line[i].numpoints;j++) {
         mvt_feature->geometry[idx++] = PARAMETER(MS_NINT(shape->line[i].point[j].x)-lastx);


### PR DESCRIPTION
The number associated with the MOVETO command should be the number of
coordinate *pairs*. We wrote twice that number. This caused for
example the OGR MVT driver to reject such geometries.