### PR TITLE
msLoadMap(): fix double-free related to labels

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -1623,7 +1623,6 @@ static int loadLabel(labelObj *label)
         break;
       case(EOF):
         msSetError(MS_EOFERR, NULL, "loadLabel()");
-        freeLabel(label);       /* free any structures allocated before EOF */
         return(-1);
       case(EXPRESSION):
         if(loadExpression(&(label->expression)) == -1) return(-1); /* loadExpression() cleans up previously allocated expression */
@@ -3231,7 +3230,9 @@ int loadClass(classObj *class, layerObj *layer)
         initLabel(class->labels[class->numlabels]);
         class->labels[class->numlabels]->size = MS_MEDIUM; /* only set a default if the LABEL section is present */
         if(loadLabel(class->labels[class->numlabels]) == -1) {
-          msFree(class->labels[class->numlabels]);
+          freeLabel(class->labels[class->numlabels]);
+          free(class->labels[class->numlabels]);
+          class->labels[class->numlabels] = NULL;
           return(-1);
         }
         class->numlabels++;


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52102