### PR TITLE
[Backport 7.6] msProjectRect(): fix PROJ >= 6 when datum shift is involved (fixes #6478)

### DIFF
--- a/mapproject.c
+++ b/mapproject.c
@@ -2059,7 +2059,26 @@ int msProjectRect(projectionObj *in, projectionObj *out, rectObj *rect)
    *  parameter in order to disable dateline wrapping.
    */ 
   else {
-    if(out) {
+    int apply_over = MS_TRUE;
+#if PROJ_VERSION_MAJOR >= 6 && PROJ_VERSION_MAJOR < 9
+    // Workaround PROJ [6,9[ bug (fixed per https://github.com/OSGeo/PROJ/pull/3055)
+    // that prevents datum shifts from being applied when +over is added to +init=epsg:XXXX
+    // This is far from being bullet proof but it should work for most common use cases
+    if(in && in->proj)
+    {
+        if( in->numargs == 1 && EQUAL(in->args[0], "init=epsg:4326") &&
+            rect->minx >= -180 && rect->maxx <= 180 )
+        {
+            apply_over = MS_FALSE;
+        }
+        else if( in->numargs == 1 && EQUAL(in->args[0], "init=epsg:3857") &&
+                 rect->minx >= -20037508.3427892 && rect->maxx <= 20037508.3427892 )
+        {
+            apply_over = MS_FALSE;
+        }
+    }
+#endif
+    if(out && apply_over) {
       bFreeOutOver = MS_TRUE;
       msInitProjection(&out_over);
       msCopyProjectionExtended(&out_over,out,&over,1);
@@ -2071,7 +2090,7 @@ int msProjectRect(projectionObj *in, projectionObj *out, rectObj *rect)
     } else {
       outp = out;
     }
-    if(in) {
+    if(in && apply_over) {
       bFreeInOver = MS_TRUE;
       msInitProjection(&in_over);
       msCopyProjectionExtended(&in_over,in,&over,1);

--- a/msautotest/mspython/test_bug_check.py
+++ b/msautotest/mspython/test_bug_check.py
@@ -145,3 +145,25 @@ def test_reprojection_lines_from_polar_stereographic_to_webmercator():
     assert point12.x == pytest.approx(-20037508.34, abs=1e-2)
     assert point21.x == pytest.approx(20037508.34, abs=1e-2)
     assert point22.x == pytest.approx(19926188.85, abs=1e-2)
+
+
+###############################################################################
+# Test reprojection of rectangle involving a datum shift (#6478)
+
+def test_reprojection_rect_and_datum_shift():
+
+    webmercator = mapscript.projectionObj("init=epsg:3857")
+    epsg_28992 = mapscript.projectionObj("init=epsg:28992") # "Amersfoort / RD New"
+
+    point = mapscript.pointObj(545287, 6867556)
+    point.project(webmercator, epsg_28992)
+    if point.x == pytest.approx(121685, abs=2):
+        # Builds of PROJ >= 6 and < 8 with -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H
+        # use pj_transform() but it doesn't work well with datum shift
+        # This is a non-nominal configuration used in some CI confs when use a
+        # PROJ 7 build to test PROJ.4 API and PROJ 6 API.
+        pytest.skip('This test cannot run with PROJ [6,8[ in builds with ACCEPT_USE_OF_DEPRECATED_PROJ_API_H')
+
+    rect = mapscript.rectObj(545287, 6867556, 545689, 6868025)
+    assert rect.project(webmercator, epsg_28992) == 0
+    assert rect.minx == pytest.approx(121711, abs=2)


### PR DESCRIPTION
Backport of https://github.com/MapServer/MapServer/pull/6479