### PR TITLE
Expose reprojectionObj to MapScript

### DIFF
--- a/mapproject.c
+++ b/mapproject.c
@@ -64,16 +64,6 @@ static void msProjectionContextUnref(projectionContext* ctx);
 
 #include "proj_experimental.h"
 
-struct reprojectionObj
-{
-    projectionObj* in;
-    projectionObj* out;
-    PJ* pj;
-    int should_do_line_cutting;
-    shapeObj splitShape;
-    int bFreePJ;
-};
-
 /* Helps considerably for use cases like msautotest/wxs/wms_inspire.map */
 /* which involve a number of layers with same SRS, and a number of exposed */
 /* output SRS */
@@ -1816,8 +1806,7 @@ int msProjectRectGrid(reprojectionObj* reprojector, rectObj *rect)
 /*                       msProjectRectAsPolygon()                       */
 /************************************************************************/
 
-static int
-msProjectRectAsPolygon(reprojectionObj* reprojector, rectObj *rect)
+int msProjectRectAsPolygon(reprojectionObj* reprojector, rectObj *rect)
 {
   shapeObj polygonObj;
   lineObj  ring;

--- a/mapproject.c
+++ b/mapproject.c
@@ -540,15 +540,6 @@ void msProjectionContextUnref(projectionContext* ctx)
     (void)ctx;
 }
 
-struct reprojectionObj
-{
-    projectionObj* in;
-    projectionObj* out;
-    int should_do_line_cutting;
-    shapeObj splitShape;
-    int no_op;
-};
-
 /************************************************************************/
 /*                        msProjectCreateReprojector()                  */
 /************************************************************************/

--- a/mapproject.h
+++ b/mapproject.h
@@ -87,9 +87,22 @@ but are not directly exposed by the mapscript module
     int wellknownprojection; ///< One of ``wkp_none 0``, ``wkp_lonlat 1``, or ``wkp_gmerc 2``
   } projectionObj;
 
+  typedef struct {
+#ifdef SWIG
+    %immutable;
+#endif
+    projectionObj* in;
+    projectionObj* out;
+    PJ* pj;
+    int should_do_line_cutting;
+    shapeObj splitShape;
+    int bFreePJ;
+#ifdef SWIG
+    %mutable;
+#endif
+  } reprojectionObj;
 #ifndef SWIG
 
-  typedef struct reprojectionObj reprojectionObj;
   MS_DLL_EXPORT reprojectionObj* msProjectCreateReprojector(projectionObj* in, projectionObj* out);
   MS_DLL_EXPORT void msProjectDestroyReprojector(reprojectionObj* reprojector);
 
@@ -104,10 +117,10 @@ but are not directly exposed by the mapscript module
   MS_DLL_EXPORT int msProjectShapeEx(reprojectionObj* reprojector, shapeObj *shape);
   MS_DLL_EXPORT int msProjectLine(projectionObj *in, projectionObj *out, lineObj *line); /* legacy interface */
   MS_DLL_EXPORT int msProjectLineEx(reprojectionObj* reprojector, lineObj *line);
-  MS_DLL_EXPORT int msProjectRect(projectionObj *in, projectionObj *out, rectObj *rect);
+  MS_DLL_EXPORT int msProjectRect(projectionObj *in, projectionObj *out, rectObj *rect); /* legacy interface */
+  MS_DLL_EXPORT int msProjectRectAsPolygon(reprojectionObj* reprojector, rectObj *rect);
   MS_DLL_EXPORT int msProjectionsDiffer(projectionObj *, projectionObj *);
-  MS_DLL_EXPORT int msOGCWKT2ProjectionObj( const char *pszWKT, projectionObj *proj, int
-      debug_flag );
+  MS_DLL_EXPORT int msOGCWKT2ProjectionObj( const char *pszWKT, projectionObj *proj, int debug_flag );
   MS_DLL_EXPORT char *msProjectionObj2OGCWKT( projectionObj *proj );
 
   MS_DLL_EXPORT void msFreeProjection(projectionObj *p);

--- a/mapproject.h
+++ b/mapproject.h
@@ -88,19 +88,26 @@ but are not directly exposed by the mapscript module
   } projectionObj;
 
   typedef struct {
-#ifdef SWIG
-    %immutable;
-#endif
+#if PROJ_VERSION_MAJOR >= 6
+#ifndef SWIG
     projectionObj* in;
     projectionObj* out;
     PJ* pj;
     int should_do_line_cutting;
     shapeObj splitShape;
     int bFreePJ;
-#ifdef SWIG
-    %mutable;
+#endif
+#else
+#ifndef SWIG
+    projectionObj* in;
+    projectionObj* out;
+    int should_do_line_cutting;
+    shapeObj splitShape;
+    int no_op;
+#endif
 #endif
   } reprojectionObj;
+
 #ifndef SWIG
 
   MS_DLL_EXPORT reprojectionObj* msProjectCreateReprojector(projectionObj* in, projectionObj* out);

