### PR TITLE
Check if a LAYER has a NAME before accessing the property

### DIFF
--- a/mapwms.cpp
+++ b/mapwms.cpp
@@ -539,8 +539,10 @@ void msWMSPrepareNestedGroups(mapObj* map, int /* nVersion */, char*** nestedGro
  } 
  /* Iterate through layers to find out whether they are in any of the nested groups */
  for (int i = 0; i < map->numlayers; i++) {
-    if( uniqgroups.find(msStringToLower(std::string(GET_LAYER(map, i)->name))) != uniqgroups.end() ) {
-        isUsedInNestedGroup[i] = 1;
+    if (GET_LAYER(map, i)->name) {
+        if( uniqgroups.find(msStringToLower(std::string(GET_LAYER(map, i)->name))) != uniqgroups.end() ) {
+            isUsedInNestedGroup[i] = 1;
+        }
     }
   }
 }


### PR DESCRIPTION
See discussions at https://lists.osgeo.org/pipermail/mapserver-dev/2022-August/016847.html

> It appears that as of 8.0 a layer must have a NAME. In the past it has been
possible for a layer not to have a NAME if it had a  GROUP.

> with a WMS request. Apache throws a 500 error "End of script
output before headers". I define a LAYER with a GROUP but no NAME

This update  ensures the same behaviour as 7.6 and avoids crashing the server. 