### PR TITLE
WIP: handle CMake UseSWIG warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,10 @@ cmake_minimum_required (VERSION 3.0)
 project (MapServer)
 
 if (${CMAKE_VERSION} GREATER "3.13")
-	cmake_policy(SET CMP0078 NEW) # related to UseSWIG
+    cmake_policy(SET CMP0078 NEW) # related to UseSWIG
 endif()
 if (${CMAKE_VERSION} GREATER "3.14")
-	cmake_policy(SET CMP0086 NEW) # related to UseSWIG
+    cmake_policy(SET CMP0086 NEW) # related to UseSWIG
 endif()
 
 if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,10 @@ cmake_minimum_required (VERSION 3.0)
 project (MapServer)
 
 if (${CMAKE_VERSION} GREATER "3.13")
-    cmake_policy(SET CMP0078 OLD) # related to UseSWIG
+	cmake_policy(SET CMP0078 NEW) # related to UseSWIG
 endif()
 if (${CMAKE_VERSION} GREATER "3.14")
-    cmake_policy(SET CMP0086 OLD) # related to UseSWIG
+	cmake_policy(SET CMP0086 NEW) # related to UseSWIG
 endif()
 
 if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")


### PR DESCRIPTION
- handles 2 CMake warnings:
```
CMake Deprecation Warning at CMakeLists.txt:6 (cmake_policy):
  The OLD behavior for policy CMP0078 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
```
and
```
CMake Deprecation Warning at CMakeLists.txt:9 (cmake_policy):
  The OLD behavior for policy CMP0086 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
```