### PR TITLE
reset layer filteritem to its old value when the query extent doesnt overlap the layer extent

### DIFF
--- a/mapquery.c
+++ b/mapquery.c
@@ -905,6 +905,9 @@ int msQueryByFilter(mapObj *map)
 
     status = msLayerWhichShapes(lp, search_rect, MS_TRUE);
     if(status == MS_DONE) { /* no overlap */
+      lp->filteritem = old_filteritem; /* point back to original value */
+      msCopyExpression(&lp->filter, &old_filter); /* restore old filter */
+      msFreeExpression(&old_filter);
       msLayerClose(lp);
       continue;
     } else if(status != MS_SUCCESS) goto restore_old_filter;


### PR DESCRIPTION
fixes #6580 - after all we're looping on all map layers so we cant just `goto restore_old_filter`, so i just copy/pasted a similar idiom found in other places in mapquery.c

more eyes welcome on the logic, but fixes the double-free for me in the case where the layer extent doesn't overlap with the map/query extent.