### PR TITLE
msIsAxisInverted(): avoid undefined-shift on invalid code

### DIFF
--- a/mapproject.c
+++ b/mapproject.c
@@ -980,6 +980,8 @@ int msProcessProjection(projectionObj *p)
 /************************************************************************/
 int msIsAxisInverted(int epsg_code)
 {
+  if( epsg_code < 0 )
+    return MS_FALSE;
   const unsigned int row = epsg_code / 8;
   const unsigned char index = epsg_code % 8;
 


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52259