### PR TITLE
Allow a CONFIG to be used when loading a Mapfile from a string

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -6148,7 +6148,7 @@ static bool msGetCWD(char* szBuffer, size_t nBufferSize, const char* pszFunction
 /*
 ** Sets up string-based mapfile loading and calls loadMapInternal to do the work.
 */
-mapObj *msLoadMapFromString(char *buffer, char *new_mappath)
+mapObj *msLoadMapFromString(char *buffer, char *new_mappath, const configObj *config)
 {
   mapObj *map;
   struct mstimeval starttime = {0}, endtime = {0};
@@ -6179,6 +6179,8 @@ mapObj *msLoadMapFromString(char *buffer, char *new_mappath)
     return(NULL);
   }
 
+  map->config = config; // create a read-only reference
+  
   msAcquireLock( TLOCK_PARSER ); /* might need to move this lock a bit higher, yup (bug 2108) */
 
   msyystate = MS_TOKENIZE_STRING;

--- a/mapscript/python/pyextend.i
+++ b/mapscript/python/pyextend.i
@@ -41,7 +41,7 @@ def fromstring(data, mappath=None, configpath=None):
     if re.search(r"^\s*MAP", data, re.I):
         # create a config object if a path is supplied
         if configpath:
-             config = configObj(configpath):
+             config = configObj(configpath)
         else:
              config = None
         return msLoadMapFromString(data, mappath, config)

--- a/mapscript/python/pyextend.i
+++ b/mapscript/python/pyextend.i
@@ -21,7 +21,7 @@
 /* fromstring: Factory for mapfile objects */
 
 %pythoncode %{
-def fromstring(data, mappath=None):
+def fromstring(data, mappath=None, configpath=None):
     """Creates map objects from mapfile strings.
 
     Parameters
@@ -38,8 +38,13 @@ def fromstring(data, mappath=None):
     'test'
     """
     import re
-    if re.search(r"^\s*MAP", data, re.I): 
-        return msLoadMapFromString(data, mappath)
+    if re.search(r"^\s*MAP", data, re.I):
+        # create a config object if a path is supplied
+        if configpath:
+             config = configObj(configpath):
+        else:
+             config = None
+        return msLoadMapFromString(data, mappath, config)
     elif re.search(r"^\s*LAYER", data, re.I):
         ob = layerObj()
         ob.updateFromString(data)

--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -55,6 +55,12 @@
   {
       return msLoadMapFromString(mapText, NULL);
   }
+
+  mapObj(char *mapText, int isMapText, configObj *config=NULL) 
+  {
+      return msLoadMapFromString(mapText, NULL, config);
+  }
+
 #endif 
     
     ~mapObj() 

--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -53,7 +53,7 @@
 
   mapObj(char *mapText, int isMapText /*used as signature only to differentiate this constructor from default constructor*/ ) 
   {
-      return msLoadMapFromString(mapText, NULL);
+      return msLoadMapFromString(mapText, NULL, NULL);
   }
 
   mapObj(char *mapText, int isMapText, configObj *config=NULL) 

--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -56,7 +56,7 @@
       return msLoadMapFromString(mapText, NULL, NULL);
   }
 
-  mapObj(char *mapText, int isMapText, configObj *config=NULL) 
+  mapObj(char *mapText, int isMapText, configObj *config) 
   {
       return msLoadMapFromString(mapText, NULL, config);
   }

--- a/mapserver.h
+++ b/mapserver.h
@@ -2091,7 +2091,7 @@ void msPopulateTextSymbolForLabelAndString(textSymbolObj *ts, labelObj *l, char 
   /**
   Sets up string-based mapfile loading and calls loadMapInternal to do the work
   */
-  MS_DLL_EXPORT mapObj *msLoadMapFromString(char *buffer, char *new_mappath);
+  MS_DLL_EXPORT mapObj *msLoadMapFromString(char *buffer, char *new_mappath, const configObj* config);
 
   /* Function prototypes, not wrapable */
 


### PR DESCRIPTION
Update to address #6626. 

[Python ](https://github.com/MapServer/MapServer/blob/545b44a4924505c97d2192b042091cc38972fc5f/mapscript/python/pyextend.i#L24)and C# MapScript both allow loading a Mapfile from a string. 

MapServer 8.0 now uses a `CONFIG` file that allows setting keys for plugins and other settings.  This update allows a config file to be used when loading the Mapfile from a sting:

`mapscript.fromstring("MAP NAME TEST END", r"C:/MapfileResources/", config_file)` 

I've not tested if the C# approach works - the following is reported in the SWIG output, although I'm unsure if this is relevant:

```
 [  6%] Swig compile ../mapscript.i for csharp
/home/runner/work/mapserver/mapserver/mapscript/v8/../swiginc/map.i:62: Warning 516: Overloaded method mapObj::mapObj(char *,int,configObj *) ignored,
/home/runner/work/mapserver/mapserver/mapscript/v8/../swiginc/map.i:57: Warning 516: using mapObj::mapObj(char *,int) instead.
```