### PR TITLE
[ogcapi] make sure there are features before accessing them in jinja templates

### DIFF
--- a/share/ogcapi/templates/html-bootstrap4/collection-items.html
+++ b/share/ogcapi/templates/html-bootstrap4/collection-items.html
@@ -49,9 +49,11 @@
 <table class="table">
   <thead class="thead-light">
     <th>ID</th>
+{% if response.features %}
 {% for key, value in response.features.0.properties %}
     <th>{{ key }}</th>
 {% endfor %} 
+{% endif %}
   </thead>
   <tbody>    
 {% for feature in response.features %}

--- a/share/ogcapi/templates/html-plain/collection-items.html
+++ b/share/ogcapi/templates/html-plain/collection-items.html
@@ -10,9 +10,11 @@
 <table>
   <thead>
     <th>ID</th>
+{% if response.features %}
 {% for key, value in response.features.0.properties %}
     <th>{{ key }}</th>
 {% endfor %} 
+{% endif %}
   </thead>
   <tbody>    
 {% for feature in response.features %}


### PR DESCRIPTION
in case you have a layer/data entry with zero features (extent incompatible with map extent, sql query that returns 0 records, broken FILTER expression in mapfile...) right now accessing it via OGCAPI using the html format yields
```
{"code":"ConfigError","description":"Template rendering error. [inja.exception.render_error] (at 52:22) variable 'response.features.0.properties' not found (collection-items.html)."}
```

PR makes sure that there are features before trying to enumerate properties, fixing this error - the default HTML template is properly rendered with an empty map zoomed to the world, and properly reports `Number of returned items: 0`

@sdlime ? does this make sense to you ?