### PR TITLE
Properly handle datetime fields

### DIFF
--- a/mapgml.c
+++ b/mapgml.c
@@ -1021,10 +1021,26 @@ static void msGMLWriteItem(FILE *stream, gmlItemObj *item,
                        tm.tm_hour, tm.tm_min, tm.tm_sec,
                        pszEndTag);
           else
-              snprintf(encoded_value, 256, "%s%04d-%02d-%02dT%02d:%02d:%02dZ%s",
-                       pszStartTag,
-                       tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-                       tm.tm_hour, tm.tm_min, tm.tm_sec, pszEndTag);
+          {
+              // Detected date time already formatted as YYYY-MM-DDTHH:mm:SS+ab:cd
+              // because msParseTime() can't handle time zones.
+              if( strlen(value) == 4+1+2+1+2+1+2+1+2+1+2+1+2+1+2 &&
+                  value[4] == '-' && value[7] == '-' && value[10] == 'T' &&
+                  value[13] == ':' && value[16] == ':' &&
+                  (value[19] == '+' || value[19] == '-') &&
+                  value[22] == ':' )
+              {
+                  snprintf(encoded_value, 256, "%s%s%s",
+                           pszStartTag, value, pszEndTag);
+              }
+              else
+              {
+                  snprintf(encoded_value, 256, "%s%04d-%02d-%02dT%02d:%02d:%02dZ%s",
+                           pszStartTag,
+                           tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+                           tm.tm_hour, tm.tm_min, tm.tm_sec, pszEndTag);
+              }
+          }
       }
   }
 

--- a/msautotest/wxs/data/withnullvalues.csv
+++ b/msautotest/wxs/data/withnullvalues.csv
@@ -1,3 +1,3 @@
-id,intvalue,floatvalue,WKT
-1,2,3.4,"POINT(10 30)"
-2,,,"POINT(10 30)"
+id,intvalue,floatvalue,date,time,datetime,WKT
+1,2,3.4,"2021/12/15","12:41:00","2021/12/15 12:41:00+0115","POINT(10 30)"
+2,,,,,"2021/12/15 11:41:12Z","POINT(10 30)"

--- a/msautotest/wxs/data/withnullvalues.csvt
+++ b/msautotest/wxs/data/withnullvalues.csvt
@@ -1,1 +1,1 @@
-Integer,Integer,Real,String
+Integer,Integer,Real,Date,Time,DateTime,String

--- a/msautotest/wxs/expected/wfsogr10_datetime.xml
+++ b/msautotest/wxs/expected/wfsogr10_datetime.xml
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd 
+                       http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=withnullvalues&amp;OUTPUTFORMAT=XMLSCHEMA">
+      <gml:boundedBy>
+      	<gml:Box srsName="EPSG:27700">
+      		<gml:coordinates>10.000000,30.000000 10.000000,30.000000</gml:coordinates>
+      	</gml:Box>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:withnullvalues fid="withnullvalues.1">
+        <gml:boundedBy>
+        	<gml:Box srsName="EPSG:27700">
+        		<gml:coordinates>10.000000,30.000000 10.000000,30.000000</gml:coordinates>
+        	</gml:Box>
+        </gml:boundedBy>
+        <ms:msGeometry>
+        <gml:Point srsName="EPSG:27700">
+          <gml:coordinates>10.000000,30.000000</gml:coordinates>
+        </gml:Point>
+        </ms:msGeometry>
+        <ms:id>1</ms:id>
+        <ms:intvalue>2</ms:intvalue>
+        <ms:floatvalue>3.4</ms:floatvalue>
+        <ms:date>2021-12-15</ms:date>
+        <ms:time>12:41:00Z</ms:time>
+        <ms:datetime>2021-12-15T12:41:00+01:15</ms:datetime>
+        <ms:WKT>POINT(10 30)</ms:WKT>
+      </ms:withnullvalues>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:withnullvalues fid="withnullvalues.2">
+        <gml:boundedBy>
+        	<gml:Box srsName="EPSG:27700">
+        		<gml:coordinates>10.000000,30.000000 10.000000,30.000000</gml:coordinates>
+        	</gml:Box>
+        </gml:boundedBy>
+        <ms:msGeometry>
+        <gml:Point srsName="EPSG:27700">
+          <gml:coordinates>10.000000,30.000000</gml:coordinates>
+        </gml:Point>
+        </ms:msGeometry>
+        <ms:id>2</ms:id>
+        <ms:intvalue></ms:intvalue>
+        <ms:floatvalue></ms:floatvalue>
+        <ms:date></ms:date>
+        <ms:time></ms:time>
+        <ms:datetime>2021-12-15T11:41:12Z</ms:datetime>
+        <ms:WKT>POINT(10 30)</ms:WKT>
+      </ms:withnullvalues>
+    </gml:featureMember>
+</wfs:FeatureCollection>
+

