### PR TITLE
Invalid geometry from buildmbr when a point is used a base for the rect

### DIFF
--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -2383,9 +2383,14 @@ static int msOGRFileWhichShapes(layerObj *layer, rectObj rect, msOGRFileInfo *ps
                 filter = msStringConcatenate(filter, "\"");
                 if( isGPKG )
                     filter = msStringConcatenate(filter, ")");
-                filter = msStringConcatenate(filter, ", BuildMbr(");
                 char *points = (char *)msSmallMalloc(30*2*5);
-                snprintf(points, 30*4, "%lf,%lf,%lf,%lf", rect.minx, rect.miny, rect.maxx, rect.maxy);
+                if( rect.minx == rect.maxx && rect.miny == rect.maxy ) {
+                  filter = msStringConcatenate(filter, ",  ST_GeomFromText(");
+                  snprintf(points, 30*4, "'POINT(%lf %lf)'", rect.minx, rect.miny);
+                } else {
+                  filter = msStringConcatenate(filter, ", BuildMbr(");
+                  snprintf(points, 30*4, "%lf,%lf,%lf,%lf", rect.minx, rect.miny, rect.maxx, rect.maxy);
+                }
                 filter = msStringConcatenate(filter, points);
                 msFree(points);
                 filter = msStringConcatenate(filter, "))");

--- a/msautotest/wxs/expected/wfs_ogr_gpkg_filter_intersects_point.xml
+++ b/msautotest/wxs/expected/wfs_ogr_gpkg_filter_intersects_point.xml
@@ -1,0 +1,34 @@
+Content-Type: text/xml; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd 
+                       http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=test_6325&amp;OUTPUTFORMAT=XMLSCHEMA">
+      <gml:boundedBy>
+      	<gml:Box srsName="EPSG:4326">
+      		<gml:coordinates>0.000000,0.000000 1.000000,1.000000</gml:coordinates>
+      	</gml:Box>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:test_6325 fid="test_6325.1">
+        <gml:boundedBy>
+        	<gml:Box srsName="EPSG:4326">
+        		<gml:coordinates>0.000000,0.000000 1.000000,1.000000</gml:coordinates>
+        	</gml:Box>
+        </gml:boundedBy>
+        <ms:msGeometry>
+        <gml:LineString srsName="EPSG:4326">
+          <gml:coordinates>1.000000,0.000000 0.000000,1.000000 </gml:coordinates>
+        </gml:LineString>
+        </ms:msGeometry>
+        <ms:id>1</ms:id>
+        <ms:WKT>LINESTRING(1 0,0 1)</ms:WKT>
+      </ms:test_6325>
+    </gml:featureMember>
+</wfs:FeatureCollection>
+

--- a/msautotest/wxs/wfs_ogr_gpkg.map
+++ b/msautotest/wxs/wfs_ogr_gpkg.map
@@ -11,6 +11,9 @@
 #
 # RUN_PARMS: wfs_ogr_gpkg_issue_6325.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=test_6325&BBOX=0.75,0.75,9,9&COUNT=1" > [RESULT_DEVERSION]
 #
+# Filter using intersect with point
+# RUN_PARMS: wfs_ogr_gpkg_filter_intersects_point.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=test_6325&FILTER=<Filter><Intersects><PropertyName>msGeometry</PropertyName><gml:Point srsName=%22EPSG:4326%22><gml:coordinates>1.000000,0.000000</gml:coordinates></gml:Point></Intersects></Filter>" > [RESULT]
+#
 
 MAP
 
@@ -95,6 +98,7 @@ LAYER
     "wfs_featureid"     "id"
     "gml_include_items" "all"
     "gml_types"         "auto"
+    "wfs_use_default_extent_for_getfeature" "no"
   END
   TYPE LINE
   STATUS ON


### PR DESCRIPTION
When `wfs_use_default_extent_for_getfeature` is set to `off` on a layer, the geometry in an intersect filter is used to calculate the `rect`. This `rect` is the input for the `BuildMbr` spatialite function. When the geometry in the intersect filter is a POINT, the POLYGON resulting from `BuildMbr` is invalid, because all vertices in the POLYGON are the same. This POLYGON is used in the `Intersect` spatialite function. It seems to depend on the version of spatialite whether or not this is an issue. Some versions of spatialite seem to handle an intersect with an invalid POLYGON fine and some never result in a match. This PR tries to make this more robust and checks if the `rect` is a POINT and in this case uses a POINT as the input for the intersect, in all other cases the `BuildMbr` is used to create a POLYGON.