### PR TITLE
Python MapScript updates to work with Python 3.10

### DIFF
--- a/mapscript/python/pyextend.i
+++ b/mapscript/python/pyextend.i
@@ -13,6 +13,10 @@
  *
  *****************************************************************************/
 
+// required for Python 3.10+ - see https://bugs.python.org/issue40943
+%begin %{
+#define PY_SSIZE_T_CLEAN
+%}
 
 /* fromstring: Factory for mapfile objects */
 
@@ -378,7 +382,7 @@ def fromstring(data, mappath=None):
 
 %#if PY_MAJOR_VERSION >= 3
             // https://docs.python.org/3/c-api/arg.html
-            noerr = PyObject_CallMethod(file, "write", "y#", imgbuffer, imgsize);
+            noerr = PyObject_CallMethod(file, "write", "y#", imgbuffer, (Py_ssize_t)imgsize);
 %#else
             // https://docs.python.org/2/c-api/arg.html
             noerr = PyObject_CallMethod(file, "write", "s#", imgbuffer, imgsize);

--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -558,7 +558,7 @@
       intarray *order;
       order = new_intarray(self->numlayers);
       for (i=0; i<self->numlayers; i++) {
-          # see http://www.swig.org/Doc4.0/SWIGDocumentation.html#Library_carrays for %array_class interface
+          // see http://www.swig.org/Doc4.0/SWIGDocumentation.html#Library_carrays for %array_class interface
           order.setitem(i, self->layerorder[i]);
       }
       return order;

--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -557,12 +557,10 @@
       int i;
       intarray *order;
       order = new_intarray(self->numlayers);
-      for (i=0; i<self->numlayers; i++)
-          #if (defined(SWIGPYTHON) || defined(SWIGRUBY) ) && SWIG_VERSION >= 0x010328 /* 1.3.28 */
-          intarray___setitem__(order, i, self->layerorder[i]);
-          #else
-          intarray_setitem(order, i, self->layerorder[i]);
-          #endif
+      for (i=0; i<self->numlayers; i++) {
+          # see http://www.swig.org/Doc4.0/SWIGDocumentation.html#Library_carrays for %array_class interface
+          order.setitem(i, self->layerorder[i]);
+      }
       return order;
     }
 

--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -559,7 +559,7 @@
       order = new_intarray(self->numlayers);
       for (i=0; i<self->numlayers; i++) {
           // see http://www.swig.org/Doc4.0/SWIGDocumentation.html#Library_carrays for %array_class interface
-          order.setitem(i, self->layerorder[i]);
+          order[i] = self->layerorder[i];
       }
       return order;
     }


### PR DESCRIPTION
This update fixes issues when building MapScript for Python 3,10 with (as yet unreleased) SWIG 4.1.0. 

- Calls to `PyObject_CallMethod` (used by MapScript for writing images) need to use `Py_ssize_t` rather than `int` for specifying size (to allow output > 2GB). See https://bugs.python.org/issue40943
- SWIG methods all now have `__SWIG` appended to them which broke `intarray___setitem__(order, i, self->layerorder[i]);` - I'm unsure why the method name rather than array access was used in the first place. 