### PR TITLE
add MS_MAP_BAD_PATTERN to sample conf

### DIFF
--- a/etc/mapserver-sample.conf
+++ b/etc/mapserver-sample.conf
@@ -12,6 +12,7 @@ CONFIG
     #
     # MS_MAP_NO_PATH "1"
     MS_MAP_PATTERN "^/opt/mapserver" ## required
+    # MS_MAP_BAD_PATTERN "[/\\]{2}|[/\\]?\\.+[/\\]|,"
 
     #
     # Global Log/Debug Setup
@@ -27,7 +28,7 @@ CONFIG
     #
     # Proj Library
     #
-    # PROJ_LIB ""
+    # PROJ_LIB "/usr/local/share/proj"
 
     #
     # Request Control


### PR DESCRIPTION
- add to mapserver-sample.conf :
  - MS_MAP_BAD_PATTERN
  - default PROJ_LIB value