--- a/msautotest/wxs/expected/wfsogr10_nullnumeric.csv
+++ b/msautotest/wxs/expected/wfsogr10_nullnumeric.csv
@@ -1,0 +1,3 @@
+WKT,id,intvalue,floatvalue,date,time,datetime,WKT
+"POINT (10 30)","1","2",3.4,2021/12/15,12:41:00,2021/12/15 12:41:00+0115,POINT(10 30)
+"POINT (10 30)","2",,,,,2021/12/15 11:41:12+00,POINT(10 30)

--- a/msautotest/wxs/expected/wfsogr10_nullnumeric.xml
+++ b/msautotest/wxs/expected/wfsogr10_nullnumeric.xml
@@ -1,6 +1,0 @@
-Content-Disposition: attachment; filename=result.csv
-Content-Type: text/csv
-
-WKT,id,intvalue,floatvalue,WKT
-"POINT (10 30)","1","2",3.4,POINT(10 30)
-"POINT (10 30)","2",,,POINT(10 30)

--- a/msautotest/wxs/wfs_ogr.map
+++ b/msautotest/wxs/wfs_ogr.map
@@ -44,8 +44,11 @@
 # Test fetching from two layers with a filter.
 # RUN_PARMS: wfsogr10_twolayer.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=popplace,road&OUTPUTFORMAT=MultiMIDMIF&FILTER=(<Filter><BBOX><PropertyName>POINT</PropertyName><Box+srsName=%22EPSG:4326%22><coordinates>-65.86,44.56+-65.76,44.68</coordinates></Box></BBOX></Filter>)(<Filter><BBOX><PropertyName>POINT</PropertyName><Box+srsName=%22EPSG:4326%22><coordinates>-65.86,44.56+-65.76,44.68</coordinates></Box></BBOX></Filter>)" > [RESULT]
 #
-# Test writing features with null numeric fields (#4633)
-# RUN_PARMS: wfsogr10_nullnumeric.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=withnullvalues&OUTPUTFORMAT=CSV" > [RESULT]
+# Test writing features with null numeric fields (#4633) and datetime (#6434)
+# RUN_PARMS: wfsogr10_nullnumeric.csv [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=withnullvalues&OUTPUTFORMAT=CSV" > [RESULT_DEMIME]
+#
+# Test writing features with null numeric fields (#4633) and datetime (#6434)
+# RUN_PARMS: wfsogr10_datetime.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=withnullvalues" > [RESULT_DEMIME]
 
 # WFS 1.1
 #


### PR DESCRIPTION
We encountered incorrect date/time values in WFS GetFeature responses of our (GeoPackage backed) MapServer instances. Only the year was rendered correctly. All other parts where zeroed out. 

While investigating the issue it was discovered that the code that handles date/time values (`msParseTime` in `maptime.c`, called by `msGMLWriteItem` in `mapgml.c`) expects the provided date/time strings to be formatted in ISO 8601. Unfortunately the OGR backend (`mapogr.cpp`) provides date/time strings in a different format (yyyy/mm/dd hh:mm:ss) and `msParseTime` only succeeds in parsing the year part of the date/time string and silently ignores the rest. Resulting in malformed GML output.

It was discovered that the `msOGRGetValues` function treats every field as a string field, leaving it up to OGR how to convert any non-string field into a string. After changing the code to use `OGR_F_GetFieldAsDateTime` for date/time fields and properly format it as an ISO date/time string the problem was resolved.

I don't know if this is actually the right approach to fix this issue. But if I understand the OGR API documentation correctly, `OGR_F_GetFieldAsString` is only supposed to be called for real, integer and string fields.