### PR TITLE
Pin cryptography version

### DIFF
--- a/.github/workflows/start.sh
+++ b/.github/workflows/start.sh
@@ -29,7 +29,6 @@ eval "$(pyenv virtualenv-init -)"
 ln -s /usr/bin/python3 /usr/bin/python
 ln -s /usr/bin/pip3 /usr/bin/pip
 
-export CRYPTOGRAPHY_DONT_BUILD_RUST=1 # to avoid issue when building Cryptography python module
 pip install --upgrade pip
 
 # Install recent cmake

--- a/.github/workflows/start.sh
+++ b/.github/workflows/start.sh
@@ -29,6 +29,7 @@ eval "$(pyenv virtualenv-init -)"
 ln -s /usr/bin/python3 /usr/bin/python
 ln -s /usr/bin/pip3 /usr/bin/pip
 
+export CRYPTOGRAPHY_DONT_BUILD_RUST=1 # to avoid issue when building Cryptography python module
 pip install --upgrade pip
 
 # Install recent cmake

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -9,7 +9,7 @@ sudo apt-get remove --purge postgresql* libpq-dev libpq5 || /bin/true
 
 sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
 sudo apt-get update
-sudo apt-get install -y --allow-unauthenticated protobuf-c-compiler libprotobuf-c0-dev bison flex libfribidi-dev cmake librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal-dev libproj-dev libxml2-dev libexempi-dev lcov lftp postgis libharfbuzz-dev gdal-bin ccache curl postgresql-server-dev-10 postgresql-10-postgis-3 postgresql-10-postgis-3-scripts swig g++
+sudo apt-get install -y --allow-unauthenticated protobuf-c-compiler libprotobuf-c0-dev bison flex libfribidi-dev cmake librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal-dev libproj-dev libxml2-dev libexempi-dev lcov lftp postgis libharfbuzz-dev gdal-bin ccache curl postgresql-server-dev-10 postgresql-10-postgis-3 postgresql-10-postgis-3-scripts swig g++ ca-certificates
 # following are already installed on Travis CI
 #sudo apt-get install --allow-unauthenticated php-dev python-dev python3-dev
 sudo apt-get install -y --allow-unauthenticated libmono-system-drawing4.0-cil mono-mcs

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -27,6 +27,7 @@ pyenv global $PYTHON_VERSION
 pyenv which pip
 pyenv which python
 
+pip install cryptography==3.4.6 # avoid requiring rust compiler for the cryptography dependency
 pip install cpp-coveralls pyflakes lxml
 pip install -r msautotest/requirements.txt
 


### PR DESCRIPTION
The previous fix `ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1` only works up to 3.4 so pin the version to avoid `error: can't find Rust compiler` (e.g. [here](https://app.travis-ci.com/github/MapServer/MapServer/jobs/541345228#L1801)

See https://stackoverflow.com/questions/66118337/how-to-get-rid-of-cryptography-build-error and also https://github.com/pyca/cryptography/issues/5771
