### PR TITLE
OGR layers: fix memory leak with DWithin filter

### DIFF
--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -3449,7 +3449,9 @@ static int  msOGRExtractTopSpatialFilter( msOGRFileInfo *info,
         if (e == OGRERR_NONE) {
             OGREnvelope env;
             if( expr->m_nToken == MS_TOKEN_COMPARISON_DWITHIN ) {
-                OGR_G_GetEnvelope(OGR_G_Buffer(hSpatialFilter, expr->m_aoChildren[2]->m_dfVal, 30), &env);
+                OGRGeometryH hBuffer = OGR_G_Buffer(hSpatialFilter, expr->m_aoChildren[2]->m_dfVal, 30);
+                OGR_G_GetEnvelope(hBuffer ? hBuffer : hSpatialFilter, &env);
+                OGR_G_DestroyGeometry(hBuffer);
             } else {
                 OGR_G_GetEnvelope(hSpatialFilter, &env);
             }


### PR DESCRIPTION
Fixes leak introduced recently in master per 736baa6d55634efa027baffb08401ce38ef92caa

Fixes following failures with the Travis ASAN job:
FAILED run_test.py::test[wfs_filter_ogr_wfs_filter_dwithin_xml] - AssertionEr...
FAILED run_test.py::test[wfs_filter_ogr_wfs_filter_dwithin_units_xml] - Asser...
FAILED run_test.py::test[wfs_ogr_native_sql_wfs_ogr_native_sql_32_xml] - Asse...