### PR TITLE
msOGRShapeFromWKT(): fix memleak in error code path

### DIFF
--- a/mapogr.cpp
+++ b/mapogr.cpp
@@ -5537,7 +5537,7 @@ shapeObj *msOGRShapeFromWKT(const char *string)
                             wkbFlatten(OGR_G_GetGeometryType(hGeom)) )
       == MS_FAILURE ) {
     free( shape );
-    return NULL;
+    shape = NULL;
   }
 
   OGR_G_DestroyGeometry( hGeom );


### PR DESCRIPTION
Likely fix for https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52223 (couldn't reproduce the leak with the reproducer and current main, but this commit does fix a leak)