### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,8 @@ Note: _MapServer 7.0.0 was released on 2015-07-24._
 
 ## Version Numbering: Explained
 
+version x.y.z means:
+
 **x**
 - Major release series number.
 - Major releases indicate substantial changes to the software and 


### PR DESCRIPTION
Added time limit constraint (three years) relative to the current release series (currently 7). Since 7 is six years-old that means it's the only supported series so I adjusted the supported version table accordingly. We might also want to add a description of version numbering meaning, so for **x.y.z** we'd have:

**x**
Major release series number. Major releases indicate substantial changes to the software and backwards compatibility is not guaranteed across series. Current release series is 7.

**y**
Minor release series number. Minor releases indicate smaller, functional additions or improvements to the software and should be generally backwards compatible within a major release series. Users should be able to confidently upgrade from one minor release to another within the same release series, so from 7.4.x to 7.6.x.

**z**
Point release series number. Point releases indicate maintenance releases - usually a combination of bug and security fixes and perhaps small feature additions. Backwards compatibility should be preserved and users should be able to confidently upgrade between point releases within the same release series, so from 7.6.4 to 7.6.5.



--Steve