### PR TITLE
Apply special processings of PROJ_LIB to PROJ_DATA as well

### DIFF
--- a/map2img.c
+++ b/map2img.c
@@ -139,8 +139,8 @@ int main(int argc, char *argv[])
     if(msGetGlobalDebugLevel() >= MS_DEBUGLEVEL_TUNING)
       msGettimeofday(&requeststarttime, NULL);
 
-    /* Use PROJ_LIB env vars if set */
-    msProjLibInitFromEnv();
+    /* Use PROJ_DATA/PROJ_LIB env vars if set */
+    msProjDataInitFromEnv();
 
     /* Use MS_ERRORFILE and MS_DEBUGLEVEL env vars if set */
     if ( msDebugInitFromEnv() != MS_SUCCESS ) {

--- a/mapobject.c
+++ b/mapobject.c
@@ -166,9 +166,9 @@ int msSetConfigOption( mapObj *map, const char *key, const char *value)
 {
   /* We have special "early" handling of this so that it will be */
   /* in effect when the projection blocks are parsed and pj_init is called. */
-  if( strcasecmp(key,"PROJ_LIB") == 0 ) {
+  if( strcasecmp(key,"PROJ_DATA") == 0 || strcasecmp(key,"PROJ_LIB") == 0 ) {
     /* value may be relative to map path */
-    msSetPROJ_LIB( value, map->mappath );
+    msSetPROJ_DATA( value, map->mappath );
   }
 
   /* Same for MS_ERRORFILE, we want it to kick in as early as possible
@@ -220,8 +220,9 @@ void msApplyMapConfigOptions( mapObj *map )
        key != NULL;
        key = msNextKeyFromHashTable( &(map->configoptions), key ) ) {
     const char *value = msLookupHashTable( &(map->configoptions), key );
-    if( strcasecmp(key,"PROJ_LIB") == 0 ) {
-      msSetPROJ_LIB( value, map->mappath );
+    if( strcasecmp(key,"PROJ_DATA") == 0 ||
+        strcasecmp(key,"PROJ_LIB") == 0 ) {
+      msSetPROJ_DATA( value, map->mappath );
     } else if( strcasecmp(key,"MS_ERRORFILE") == 0 ) {
       msSetErrorFile( value, map->mappath );
     } else {

--- a/mapproject.h
+++ b/mapproject.h
@@ -156,8 +156,8 @@ but are not directly exposed by the mapscript module
   MS_DLL_EXPORT void msAxisDenormalizePoints( projectionObj *proj, int count,
       double *x, double *y );
 
-  MS_DLL_EXPORT void msSetPROJ_LIB( const char *, const char * );
-  MS_DLL_EXPORT void msProjLibInitFromEnv();
+  MS_DLL_EXPORT void msSetPROJ_DATA( const char *, const char * );
+  MS_DLL_EXPORT void msProjDataInitFromEnv();
 
   int msProjIsGeographicCRS(projectionObj* proj);
 #if PROJ_VERSION_MAJOR >= 6

--- a/mapserv-config.cpp
+++ b/mapserv-config.cpp
@@ -108,8 +108,9 @@ static int loadConfig(configObj *config)
 static void msConfigSetConfigOption(const char* key, const char* value)
 {
   CPLSetConfigOption(key, value);
-  if( strcasecmp(key,"PROJ_LIB") == 0 ) {
-    msSetPROJ_LIB( value, nullptr );
+  if( strcasecmp(key,"PROJ_DATA") == 0 ||
+      strcasecmp(key,"PROJ_LIB") == 0 ) {
+    msSetPROJ_DATA( value, nullptr );
   }
 }
 

--- a/mapservutil.c
+++ b/mapservutil.c
@@ -2010,8 +2010,8 @@ int msCGIHandler(const char *query_string, void **out_buffer, size_t *buffer_len
 
   msIO_installStdoutToBuffer();
 
-  /* Use PROJ_LIB env vars if set */
-  msProjLibInitFromEnv();
+  /* Use PROJ_DATA/PROJ_LIB env vars if set */
+  msProjDataInitFromEnv();
 
   /* Use MS_ERRORFILE and MS_DEBUGLEVEL env vars if set */
   if( msDebugInitFromEnv() != MS_SUCCESS ) {

--- a/maputil.c
+++ b/maputil.c
@@ -2008,8 +2008,8 @@ int msSetup()
   msThreadInit();
 #endif
 
-  /* Use PROJ_LIB env vars if set */
-  msProjLibInitFromEnv();
+  /* Use PROJ_DATA/PROJ_LIB env vars if set */
+  msProjDataInitFromEnv();
 
   /* Use MS_ERRORFILE and MS_DEBUGLEVEL env vars if set */
   if (msDebugInitFromEnv() != MS_SUCCESS)
@@ -2069,7 +2069,7 @@ void msCleanup()
 #  endif
   pj_deallocate_grids();
 #endif
-  msSetPROJ_LIB( NULL, NULL );
+  msSetPROJ_DATA( NULL, NULL );
   msProjectionContextPoolCleanup();
 
 #if defined(USE_CURL)


### PR DESCRIPTION
PROJ 9.1 recognizes the PROJ_DATA environment variable, as a replacement
for PROJ_LIB (both are still recognized by PROJ >= 9.1. PROJ_LIB will be
retired in PROJ 10, whose release is unplanned for now)

Cf https://github.com/OSGeo/PROJ/pull/3253