### PR TITLE
msLoadMap(): fix nullptr dereference when using LATLON keyword

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -6065,7 +6065,6 @@ static int loadMapInternal(mapObj *map)
         map->imagetype = getToken();
         break;
       case(LATLON):
-        msFreeProjectionExceptContext(&map->latlon);
         if(loadProjection(&map->latlon) == -1) return MS_FAILURE;
         break;
       case(LAYER):


### PR DESCRIPTION
As far as I can see, this was broken in the nominal case since https://github.com/MapServer/MapServer/commit/f595e91f1b418db72b806162dba4470109ac8dc1

So this feature is not used in msautotest, nor documented (https://mapserver.org/search.html?q=LATLON doesn't return anything relevant)
Probably that the mapObj::latlon member would be better initialized by taking the geographic CRS of the mapObj::projection.