### PR TITLE
handle CMake warning for include of dlfcn.h / CMAKE_REQUIRED_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required (VERSION 3.0)
 project (MapServer)
 
 if (${CMAKE_VERSION} GREATER "3.11")
-    cmake_policy(SET CMP0075 OLD) # related to dlfcn.h
+    cmake_policy(SET CMP0075 NEW) # related to dlfcn.h
 endif()
 if (${CMAKE_VERSION} GREATER "3.13")
     cmake_policy(SET CMP0078 OLD) # related to UseSWIG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required (VERSION 3.0)
 
 project (MapServer)
 
+if (${CMAKE_VERSION} GREATER "3.11")
+    cmake_policy(SET CMP0075 OLD) # related to dlfcn.h
+endif()
 if (${CMAKE_VERSION} GREATER "3.13")
     cmake_policy(SET CMP0078 OLD) # related to UseSWIG
 endif()


### PR DESCRIPTION
- handle CMake warning during include of `dlfcn.h`
```
-- Looking for dlfcn.h
CMake Warning (dev) at /usr/local/share/cmake-3.23/Modules/CheckIncludeFile.cmake:82 (message):
  Policy CMP0075 is not set: Include file check macros honor
  CMAKE_REQUIRED_LIBRARIES.  Run "cmake --help-policy CMP0075" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  CMAKE_REQUIRED_LIBRARIES is set to:

    m

  For compatibility with CMake 3.11 and below this check is ignoring it.
Call Stack (most recent call first):
  CMakeLists.txt:133 (check_include_file)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Looking for dlfcn.h - found
```