### PR TITLE
msLoadFontSet(): fix memleak in error code path

### DIFF
--- a/maplabel.c
+++ b/maplabel.c
@@ -825,6 +825,7 @@ int msLoadFontSet(fontSetObj *fontset, mapObj *map)
   if(!stream) {
     msSetError(MS_IOERR, "Error opening fontset %s.", "msLoadFontset()",
                fontset->filename);
+    free(path);
     return(-1);
   }
 


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52123