### PR TITLE
Fix memory leak related to styles on invalid mapfile

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -2961,6 +2961,11 @@ int freeClass(classObj *class)
       }
     }
   }
+  if( class->numstyles == 0 && class->styles != NULL &&
+      class->styles[0] != NULL ) {
+    /* msGrowClassStyles() creates class->styles[0] during the first call */
+    msFree(class->styles[0]);
+  }
   msFree(class->styles);
 
   for(i=0; i<class->numlabels; i++) { /* each label */


### PR DESCRIPTION
Found locally with ossfuzz

```
Direct leak of 1304 byte(s) in 1 object(s) allocated from:
    #0 0x54de9e in __interceptor_calloc /src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:77:3
    #1 0x5c6ce8 in msGrowClassStyles /src/MapServer/mapfile.c:3020:48
    #2 0x5c8513 in loadClass /src/MapServer/mapfile.c:3262:12
    #3 0x5d0f1e in loadLayer /src/MapServer/mapfile.c:3968:12
    #4 0x5ec0a0 in loadMapInternal /src/MapServer/mapfile.c:6053:12
    #5 0x5ef850 in msLoadMap /src/MapServer/mapfile.c:6333:6
    #6 0x58b1df in LLVMFuzzerTestOneInput /src/MapServer/build/../fuzzers/mapfuzzer.c:50:13
    #7 0x45cb33 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:611:15
    #8 0x45c31a in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:514:3
    #9 0x45d9e9 in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:757:19
    #10 0x45e6b5 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, std::__Fuzzer::allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:895:5
    #11 0x44da1f in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:912:6
    #12 0x477072 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #13 0x7f8124cb8082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 1878e6b475720c7c51969e69ab2d276fae6d1dee)
```