### PR TITLE
[msautotest] correct WMS endpoint

### DIFF
--- a/msautotest/gdal/wmsclient.map
+++ b/msautotest/gdal/wmsclient.map
@@ -27,7 +27,7 @@ LAYER
   STATUS DEFAULT
   DEBUG 1
   #CONNECTION "http://mstest.tiles.osgeo.org/wms/vmap0?"
-  CONNECTION "https://demo.mapserver.org/cgi-bin/mapserv?map=/mapserver/apps/msautotest/world/world.map&"
+  CONNECTION "https://demo.mapserver.org/cgi-bin/msautotest?"
   CONNECTIONTYPE WMS
   METADATA
     "wms_srs"             "EPSG:4326"

--- a/msautotest/gdal/wmsclient_3543.map
+++ b/msautotest/gdal/wmsclient_3543.map
@@ -22,7 +22,7 @@ END
 
 LAYER
   NAME "X"
-  CONNECTION "https://demo.mapserver.org/cgi-bin/mapserv?map=/mapserver/apps/msautotest/world/world.map&"
+  CONNECTION "https://demo.mapserver.org/cgi-bin/msautotest?"
   CONNECTIONTYPE WMS
   TYPE RASTER
   STATUS DEFAULT

--- a/msautotest/renderers/wmsclient.map
+++ b/msautotest/renderers/wmsclient.map
@@ -27,7 +27,7 @@ LAYER
   TYPE RASTER
   STATUS DEFAULT
   #CONNECTION "http://mstest.tiles.osgeo.org/wms/vmap0?"
-  CONNECTION "https://demo.mapserver.org/cgi-bin/mapserv?map=/mapserver/apps/msautotest/world/world.map&"
+  CONNECTION "https://demo.mapserver.org/cgi-bin/msautotest?"
   CONNECTIONTYPE WMS
   METADATA
     "wms_srs"             "EPSG:4326"


### PR DESCRIPTION
- cleaner url, and this endpoint is the one that is constantly monitored for uptime