### PR TITLE
msautotest/php: fix use-after-free issues (fixes #6537)

### DIFF
--- a/msautotest/php/colorObjTest.php
+++ b/msautotest/php/colorObjTest.php
@@ -5,12 +5,13 @@ class colorObjTest extends \PHPUnit\Framework\TestCase
     protected $color;
 	protected $original = "#00ff00";
 	protected $originalAlpha = 255;
+	protected $map;
 
     public function setUp(): void
     {
         $map_file = 'maps/labels.map';
-        $map = new mapObj($map_file);
-        $this->color = $map->getLayer(0)->getClass(0)->getLabel(0)->color;
+        $this->map = new mapObj($map_file);
+        $this->color = $this->map->getLayer(0)->getClass(0)->getLabel(0)->color;
     }
 
     public function test__getsetAlpha()

--- a/msautotest/php/hashtableObjTest.php
+++ b/msautotest/php/hashtableObjTest.php
@@ -3,12 +3,13 @@
 class hashtableObjTest extends \PHPUnit\Framework\TestCase
 {
     protected $hash;
+    protected $map;
 
     public function setUp(): void
     {
         $map_file = 'maps/helloworld-gif.map';
-        $map = new mapObj($map_file);
-        $this->hash = $map->web->metadata;
+        $this->map = new mapObj($map_file);
+        $this->hash = $this->map->web->metadata;
     }
 
     public function test__setNumItems()

--- a/msautotest/php/symbolObjTest.php
+++ b/msautotest/php/symbolObjTest.php
@@ -3,18 +3,20 @@
 class symbolObjTest extends \PHPUnit\Framework\TestCase
 {
     protected $symbol;
+    protected $map;
+    protected $outputFrmt;
 
     public function setUp(): void
     {
-        $map = new mapObj('maps/labels.map');
-        $this->symbol = $map->symbolset->getSymbolByName("plant");
+        $this->map = new mapObj('maps/labels.map');
+        $this->symbol = $this->map->symbolset->getSymbolByName("plant");
+        $this->outputFrmt = new outputFormatObj('AGG/PNG', 'theName');
     }
 
     public function testSetGetImage()
     {
-        $outputFrmt = new outputFormatObj('AGG/PNG', 'theName');
         //$this->assertInstanceOf('imageObj', $image = $this->symbol->getImage($outputFrmt));
-        $image = $this->symbol->getImage($outputFrmt);
+        $image = $this->symbol->getImage($this->outputFrmt);
         $this->symbol->setImage($image);
     }
 
@@ -50,7 +52,9 @@ class symbolObjTest extends \PHPUnit\Framework\TestCase
     
     # destroy variables, if not can lead to segmentation fault
     public function tearDown(): void {
-        unset($symbol, $map, $this->symbol, $this->symbol->anchorpoint_x, $this->symbol->anchorpoint_y, $this->symbol->maxx, $this->symbol->maxy, $this->symbol->minx, $this->symbol->miny);
+        unset($this->map);
+        unset($this->symbol);
+        unset($this->outputFrmt);
     }    
     
 }


### PR DESCRIPTION
Clean Valgrind run with that.
They are mostly related to $map object being local to the setUp() function if not using $this->map syntax. And the issue is that if it is destroyed, then depending objects will point to freed memory.

Caveats: I don't know anything about PHP...