### PR TITLE
handle PROJ6 invalid coordinates error in MapServer log

### DIFF
--- a/mapproject.c
+++ b/mapproject.c
@@ -363,7 +363,11 @@ static void msProjErrorLogger(void * user_data,
                              int level, const char * message)
 {
     (void)user_data;
-    if( level == PJ_LOG_ERROR && msGetGlobalDebugLevel() >= MS_DEBUGLEVEL_VV)
+#if PROJ_VERSION_MAJOR >= 6    
+    if( level == PJ_LOG_ERROR && msGetGlobalDebugLevel() >= MS_DEBUGLEVEL_VV )
+#else
+    if( level == PJ_LOG_ERROR )
+#endif
     {
         msDebug( "PROJ: Error: %s\n", message );
     }

--- a/mapproject.c
+++ b/mapproject.c
@@ -363,11 +363,11 @@ static void msProjErrorLogger(void * user_data,
                              int level, const char * message)
 {
     (void)user_data;
-    if( level == PJ_LOG_ERROR )
+    if( level == PJ_LOG_ERROR && msGetGlobalDebugLevel() >= MS_DEBUGLEVEL_VV)
     {
         msDebug( "PROJ: Error: %s\n", message );
     }
-    else if( level == PJ_LOG_DEBUG )
+    else if( level == PJ_LOG_DEBUG)
     {
         msDebug( "PROJ: Debug: %s\n", message );
     }

--- a/mapproject.c
+++ b/mapproject.c
@@ -367,7 +367,7 @@ static void msProjErrorLogger(void * user_data,
     {
         msDebug( "PROJ: Error: %s\n", message );
     }
-    else if( level == PJ_LOG_DEBUG)
+    else if( level == PJ_LOG_DEBUG )
     {
         msDebug( "PROJ: Debug: %s\n", message );
     }


### PR DESCRIPTION
# Background

- since the PROJ 6.0.0 release, PROJ is more strict and rejects invalid coordinates (see https://github.com/OSGeo/PROJ/blob/master/src/fwd.cpp#L56 )
- since the PROJ 8.0.0 release, PROJ changed the default log level to be `PJ_LOG_ERROR` (from `PJ_LOG_NONE`) (see https://github.com/OSGeo/PROJ/blob/master/src/ctx.cpp#L90 )

# Problem

- I'm one of the unlucky ones it seems, because all (yes all) of my mapfiles cause hundreds or thousands of PROJ error messages filling up my MapServer log, for each map draw
- imagine your MapServer log is something like:
   ```
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
    PROJ: Error: utm: Invalid latitude
   *repeated in thousands*
   ```
- PROJ is not wrong here, the issue is that MapServer (main) is not catching this error and handling it through one of the MapServer Debug Levels

# Sample mapfile and data
- small mapfile and data (one parcels layer, in UTM Zone 15 displayed in EPSG:4326 at global extents), taken from the GeoMoose demo data (I discussed this with the GeoMoose PSC as well, and they were able to reproduce the issue on Ubuntu with PROJ8): https://gatewaygeomatics.com/dl/ticket-proj6-error-debug-level.zip

# Proposed Solution
- this pull request handles the issue by only reporting the error when the user sets the MapServer debug level to be "very verbose"