### PR TITLE
Increase Python max line length for linting

### DIFF
--- a/mapscript/python/CMakeLists.txt
+++ b/mapscript/python/CMakeLists.txt
@@ -74,7 +74,7 @@ add_custom_command(
     DEPENDS mapscriptvenv.stamp
     OUTPUT mapscriptlinting.stamp
     WORKING_DIRECTORY ${OUTPUT_FOLDER}
-    COMMAND ${Python_VENV_SCRIPTS}/flake8 $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/tests --max-line-length=120
+    COMMAND ${Python_VENV_SCRIPTS}/flake8 $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/tests --max-line-length=140
     COMMAND ${Python_VENV_SCRIPTS}/flake8 $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/examples --max-line-length=120
     COMMENT "Linting test suite and examples with flake8" # note only one comment is output per custom command block
 )

--- a/mapscript/python/requirements-dev.txt
+++ b/mapscript/python/requirements-dev.txt
@@ -2,4 +2,5 @@ pytest
 pillow
 wheel>=0.31.1
 setuptools>=40.2.0
-flake8
+flake8==3.9.2; python_version == '2.7'
+flake8==5.0.3; python_version >= '3.6'

--- a/mapscript/python/requirements-dev.txt
+++ b/mapscript/python/requirements-dev.txt
@@ -3,4 +3,4 @@ pillow
 wheel>=0.31.1
 setuptools>=40.2.0
 flake8==3.9.2; python_version == '2.7'
-flake8==5.0.3; python_version >= '3.6'
+flake8==5.0.3; python_version >= '3.0'


### PR DESCRIPTION
CI is failing due to linting issues, as a Python line is 130 characters:

https://ci.appveyor.com/project/MapServer/mapserver/builds/44357880/job/wuf5k2b7gvn2e5y2#L421

Seems as though there must have been a change in Flake8 (a new version was released yesterday). 
Pull request includes a specific version of Flake8 to ensure this doesn't happen again. 