--- a/mapscript/mapscript.i
+++ b/mapscript/mapscript.i
@@ -305,6 +305,7 @@ typedef struct {
 %include "../swiginc/referencemap.i"
 %include "../swiginc/querymap.i"
 %include "../swiginc/config.i"
+%include "../swiginc/reprojection.i"
 
 /* 
 =============================================================================

--- a/mapscript/swiginc/line.i
+++ b/mapscript/swiginc/line.i
@@ -58,6 +58,13 @@
         return msProjectLine(projin, projout, self);
     }
 
+    /// Reproject line given a reprojection object. Transformation is done in place.
+    /// Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE`
+    int project(reprojectionObj *reprojector)
+    {
+        return msProjectLineEx(reprojector, self);
+    }
+
     /// Return reference to point at index *i*.
     pointObj *get(int i) 
     {

--- a/mapscript/swiginc/point.i
+++ b/mapscript/swiginc/point.i
@@ -60,6 +60,13 @@
         return msProjectPoint(projin, projout, self);
     }
 
+    /// Reproject point given a reprojection object. Transformation is done in place.
+    /// Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE`
+    int project(reprojectionObj *reprojector)
+    {
+        return msProjectPointEx(reprojector, self);
+    }
+
     /// Draw the point using the styles defined by the classindex class of layer and 
     /// labelled with string text. 
     /// Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE`

--- a/mapscript/swiginc/rect.i
+++ b/mapscript/swiginc/rect.i
@@ -83,6 +83,13 @@
         return msProjectRect(projin, projout, self);
     }
 
+    /// Reproject rectangle given a reprojection object. Transformation is done in place.
+    /// Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE`
+    int project(reprojectionObj *reprojector)
+    {
+        return msProjectRectAsPolygon(reprojector, self);
+    }
+
     /// Adjust the rect to fit the width and height. Returns cellsize of rect.
     double fit(int width, int height) {
         return  msAdjustExtent(self, width, height);

--- a/mapscript/swiginc/reprojection.i
+++ b/mapscript/swiginc/reprojection.i
@@ -1,0 +1,45 @@
+/* ===========================================================================
+   Project:  MapServer
+   Purpose:  SWIG interface file for mapscript reprojectionObj extensions
+   Author:   Steve Lime 
+             Even Rouault
+             
+   ===========================================================================
+   Copyright (c) 1996-2022 Regents of the University of Minnesota.
+   
+   Permission is hereby granted, free of charge, to any person obtaining a
+   copy of this software and associated documentation files (the "Software"),
+   to deal in the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+ 
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+ 
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+   THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+   ===========================================================================
+*/
+
+
+%extend reprojectionObj
+{
+    /// Create new instance of reprojectionObj. Input parameters are two projectionsObj's - in and out.
+    reprojectionObj(projectionObj *in, projectionObj *out) 
+    {
+	if(!in || !out) return NULL;
+        return msProjectCreateReprojector(in, out);
+    }
+
+    ~reprojectionObj() 
+    {
+        msProjectDestroyReprojector(self);
+        free(self);
+    }
+}

--- a/mapscript/swiginc/reprojection.i
+++ b/mapscript/swiginc/reprojection.i
@@ -33,7 +33,7 @@
     /// Create new instance of reprojectionObj. Input parameters are two projectionsObj's - in and out.
     reprojectionObj(projectionObj *in, projectionObj *out) 
     {
-	if(!in && !out) return NULL;
+        if(!in && !out) return NULL;
         return msProjectCreateReprojector(in, out);
     }
 

--- a/mapscript/swiginc/reprojection.i
+++ b/mapscript/swiginc/reprojection.i
@@ -40,6 +40,5 @@
     ~reprojectionObj() 
     {
         msProjectDestroyReprojector(self);
-        free(self);
     }
 }

--- a/mapscript/swiginc/reprojection.i
+++ b/mapscript/swiginc/reprojection.i
@@ -33,7 +33,7 @@
     /// Create new instance of reprojectionObj. Input parameters are two projectionsObj's - in and out.
     reprojectionObj(projectionObj *in, projectionObj *out) 
     {
-	if(!in || !out) return NULL;
+	if(!in && !out) return NULL;
         return msProjectCreateReprojector(in, out);
     }
 

--- a/mapscript/swiginc/shape.i
+++ b/mapscript/swiginc/shape.i
@@ -78,6 +78,13 @@
         return msProjectShape(projin, projout, self);
     }
 
