### PR TITLE
Add the msSaveConfig function to the MapServer C-API

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -5891,7 +5891,7 @@ int msSaveMap(mapObj *map, char *filename)
   return(0);
 }
 
-static void writeConfig(FILE *stream, int indent, configObj *config)
+static void writeConfig(FILE *stream, int indent, const configObj *config)
 {
   writeBlockBegin(stream, indent, "CONFIG");
   writeHashTable(stream, indent, "ENV", &(config->env));

--- a/mapfile.c
+++ b/mapfile.c
@@ -5916,7 +5916,7 @@ int msSaveConfig(const configObj *config, const char *filename)
 
   stream = fopen(filename, "w");
   if(!stream) {
-    msSetError(MS_IOERR, "(%s)", "msSaveConfigMap()", filename);
+    msSetError(MS_IOERR, "(%s)", "msSaveConfig()", filename);
     return(-1);
   }
 

--- a/mapfile.c
+++ b/mapfile.c
@@ -5899,7 +5899,7 @@ static void writeConfig(FILE *stream, int indent, configObj *config)
   writeBlockEnd(stream, indent, "CONFIG");
 }
 
-int msSaveConfig(const configObj *config, const char *filename)
+int msSaveConfig(configObj *config, const char *filename)
 {
   FILE *stream;
 

--- a/mapfile.c
+++ b/mapfile.c
@@ -5891,7 +5891,7 @@ int msSaveMap(mapObj *map, char *filename)
   return(0);
 }
 
-static void writeConfig(FILE *stream, int indent, const configObj *config)
+static void writeConfig(FILE *stream, int indent, configObj *config)
 {
   writeBlockBegin(stream, indent, "CONFIG");
   writeHashTable(stream, indent, "ENV", &(config->env));

--- a/mapfile.c
+++ b/mapfile.c
@@ -5914,7 +5914,7 @@ int msSaveConfig(configObj *config, char *filename)
     return(-1);
   }
 
-  stream = fopen(msBuildPath(szPath,"/", filename), "w");
+  stream = fopen(filename, "w");
   if(!stream) {
     msSetError(MS_IOERR, "(%s)", "msSaveConfigMap()", filename);
     return(-1);

--- a/mapfile.c
+++ b/mapfile.c
@@ -5899,7 +5899,7 @@ static void writeConfig(FILE *stream, int indent, configObj *config)
   writeBlockEnd(stream, indent, "CONFIG");
 }
 
-int msSaveConfig(configObj *config, char *filename)
+int msSaveConfig(const configObj *config, const char *filename)
 {
   FILE *stream;
   char szPath[MS_MAXPATHLEN];

--- a/mapfile.c
+++ b/mapfile.c
@@ -5891,6 +5891,41 @@ int msSaveMap(mapObj *map, char *filename)
   return(0);
 }
 
