### PR TITLE
Fix Appveyor builds by ignoring Python 3.10

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,7 @@ init:
 
 build_script:
   - ps: Write-Host "Build tags - $env:APPVEYOR_REPO_TAG $env:APPVEYOR_REPO_TAG_NAME"
+  - rename C:\Python310 Python310_Ignore
   - set "BUILD_FOLDER=%APPVEYOR_BUILD_FOLDER:\=/%"
   - if "%platform%" == "x64" SET VS_FULL=%VS_VERSION%
   - if "%platform%" == "x64" SET VS_ARCH=x64


### PR DESCRIPTION
Recent builds have been failing on Appveyor as even though the `Python_ROOT_DIR` hint is specified for Python 2.7, Python 3.10 is being found by CMake (e.g. [here](https://ci.appveyor.com/project/MapServer/mapserver/builds/41884531/job/h529h23wjw1abl9n#L210)). 

The simple workaround is to rename the Python 3.10 directory (it looks like some change may be required in MapScript to get Python working with 3.10 as some tests are failing). 

I'm not sure what the correct fix here is. There is discussion on user set variables being ignored by CMake at https://gitlab.kitware.com/cmake/cmake/-/issues/19492#note_597909

As Python2 and Python3 are being built [find_package (Python..](https://github.com/MapServer/MapServer/blob/main/mapscript/python/CMakeLists.txt#L4) is used rather than `find_package (Python2..` and `find_package (Python3..`

It looks like Python 3.10 is always picked up. Interestingly, this works fine with CMake 3.12 (3.22 is used by Appveyor). Maybe as 3.10 is not defined in https://github.com/Kitware/CMake/blob/master/Modules/FindPython/Support.cmake in the older version. 

