### PR TITLE
Define rect for a dwithin filter condition

### DIFF
--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -3434,12 +3434,13 @@ static int  msOGRExtractTopSpatialFilter( msOGRFileInfo *info,
                                           pSpatialFilterNode);
   }
 
-  if( (expr->m_nToken == MS_TOKEN_COMPARISON_INTERSECTS ||
+  if( (((expr->m_nToken == MS_TOKEN_COMPARISON_INTERSECTS ||
       expr->m_nToken == MS_TOKEN_COMPARISON_OVERLAPS ||
       expr->m_nToken == MS_TOKEN_COMPARISON_CROSSES ||
       expr->m_nToken == MS_TOKEN_COMPARISON_WITHIN ||
       expr->m_nToken == MS_TOKEN_COMPARISON_CONTAINS) &&
-      expr->m_aoChildren.size() == 2 &&
+      expr->m_aoChildren.size() == 2) ||
+      (expr->m_nToken == MS_TOKEN_COMPARISON_DWITHIN && expr->m_aoChildren.size() == 3)) &&
       expr->m_aoChildren[1]->m_nToken == MS_TOKEN_LITERAL_SHAPE )
   {
         if( info->rect_is_defined )
@@ -3454,7 +3455,11 @@ static int  msOGRExtractTopSpatialFilter( msOGRFileInfo *info,
         OGRErr e = OGR_G_CreateFromWkt(&wkt, NULL, &hSpatialFilter);
         if (e == OGRERR_NONE) {
             OGREnvelope env;
-            OGR_G_GetEnvelope(hSpatialFilter, &env);
+            if( expr->m_nToken == MS_TOKEN_COMPARISON_DWITHIN ) {
+                OGR_G_GetEnvelope(OGR_G_Buffer(hSpatialFilter, expr->m_aoChildren[2]->m_dfVal, 30), &env);
+            } else {
+                OGR_G_GetEnvelope(hSpatialFilter, &env);
+            }
             info->rect.minx = env.MinX;
             info->rect.miny = env.MinY;
             info->rect.maxx = env.MaxX;


### PR DESCRIPTION
We observed that our WFS (MapServer + GeoPackage utilizing the OGR backend) is a lot slower when the DWithin spatial operator is used in a filter condition. Although the spatial index in the GeoPackage could be used to accelerate this specific operator it was not.

This PR adds a bounding box to the request passed down to OGR when the DWithin spatial operator is used. For the bounding box we use the envelope of the geometry with the distance used as the buffer. Below is an example of the filter:

`<fes:Filter>
<fes:DWithin><fes:ValueReference>begrenzingPerceel</fes:ValueReference>
<gml:Point gml:id="geo.1" srsName="EPSG:28992"><gml:pos dimension="2">257050.19722083333 470137.85737916664</gml:pos></gml:Point><fes:Distance units="m">12.287004477416515</fes:Distance></fes:DWithin>
</fes:Filter>`