+static void writeConfig(FILE *stream, int indent, configObj *config)
+{
+  writeBlockBegin(stream, indent, "CONFIG");
+  writeHashTable(stream, indent, "ENV", &(config->env));
+  writeHashTable(stream, indent, "MAPS", &(config->maps));
+  writeBlockEnd(stream, indent, "CONFIG");
+}
+
+int msSaveConfig(configObj *config, char *filename)
+{
+  FILE *stream;
+  char szPath[MS_MAXPATHLEN];
+
+  if(!config) {
+    msSetError(MS_MISCERR, "Config is undefined.", "msSaveConfigMap()");
+    return(-1);
+  }
+
+  if(!filename) {
+    msSetError(MS_MISCERR, "Filename is undefined.", "msSaveConfigMap()");
+    return(-1);
+  }
+
+  stream = fopen(msBuildPath(szPath,"/", filename), "w");
+  if(!stream) {
+    msSetError(MS_IOERR, "(%s)", "msSaveConfigMap()", filename);
+    return(-1);
+  }
+
+  writeConfig(stream,0,config);
+  fclose(stream);
+
+  return(0);
+}
+
 static int loadMapInternal(mapObj *map)
 {
   int foundMapToken=MS_FALSE;

--- a/mapfile.c
+++ b/mapfile.c
@@ -5902,7 +5902,6 @@ static void writeConfig(FILE *stream, int indent, const configObj *config)
 int msSaveConfig(const configObj *config, const char *filename)
 {
   FILE *stream;
-  char szPath[MS_MAXPATHLEN];
 
   if(!config) {
     msSetError(MS_MISCERR, "Config is undefined.", "msSaveConfigMap()");

--- a/mapserver.h
+++ b/mapserver.h
@@ -2209,7 +2209,7 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   MS_DLL_EXPORT mapObj  *msLoadMap(const char *filename, const char *new_mappath, const configObj *config);
   MS_DLL_EXPORT int msTransformXmlMapfile(const char *stylesheet, const char *xmlMapfile, FILE *tmpfile);
   MS_DLL_EXPORT int msSaveMap(mapObj *map, char *filename);
-  MS_DLL_EXPORT int msSaveConfig(const configObj *map, const char *filename);
+  MS_DLL_EXPORT int msSaveConfig(configObj *map, const char *filename);
   MS_DLL_EXPORT void msFreeCharArray(char **array, int num_items);
   MS_DLL_EXPORT int msUpdateScalebarFromString(scalebarObj *scalebar, char *string);
   MS_DLL_EXPORT int msUpdateQueryMapFromString(queryMapObj *querymap, char *string);

--- a/mapserver.h
+++ b/mapserver.h
@@ -2209,7 +2209,7 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   MS_DLL_EXPORT mapObj  *msLoadMap(const char *filename, const char *new_mappath, const configObj *config);
   MS_DLL_EXPORT int msTransformXmlMapfile(const char *stylesheet, const char *xmlMapfile, FILE *tmpfile);
   MS_DLL_EXPORT int msSaveMap(mapObj *map, char *filename);
-  MS_DLL_EXPORT int msSaveConfig(configObj *map, char *filename);
+  MS_DLL_EXPORT int msSaveConfig(const configObj *map, const char *filename);
   MS_DLL_EXPORT void msFreeCharArray(char **array, int num_items);
   MS_DLL_EXPORT int msUpdateScalebarFromString(scalebarObj *scalebar, char *string);
   MS_DLL_EXPORT int msUpdateQueryMapFromString(queryMapObj *querymap, char *string);

--- a/mapserver.h
+++ b/mapserver.h
@@ -2209,6 +2209,7 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   MS_DLL_EXPORT mapObj  *msLoadMap(const char *filename, const char *new_mappath, const configObj *config);
   MS_DLL_EXPORT int msTransformXmlMapfile(const char *stylesheet, const char *xmlMapfile, FILE *tmpfile);
   MS_DLL_EXPORT int msSaveMap(mapObj *map, char *filename);
+  MS_DLL_EXPORT int msSaveConfig(configObj *map, char *filename);
   MS_DLL_EXPORT void msFreeCharArray(char **array, int num_items);
   MS_DLL_EXPORT int msUpdateScalebarFromString(scalebarObj *scalebar, char *string);
   MS_DLL_EXPORT int msUpdateQueryMapFromString(queryMapObj *querymap, char *string);


### PR DESCRIPTION
During the [2022 Joint OGC – OSGeo – ASF Code Sprint](https://github.com/opengeospatial/developer-events/wiki/2022-Joint-OGC-%E2%80%93-OSGeo-%E2%80%93-ASF-Code-Sprint), we tried to use the current main branch of the MapSever repo from the ZOO-Kernel to publish results as OGC API - Features.

By doing so, we realized that it may be useful to get access to a `msSaveConfig` function that is prototyped here from the MapServer C-API. This function would simply permit to save the config file.

From our understanding, with the current main branch, when you publish a new OGC API - Features you should have a new item in the `maps` `hashTable` to get the URL `http://SERVER/MYMAP/ogcapi/` to work properly. 

The function currently provided does not take into account saving the plugins, it should be added.

As we did not know what to pass for `abs_path` for `msBuildPath`, we decided to use the root dir, which is probably a wrong choice.

In case there is another way already available for saving the config file then, please let us know and forgive us for this PR. 