### PR TITLE
update SECURITY.md for supported versions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,12 +10,16 @@ submissions, when describing the vulnerability (see https://mapserver.org/develo
 
 ## Supported Versions
 
-The MapServer PSC (Project Steering Committee) will release patches for security vulnerabilities for the following versions:
+The MapServer PSC (Project Steering Committee) will release patches for security vulnerabilities 
+for the last release branch of the two most recent major releases.  For example, 
+once 8.0 is released, then only 8.0.x and 7.6.x will be patched.
+
+Currently, the following versions are supported:
 
 | Version | Supported          |
 | ------- | ------------------ |
 | 7.6.x   | :white_check_mark: |
 | 7.4.x   | :white_check_mark: |
-| 7.2.x   | :white_check_mark: |
-| 7.0.x   | :white_check_mark: |
+| 7.2.x   | :x:                |
+| 7.0.x   | :x:                |
 | < 7.0   | :x:                |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,15 +11,16 @@ submissions, when describing the vulnerability (see https://mapserver.org/develo
 ## Supported Versions
 
 The MapServer PSC (Project Steering Committee) will release patches for security vulnerabilities 
-for the last release branch of the two most recent major releases.  For example, 
-once 8.0 is released, then only 8.0.x and 7.6.x will be patched.
+for the last release branch of the two most recent release series (such as 8.x, 7.x. 6.x, etc.)  For example, 
+once 8.0 is released, then only 8.0.x and 7.6.x will be supported/patched.
 
 Currently, the following versions are supported:
 
 | Version | Supported          |
 | ------- | ------------------ |
 | 7.6.x   | :white_check_mark: |
-| 7.4.x   | :white_check_mark: |
+| 7.4.x   | :x:                |
 | 7.2.x   | :x:                |
 | 7.0.x   | :x:                |
-| < 7.0   | :x:                |
+| 6.4.x   | :white_check_mark: |
+| < 6.4   | :x:                |


### PR DESCRIPTION
- according to the mapserver-dev thread (https://lists.osgeo.org/pipermail/mapserver-dev/2021-July/016572.html) and the recent discussion in the PSC meeting on 2021-08-26 (https://github.com/MapServer/MapServer/wiki/PSC-Meeting-2021-08-26)
- this was the suggestion by Daniel, Even, Jeff (all with the same idea, yet different wording).
- the wording that seems to be the most clear was provided by Daniel, and is used in this pull request