### PR TITLE
Reconfigure pyenv to fix broken Travis builds

### DIFF
--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -16,6 +16,9 @@ sudo apt-get install -y --allow-unauthenticated libmono-system-drawing4.0-cil mo
 sudo apt-get install -y --allow-unauthenticated libperl-dev
 sudo apt-get install -y --allow-unauthenticated openjdk-8-jdk
 
+eval "$(pyenv init --path)"
+eval "$(pyenv init -)"
+
 # list installed and available Python versions
 # pyenv versions
 # echo $(pyenv root)

--- a/ci/travis/script.sh
+++ b/ci/travis/script.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -eu
 
+eval "$(pyenv init --path)"
+eval "$(pyenv init -)"
+
 #if [ "$BUILD_NAME" = "PHP_7.2_WITH_ASAN" ]; then
 #    export CC="ccache clang"
 #    export CXX="ccache clang++"


### PR DESCRIPTION
Attempt to fix errors e.g. at https://app.travis-ci.com/github/MapServer/MapServer/jobs/552166460#L1598

`ERROR: Could not find a version that satisfies the requirement cryptography==3.4.6`

This is turning out to be more complicated than hoped. 
Details so far:

- it looks like something has changed with `pyenv` on Travis. There were no commits to code between the last time Travis passed and when it first start failing (8th of Devember 2021) - see https://app.travis-ci.com/github/MapServer/MapServer/builds
- the issue is that calling `pyenv global $PYTHON_VERSION` in `before_install.sh` no longer seems to point `python` and `pip` to the desired Python version. `.travis.yml` sets `$PYTHON_VERSION` to 3.6, 3.7 and then 3.8. 
- python and pip then fall back to using the system Python which is Python 2.7 (hence the `ERROR: No matching distribution found for cryptography==3.4.6` error) and deprecation warnings about Python 2.7
- Calling `pyenv exec pip --version` shows the correct version, but `pip --version` does not (nor does `python --version`)
- Putting `pyenv exec` in fron of every call to `pip` or `python` on Travis works..
- The most relevant change in pyenv looks like it could be https://github.com/pyenv/pyenv/issues/1959
- Setting `eval "$(pyenv init --path)"` and `eval "$(pyenv init -)"` seems to work for all python and pip calls within `before_install.sh`, but not later calls