+    /// Reproject shape given a reprojection object. Transformation is done in place.
+    /// Returns :data:`MS_SUCCESS` or :data:`MS_FAILURE`
+    int project(reprojectionObj *reprojector)
+    {
+        return msProjectShapeEx(reprojector, self);
+    }
+
     /// Returns a reference to part at index. Reference is valid only during 
     /// the life of the shapeObj.
     lineObj *get(int i) {

--- a/msautotest/php/maps/reprojection.map
+++ b/msautotest/php/maps/reprojection.map
@@ -1,0 +1,38 @@
+/* 
+PURPOSE:     test reprojection through MapScript
+SOURCE DATA: OSM places for Nova Scotia, 3843 points
+             in EPSG:4326
+DATA FORMAT: SpatiaLite database
+*/
+
+MAP
+  NAME 'reproj-mapscript'
+  EXTENT -66.374741 43.400270 -59.697577 50.267922
+  UNITS DD
+  SIZE 300 300
+  IMAGETYPE PNG
+  
+  SYMBOL
+    NAME "circle"
+    TYPE ellipse
+    POINTS 1 1 END
+    FILLED true
+  END #symbol  
+
+  LAYER
+    NAME "ns-places"
+    STATUS ON
+    TYPE POINT    
+    CONNECTIONTYPE OGR
+    CONNECTION "data/ns.db"
+    DATA "places"
+    CLASS
+      STYLE 
+        COLOR 255 100 100 
+        SYMBOL "circle"
+        SIZE 5
+      END #style
+    END #class
+  END #layer
+
+END #map

--- a/msautotest/php/reprojectionObjTest.php
+++ b/msautotest/php/reprojectionObjTest.php
@@ -49,7 +49,7 @@ class reprojectionObjTest extends \PHPUnit\Framework\TestCase
         }
         $time_elapsed_secs = microtime(true) - $start;
         //should take ~0.04 seconds long
-        echo $i." points reprojected in ".round($time_elapsed_secs, 4)." seconds";
+        echo "    ".$i." points reprojected in ".round($time_elapsed_secs, 4)." seconds\n";
         $this->layer->close();
     }
     

--- a/msautotest/php/reprojectionObjTest.php
+++ b/msautotest/php/reprojectionObjTest.php
@@ -1,0 +1,63 @@
+<?php
+/* 
+PURPOSE:     test reprojectionObj through MapScript
+SOURCE DATA: OSM places for Nova Scotia, 3843 points
+             in EPSG:4326
+DATA FORMAT: SpatiaLite database
+*/
+class reprojectionObjTest extends \PHPUnit\Framework\TestCase
+{
+    protected $reprojector;
+    protected $map;
+    protected $layer;
+    protected $shape;
+    protected $sourceProjection;
+    protected $outputProjection;
+
+    public function setUp(): void
+    {
+        $this->map = new mapObj('maps/reprojection.map');
+        $this->layer = $this->map->getLayer(0);
+        $this->shape = new shapeObj(MS_SHAPE_POINT);
+        //$this->sourceProjection = new projectionObj("proj=latlong");
+        $this->sourceProjection = new projectionObj("EPSG:4326");
+        $this->outputProjection = new projectionObj("EPSG:3857");        
+    }
+
+    public function testReprojectionInstance()
+    {
+
+        $this->assertInstanceOf("reprojectionObj",  $this->reprojection = new reprojectionObj( $this->sourceProjection,  $this->outputProjection ));
+    }
+
+    public function testProjectMethodSpeed()
+    {
+        $reprojector = new reprojectionObj( $this->sourceProjection,  $this->outputProjection );        
+        
+        $this->layer->open();
+        $i = 0;
+        
+        $start = microtime(true);
+        while (($shape = $this->layer->nextShape()) != null) {
+          $point = $shape->getCentroid();
+          $point->project($reprojector);
+          //check that the first shape reprojects correctly, to EPSG:3857
+          if ($i == 0) {
+            $this->assertStringContainsString("'x': -7078355.430891216, 'y': 5566372.173407509", $point->toString());
+          }
+          $i++;          
+        }
+        $time_elapsed_secs = microtime(true) - $start;
+        //should take ~0.04 seconds long
+        echo $i." points reprojected in ".round($time_elapsed_secs, 4)." seconds";
+        $this->layer->close();
+    }
+    
+    # destroy variables, if not can lead to segmentation fault
+    public function tearDown(): void {
+        unset($reprojector, $this->reprojection, $this->map, $this->layer, $this->sourceProjection, $this->outputProjection, $point);
+    }    
+    
+}
+
+?>


### PR DESCRIPTION
Legacy MapScript projection operations are very slow when used in batch context - e.g. looping over a series of geometries and reprojecting. This pull request exposes the reprojectionObj to MapScript and adds overloaded project methods to point, line, rect and shape classes. Use looks like so (in Perl):
```
my $proj_26915 = new mapscript::projectionObj('epsg:26915');
my $proj_4326 = new mapscript::projectionObj('epsg:4326');
my $reprojector =  new mapscript::reprojectionObj( $proj_26915,  $proj_4329 );

while (my $shape = $layer->nextShape()) {
    my $point = $shape->getCentroid();
    $point->project($reprojector);
    # do something with $point
}
```
--Steve