### PR TITLE
[Backport 7.6] Redact password= content in msError() and msDebug() messages

### DIFF
--- a/mapdebug.c
+++ b/mapdebug.c
@@ -324,9 +324,17 @@ void msDebug( const char * pszFormat, ... )
 {
   va_list args;
   debugInfoObj *debuginfo = msGetDebugInfoObj();
+  char szMessage[MESSAGELENGTH];
 
   if (debuginfo == NULL || debuginfo->debug_mode == MS_DEBUGMODE_OFF)
     return;  /* Don't waste time here! */
+
+  va_start(args, pszFormat);
+  vsnprintf( szMessage, MESSAGELENGTH, pszFormat, args );
+  va_end(args);
+  szMessage[MESSAGELENGTH-1] = '\0';
+
+  msRedactCredentials(szMessage);
 
   if (debuginfo->fp) {
     /* Writing to a stdio file handle */
@@ -345,21 +353,11 @@ void msDebug( const char * pszFormat, ... )
                    msStringChop(ctime(&t)), (long)tv.tv_usec);
     }
 
-    va_start(args, pszFormat);
-    msIO_vfprintf(debuginfo->fp, pszFormat, args);
-    va_end(args);
+    msIO_fprintf(debuginfo->fp, "%s", szMessage);
   }
 #ifdef _WIN32
   else if (debuginfo->debug_mode == MS_DEBUGMODE_WINDOWSDEBUG) {
     /* Writing to Windows Debug Console */
-
-    char szMessage[MESSAGELENGTH];
-
-    va_start(args, pszFormat);
-    vsnprintf( szMessage, MESSAGELENGTH, pszFormat, args );
-    va_end(args);
-
-    szMessage[MESSAGELENGTH-1] = '\0';
     OutputDebugStringA(szMessage);
   }
 #endif

--- a/maperror.c
+++ b/maperror.c
@@ -324,6 +324,18 @@ char *msGetErrorString(char *delimiter)
   return(errstr);
 }
 
+void msRedactCredentials(char* str)
+{
+  char* password = strstr(str, "password=");
+  if (password != NULL) {
+    char* ptr = password + strlen("password=");
+    while (*ptr != '\0' && *ptr != ' ') {
+      *ptr = '*';
+      ptr++;
+    }
+  }
+}
+
 void msSetError(int code, const char *message_fmt, const char *routine, ...)
 {
   errorObj *ms_error;
@@ -355,6 +367,8 @@ void msSetError(int code, const char *message_fmt, const char *routine, ...)
   }
   else
       ++ms_error->errorcount;
+
+  msRedactCredentials(ms_error->message);
 
   /* Log a copy of errors to MS_ERRORFILE if set (handled automatically inside msDebug()) */
   msDebug("%s: %s %s\n", ms_error->routine, ms_errorCodes[ms_error->code], ms_error->message);

--- a/maperror.h
+++ b/maperror.h
@@ -125,6 +125,7 @@ extern "C" {
   MS_DLL_EXPORT char *msGetErrorString(char *delimiter);
 
 #ifndef SWIG
+  MS_DLL_EXPORT void msRedactCredentials(char* str);
   MS_DLL_EXPORT void msSetError(int code, const char *message, const char *routine, ...) MS_PRINT_FUNC_FORMAT(2,4) ;
   MS_DLL_EXPORT void msWriteError(FILE *stream);
   MS_DLL_EXPORT void msWriteErrorXML(FILE *stream);

--- a/mappostgis.c
+++ b/mappostgis.c
@@ -2598,25 +2598,13 @@ int msPostGISLayerOpen(layerObj *layer)
     ** Connection failed, return error message with passwords ***ed out.
     */
     if (!layerinfo->pgconn || PQstatus(layerinfo->pgconn) == CONNECTION_BAD) {
-      char *index, *maskeddata;
       if (layer->debug)
         msDebug("msPostGISLayerOpen: Connection failure.\n");
 
-      maskeddata = msStrdup(layer->connection);
-      index = strstr(maskeddata, "password=");
-      if (index != NULL) {
-        index = (char*)(index + 9);
-        while (*index != '\0' && *index != ' ') {
-          *index = '*';
-          index++;
-        }
-      }
-
-      msDebug( "Database connection failed (%s) with connect string '%s'\nIs the database running? Is it allowing connections? Does the specified user exist? Is the password valid? Is the database on the standard port? in msPostGISLayerOpen()", PQerrorMessage(layerinfo->pgconn), maskeddata);
+      msDebug( "Database connection failed (%s) with connect string '%s'\nIs the database running? Is it allowing connections? Does the specified user exist? Is the password valid? Is the database on the standard port? in msPostGISLayerOpen()", PQerrorMessage(layerinfo->pgconn), layer->connection);
       msSetError(MS_QUERYERR, "Database connection failed. Check server logs for more details.Is the database running? Is it allowing connections? Does the specified user exist? Is the password valid? Is the database on the standard port?", "msPostGISLayerOpen()");
 
       if(layerinfo->pgconn) PQfinish(layerinfo->pgconn);
-      free(maskeddata);
       free(layerinfo);
       return MS_FAILURE;
     }


### PR DESCRIPTION
Fixes https://github.com/MapServer/MapServer-private/issues/2

Backport of https://github.com/MapServer/MapServer/pull/6616#issuecomment-1252356026