### PR TITLE
[msautotest] upgrade tests to use PHP 8.1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - BUILD_NAME=PHP_8.0
         - PYTHON_VERSION=3.8
 
-    - php: 8.1.7
+    - php: 8.1.8
       env:
         - BUILD_NAME=PHP_8.1
         - PYTHON_VERSION=3.9


### PR DESCRIPTION
- upgrade TravisCI tests to use the recent PHP 8.1.8 release