### PR TITLE
Set layer startindex for paging in OGC Features API

### DIFF
--- a/mapogcapi.cpp
+++ b/mapogcapi.cpp
@@ -1058,9 +1058,10 @@ static int processCollectionItemsRequest(mapObj *map, cgiRequestObj *request, co
               return MS_SUCCESS;
             }
 
-            // msExecuteQuery() use a 1-based offst convention, whereas the API
+            // msExecuteQuery() use a 1-based offset convention, whereas the API
             // uses a 0-based offset convention.
             map->query.startindex = 1 + offset;
+            layer->startindex = 1 + offset;
         }
 
         if(msExecuteQuery(map) != MS_SUCCESS) {


### PR DESCRIPTION
Possible fix for #6613. 

The database drivers use `lp->startindex` for generating queries with `rownnum` for paging. E.g.

https://github.com/MapServer/MapServer/blob/6c3486b3577d7efc6988d4e319df45807419d59f/mapmssql2008.c#L1577

This doesn't appear to be set when using the OGC Features API, only `map->query.startindex` is set. 

Paging in WFS works by setting `lpQueried->startindex`. 

https://github.com/MapServer/MapServer/blob/e789297546c00d60f6aad3fb51e53cc4b2dd8e35/mapwfs.cpp#L2961

Testing locally with MSSQL this correctly sets the `rownum` based on the offset. I'm unsure of any possible side effects of this change though. 
An `offset=20` produces a SQL query with `[rownum] >= 21 and [rownum] < 31` - is this the correct? Or should the `1+ offset` be changed to simply `offset`?

