### PR TITLE
Fix compilation warning in shptreevis

### DIFF
--- a/shptreevis.c
+++ b/shptreevis.c
@@ -47,7 +47,7 @@
 char* AddFileSuffix ( const char * Filename, const char * Suffix )
 {
   char  *pszFullname, *pszBasename;
-  int i;
+  size_t i;
 
   /* -------------------------------------------------------------------- */
   /*  Compute the base (layer) name.  If there is any extension     */


### PR DESCRIPTION
Use correct size to avoid the following:

` warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data`