### PR TITLE
Ensure all layer debug statements are output

### DIFF
--- a/mapraster.c
+++ b/mapraster.c
@@ -617,7 +617,7 @@ void* msDrawRasterLayerLowOpenDataset(mapObj *map, layerObj *layer,
 
   msGDALInitialize();
 
-  if(layer->debug == MS_TRUE)
+  if(layer->debug)
     msDebug( "msDrawRasterLayerLow(%s): Filename is: %s\n", layer->name, filename);
 
   if( strncmp(filename, "<VRTDataset", strlen("<VRTDataset")) == 0 )
@@ -629,7 +629,7 @@ void* msDrawRasterLayerLowOpenDataset(mapObj *map, layerObj *layer,
     msDrawRasterBuildRasterPath(map, layer, filename, szPath);
     pszPath = szPath;
   }
-  if(layer->debug == MS_TRUE)
+  if(layer->debug)
     msDebug("msDrawRasterLayerLow(%s): Path is: %s\n", layer->name, pszPath);
 
     /*
@@ -705,26 +705,26 @@ void msDrawRasterLayerLowCloseDataset(layerObj *layer, void* hDS)
 int msDrawRasterLayerLowCheckIfMustDraw(mapObj *map, layerObj *layer)
 {
   if(!layer->data && !layer->tileindex && !(layer->connectiontype==MS_KERNELDENSITY || layer->connectiontype==MS_IDW)) {
-    if(layer->debug == MS_TRUE)
+    if(layer->debug)
       msDebug( "msDrawRasterLayerLow(%s): layer data and tileindex NULL ... doing nothing.", layer->name );
     return(0);
   }
 
   if((layer->status != MS_ON) && (layer->status != MS_DEFAULT)) {
-    if(layer->debug == MS_TRUE)
+    if(layer->debug)
       msDebug( "msDrawRasterLayerLow(%s): not status ON or DEFAULT, doing nothing.", layer->name );
     return(0);
   }
 
   if(map->scaledenom > 0) {
     if((layer->maxscaledenom > 0) && (map->scaledenom > layer->maxscaledenom)) {
-      if(layer->debug == MS_TRUE)
+      if(layer->debug)
         msDebug( "msDrawRasterLayerLow(%s): skipping, map scale %.2g > MAXSCALEDENOM=%g\n",
                  layer->name, map->scaledenom, layer->maxscaledenom );
       return(0);
     }
     if((layer->minscaledenom > 0) && (map->scaledenom <= layer->minscaledenom)) {
-      if(layer->debug == MS_TRUE)
+      if(layer->debug)
         msDebug( "msDrawRasterLayerLow(%s): skipping, map scale %.2g < MINSCALEDENOM=%g\n",
                  layer->name, map->scaledenom, layer->minscaledenom );
       return(0);
@@ -733,13 +733,13 @@ int msDrawRasterLayerLowCheckIfMustDraw(mapObj *map, layerObj *layer)
 
   if(layer->maxscaledenom <= 0 && layer->minscaledenom <= 0) {
     if((layer->maxgeowidth > 0) && ((map->extent.maxx - map->extent.minx) > layer->maxgeowidth)) {
-      if(layer->debug == MS_TRUE)
+      if(layer->debug)
         msDebug( "msDrawRasterLayerLow(%s): skipping, map width %.2g > MAXSCALEDENOM=%g\n", layer->name,
                  (map->extent.maxx - map->extent.minx), layer->maxgeowidth );
       return(0);
     }
     if((layer->mingeowidth > 0) && ((map->extent.maxx - map->extent.minx) < layer->mingeowidth)) {
-      if(layer->debug == MS_TRUE)
+      if(layer->debug)
         msDebug( "msDrawRasterLayerLow(%s): skipping, map width %.2g < MINSCALEDENOM=%g\n", layer->name,
                  (map->extent.maxx - map->extent.minx), layer->mingeowidth );
       return(0);

--- a/mapuvraster.c
+++ b/mapuvraster.c
@@ -717,7 +717,7 @@ int msUVRASTERLayerWhichShapes(layerObj *layer, rectObj rect, int isQuery)
     msDebug("msUVRASTERLayerWhichShapes(): width: %d, height: %d, cellsize: %g\n",
             width, height, map_tmp->cellsize);
 
-  if (layer->debug == 5)
+  if (layer->debug == MS_DEBUGLEVEL_VVV)
     msDebug("msUVRASTERLayerWhichShapes(): extent: %g %g %g %g\n",
             map_tmp->extent.minx, map_tmp->extent.miny,
             map_tmp->extent.maxx, map_tmp->extent.maxy);
@@ -726,7 +726,7 @@ int msUVRASTERLayerWhichShapes(layerObj *layer, rectObj rect, int isQuery)
      geotransform, used by the resampling*/
    msMapSetSize(map_tmp, width, height);
 
-  if (layer->debug == 5)
+  if (layer->debug == MS_DEBUGLEVEL_VVV)
     msDebug("msUVRASTERLayerWhichShapes(): geotransform: %g %g %g %g %g %g\n",
             map_tmp->gt.geotransform[0], map_tmp->gt.geotransform[1],
             map_tmp->gt.geotransform[2], map_tmp->gt.geotransform[3],
@@ -864,7 +864,7 @@ int msUVRASTERLayerGetShape(layerObj *layer, shapeObj *shape, resultObj *record)
                        uvlinfo->extent.minx, uvlinfo->extent.maxx, MS_FALSE);
   point.y = Pix2Georef(y, 0, uvlinfo->height-1,
                        uvlinfo->extent.miny, uvlinfo->extent.maxy, MS_TRUE);
-  if (layer->debug == 5)
+  if (layer->debug == MS_DEBUGLEVEL_VVV)
     msDebug("msUVRASTERLayerWhichShapes(): shapeindex: %ld, x: %g, y: %g\n",
             shapeindex, point.x, point.y);
 


### PR DESCRIPTION
There are a few instances of `if(layer->debug == MS_TRUE)` statements. Layers that use the following syntax don't get these debug statements:

```
LAYER
    DEBUG 5 # any value apart from 1/ON/TRUE are ignored by the above statements
```    

Also includes a couple of updates changing the hardcoded 5 to use `MS_DEBUGLEVEL_VVV` as used throughout the rest of the codebase. 
