### PR TITLE
[Backport 7.6] maplexer.l: fix heap-buffer-overflow issues with NUL characters

### DIFF
--- a/maplexer.c
+++ b/maplexer.c
@@ -4518,8 +4518,8 @@ YY_RULE_SETUP
 #line 504 "maplexer.l"
 {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-1] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer,msyytext);
                                                  return(MS_STRING);
@@ -4530,8 +4530,8 @@ YY_RULE_SETUP
 #line 512 "maplexer.l"
 {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-1] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer,msyytext);                                                 
                                                  msyynumber = atof(msyytext);
@@ -4544,8 +4544,8 @@ YY_RULE_SETUP
 #line 522 "maplexer.l"
 {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-1] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer,msyytext);
                                                  return(MS_BINDING);
@@ -4582,8 +4582,8 @@ YY_RULE_SETUP
 {
   /* attribute binding - numeric (no quotes) */
   msyytext++;
-  msyytext[strlen(msyytext)-1] = '\0';
-  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+  msyytext[msyyleng-1-1] = '\0';
+  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                           msyystring_buffer_size);
   strcpy(msyystring_buffer, msyytext);
   return(MS_TOKEN_BINDING_DOUBLE);
@@ -4596,8 +4596,8 @@ YY_RULE_SETUP
 {
   /* attribute binding - string (single or double quotes) */
   msyytext+=2;
-  msyytext[strlen(msyytext)-2] = '\0';
-  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+  msyytext[msyyleng-2-2] = '\0';
+  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                           msyystring_buffer_size);
   strcpy(msyystring_buffer, msyytext);
   return(MS_TOKEN_BINDING_STRING);
@@ -4610,8 +4610,8 @@ YY_RULE_SETUP
 {
   /* attribute binding - time */
   msyytext+=2;
-  msyytext[strlen(msyytext)-2] = '\0';
-  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext),
+  msyytext[msyyleng-2-2] = '\0';
+  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng,
                           msyystring_buffer_size);
   strcpy(msyystring_buffer, msyytext);
   return(MS_TOKEN_BINDING_TIME);
@@ -4621,7 +4621,7 @@ case 334:
 YY_RULE_SETUP
 #line 571 "maplexer.l"
 {
-  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                           msyystring_buffer_size);
   strcpy(msyystring_buffer,msyytext);
   msyynumber = atof(msyytext);
@@ -4632,7 +4632,7 @@ case 335:
 YY_RULE_SETUP
 #line 579 "maplexer.l"
 {
-  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                           msyystring_buffer_size);
   strcpy(msyystring_buffer,msyytext);
   msyynumber = atof(msyytext);
@@ -4645,8 +4645,8 @@ YY_RULE_SETUP
 #line 587 "maplexer.l"
 {
   msyytext++;
-  msyytext[strlen(msyytext)-1] = '\0';
-  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+  msyytext[msyyleng-1-1] = '\0';
+  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                           msyystring_buffer_size);
   strcpy(msyystring_buffer, msyytext);
   return(MS_TOKEN_LITERAL_TIME);
@@ -4658,8 +4658,8 @@ YY_RULE_SETUP
 #line 596 "maplexer.l"
 {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-2] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-2] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer, msyytext);
                                                  return(MS_IREGEX);
@@ -4671,8 +4671,8 @@ YY_RULE_SETUP
 #line 605 "maplexer.l"
 {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-1] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer, msyytext);
                                                  return(MS_REGEX);
@@ -4683,8 +4683,8 @@ YY_RULE_SETUP
 #line 614 "maplexer.l"
 {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-1] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer, msyytext);
                                                  return(MS_EXPRESSION);
@@ -4695,8 +4695,8 @@ YY_RULE_SETUP
 #line 623 "maplexer.l"
 {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-1] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer, msyytext);
                                                  return(MS_LIST);
@@ -4720,7 +4720,7 @@ YY_RULE_SETUP
                                                 if (msyystring_begin == msyytext[0]) {
                                                    BEGIN(msyystring_begin_state);
                                                    if (msyystring_return_state == MS_STRING) {
-                                                      if (msyystring_icase && strlen(msyytext)==2) {
+                                                      if (msyystring_icase && msyyleng==2) {
                                                          msyystring_icase = MS_FALSE; // reset
                                                          return MS_ISTRING;
                                                       } else
@@ -4731,11 +4731,11 @@ YY_RULE_SETUP
                                                 }
                                                 else {
                                                   int old_size = msyystring_size;
-                                                  msyystring_size += (strlen(msyytext)==2) ? 2 : 1;
+                                                  msyystring_size += (msyyleng==2) ? 2 : 1;
                                                   MS_LEXER_STRING_REALLOC(msyystring_buffer, msyystring_size,
                                                                           msyystring_buffer_size);
                                                   msyystring_buffer[old_size] = *msyytext;
-                                                  if (strlen(msyytext)==2) {
+                                                  if (msyyleng==2) {
                                                      msyystring_buffer[old_size+1] = msyytext[1];
                                                   }
                                                   msyystring_buffer[msyystring_size] = '\0';
@@ -4750,7 +4750,7 @@ YY_RULE_SETUP
                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyystring_size,
                                                                         msyystring_buffer_size);
 
-                                                if (strlen(msyytext) == 2)
+                                                if (msyyleng == 2)
                                                     msyystring_buffer[msyystring_size-1] = msyytext[1]; 
                                                 else
                                                     msyystring_buffer[msyystring_size-1] = msyytext[0];
@@ -4763,20 +4763,19 @@ YY_RULE_SETUP
 #line 678 "maplexer.l"
 {
                                                  int old_size = msyystring_size;
-                                                 int msyytext_len = (int)strlen(msyytext);
-                                                 msyystring_size += msyytext_len;
+                                                 msyystring_size += msyyleng;
                                                  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyystring_size,
                                                                          msyystring_buffer_size);
-                                                 memcpy(msyystring_buffer + old_size, msyytext, msyytext_len + 1);
+                                                 memcpy(msyystring_buffer + old_size, msyytext, msyyleng + 1);
                                              }
 	YY_BREAK
 case 345:
 /* rule 345 can match eol */
 YY_RULE_SETUP
-#line 687 "maplexer.l"
+#line 686 "maplexer.l"
 {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
+                                                 msyytext[msyyleng-1-1] = '\0';
 
                                                  if(include_stack_ptr >= MAX_INCLUDE_DEPTH) {
                                                    msSetError(MS_IOERR, "Includes nested to deeply.", "msyylex()");
@@ -4802,7 +4801,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 346:
 YY_RULE_SETUP
-#line 713 "maplexer.l"
+#line 712 "maplexer.l"
 {
                                                  msyystring_return_state = MS_TOKEN_LITERAL_STRING;
                                                  msyystring_begin = msyytext[0]; 
@@ -4813,9 +4812,9 @@ YY_RULE_SETUP
 	YY_BREAK
 case 347:
 YY_RULE_SETUP
-#line 721 "maplexer.l"
+#line 720 "maplexer.l"
 { 
-                                                    MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                    MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                             msyystring_buffer_size);
                                                     strcpy(msyystring_buffer, msyytext); 
                                                     return(MS_STRING); 
@@ -4824,11 +4823,11 @@ YY_RULE_SETUP
 case 348:
 /* rule 348 can match eol */
 YY_RULE_SETUP
-#line 728 "maplexer.l"
+#line 727 "maplexer.l"
 { msyylineno++; }
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):
-#line 730 "maplexer.l"
+#line 729 "maplexer.l"
 {
                                                   if( --include_stack_ptr < 0 )
                                                     return(EOF); /* end of main file */
@@ -4843,16 +4842,16 @@ case YY_STATE_EOF(INITIAL):
 case 349:
 /* rule 349 can match eol */
 YY_RULE_SETUP
-#line 741 "maplexer.l"
+#line 740 "maplexer.l"
 {
   return(0); 
 }
 	YY_BREAK
 case 350:
 YY_RULE_SETUP
-#line 745 "maplexer.l"
+#line 744 "maplexer.l"
 { 
-                                                  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                           msyystring_buffer_size);
                                                   strcpy(msyystring_buffer, msyytext); 
                                                   return(0); 
@@ -4860,15 +4859,15 @@ YY_RULE_SETUP
 	YY_BREAK
 case 351:
 YY_RULE_SETUP
-#line 751 "maplexer.l"
+#line 750 "maplexer.l"
 { return(msyytext[0]); }
 	YY_BREAK
 case 352:
 YY_RULE_SETUP
-#line 752 "maplexer.l"
+#line 751 "maplexer.l"
 ECHO;
 	YY_BREAK
-#line 4872 "/home/even/mapserver/mapserver/maplexer.c"
+#line 4871 "/home/even/mapserver/mapserver/maplexer.c"
 case YY_STATE_EOF(URL_VARIABLE):
 case YY_STATE_EOF(URL_STRING):
 case YY_STATE_EOF(EXPRESSION_STRING):
@@ -5879,7 +5878,7 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 752 "maplexer.l"
+#line 751 "maplexer.l"
 
 
 /*

--- a/maplexer.l
+++ b/maplexer.l
@@ -502,16 +502,16 @@ char path[MS_MAXPATHLEN];
 
 <URL_VARIABLE>\[[a-z/\.][a-z0-9/:\.\-\=_ ]*\]  {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-1] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer,msyytext);
                                                  return(MS_STRING);
                                                }
 <URL_VARIABLE>\[[0-9]*\]                       {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-1] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer,msyytext);                                                 
                                                  msyynumber = atof(msyytext);
@@ -520,8 +520,8 @@ char path[MS_MAXPATHLEN];
 
 <INITIAL>\[[^\]]*\]                            {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-1] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer,msyytext);
                                                  return(MS_BINDING);
@@ -542,8 +542,8 @@ char path[MS_MAXPATHLEN];
 <EXPRESSION_STRING>\[[^\]]*\] {
   /* attribute binding - numeric (no quotes) */
   msyytext++;
-  msyytext[strlen(msyytext)-1] = '\0';
-  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+  msyytext[msyyleng-1-1] = '\0';
+  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                           msyystring_buffer_size);
   strcpy(msyystring_buffer, msyytext);
   return(MS_TOKEN_BINDING_DOUBLE);
@@ -551,8 +551,8 @@ char path[MS_MAXPATHLEN];
 <EXPRESSION_STRING>\"\[[^\"]*\]\"|\'\[[^\']*\]\' {
   /* attribute binding - string (single or double quotes) */
   msyytext+=2;
-  msyytext[strlen(msyytext)-2] = '\0';
-  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+  msyytext[msyyleng-2-2] = '\0';
+  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                           msyystring_buffer_size);
   strcpy(msyystring_buffer, msyytext);
   return(MS_TOKEN_BINDING_STRING);
@@ -560,15 +560,15 @@ char path[MS_MAXPATHLEN];
 <EXPRESSION_STRING>\`\[[^\`]*\]\` {
   /* attribute binding - time */
   msyytext+=2;
-  msyytext[strlen(msyytext)-2] = '\0';
-  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext),
+  msyytext[msyyleng-2-2] = '\0';
+  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng,
                           msyystring_buffer_size);
   strcpy(msyystring_buffer, msyytext);
   return(MS_TOKEN_BINDING_TIME);
 }
 
 <INITIAL,URL_STRING>-?[0-9]+|-?[0-9]+\.[0-9]*|-?\.[0-9]*|-?[0-9]+[eE][+-]?[0-9]+|-?[0-9]+\.[0-9]*[eE][+-]?[0-9]+|-?\.[0-9]*[eE][+-]?[0-9]+ {
-  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                           msyystring_buffer_size);
   strcpy(msyystring_buffer,msyytext);
   msyynumber = atof(msyytext);
@@ -576,7 +576,7 @@ char path[MS_MAXPATHLEN];
 }
 
 <EXPRESSION_STRING>-?[0-9]+|-?[0-9]+\.[0-9]*|-?\.[0-9]*|-?[0-9]+[eE][+-]?[0-9]+|-?[0-9]+\.[0-9]*[eE][+-]?[0-9]+|-?\.[0-9]*[eE][+-]?[0-9]+ {
-  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                           msyystring_buffer_size);
   strcpy(msyystring_buffer,msyytext);
   msyynumber = atof(msyytext);
@@ -585,8 +585,8 @@ char path[MS_MAXPATHLEN];
 
 <EXPRESSION_STRING>\`[^\`]*\` {
   msyytext++;
-  msyytext[strlen(msyytext)-1] = '\0';
-  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+  msyytext[msyyleng-1-1] = '\0';
+  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                           msyystring_buffer_size);
   strcpy(msyystring_buffer, msyytext);
   return(MS_TOKEN_LITERAL_TIME);
@@ -594,8 +594,8 @@ char path[MS_MAXPATHLEN];
 
 <INITIAL,URL_STRING>\/[^*]{1}[^\/]*\/i         {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-2] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-2] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer, msyytext);
                                                  return(MS_IREGEX);
@@ -603,8 +603,8 @@ char path[MS_MAXPATHLEN];
 
 <INITIAL,URL_STRING>\/[^*]{1}[^\/]*\/          {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-1] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer, msyytext);
                                                  return(MS_REGEX);
@@ -612,8 +612,8 @@ char path[MS_MAXPATHLEN];
 
 <INITIAL,URL_STRING>\(.*\)                     {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-1] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer, msyytext);
                                                  return(MS_EXPRESSION);
@@ -621,8 +621,8 @@ char path[MS_MAXPATHLEN];
 
 <INITIAL,URL_STRING>\{.*\}                     {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
-                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                 msyytext[msyyleng-1-1] = '\0';
+                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                          msyystring_buffer_size);
                                                  strcpy(msyystring_buffer, msyytext);
                                                  return(MS_LIST);
@@ -640,7 +640,7 @@ char path[MS_MAXPATHLEN];
                                                 if (msyystring_begin == msyytext[0]) {
                                                    BEGIN(msyystring_begin_state);
                                                    if (msyystring_return_state == MS_STRING) {
-                                                      if (msyystring_icase && strlen(msyytext)==2) {
+                                                      if (msyystring_icase && msyyleng==2) {
                                                          msyystring_icase = MS_FALSE; // reset
                                                          return MS_ISTRING;
                                                       } else
@@ -651,11 +651,11 @@ char path[MS_MAXPATHLEN];
                                                 }
                                                 else {
                                                   int old_size = msyystring_size;
-                                                  msyystring_size += (strlen(msyytext)==2) ? 2 : 1;
+                                                  msyystring_size += (msyyleng==2) ? 2 : 1;
                                                   MS_LEXER_STRING_REALLOC(msyystring_buffer, msyystring_size,
                                                                           msyystring_buffer_size);
                                                   msyystring_buffer[old_size] = *msyytext;
-                                                  if (strlen(msyytext)==2) {
+                                                  if (msyyleng==2) {
                                                      msyystring_buffer[old_size+1] = msyytext[1];
                                                   }
                                                   msyystring_buffer[msyystring_size] = '\0';
@@ -667,7 +667,7 @@ char path[MS_MAXPATHLEN];
                                                 MS_LEXER_STRING_REALLOC(msyystring_buffer, msyystring_size,
                                                                         msyystring_buffer_size);
 
-                                                if (strlen(msyytext) == 2)
+                                                if (msyyleng == 2)
                                                     msyystring_buffer[msyystring_size-1] = msyytext[1]; 
                                                 else
                                                     msyystring_buffer[msyystring_size-1] = msyytext[0];
@@ -676,16 +676,15 @@ char path[MS_MAXPATHLEN];
 
 <MSSTRING>[^\\\'\\\"]+                       {
                                                  int old_size = msyystring_size;
-                                                 int msyytext_len = (int)strlen(msyytext);
-                                                 msyystring_size += msyytext_len;
+                                                 msyystring_size += msyyleng;
                                                  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyystring_size,
                                                                          msyystring_buffer_size);
-                                                 memcpy(msyystring_buffer + old_size, msyytext, msyytext_len + 1);
+                                                 memcpy(msyystring_buffer + old_size, msyytext, msyyleng + 1);
                                              }
 
 <INCLUDE>\"[^\"]*\"|\'[^\']*\'                 {
                                                  msyytext++;
-                                                 msyytext[strlen(msyytext)-1] = '\0';
+                                                 msyytext[msyyleng-1-1] = '\0';
 
                                                  if(include_stack_ptr >= MAX_INCLUDE_DEPTH) {
                                                    msSetError(MS_IOERR, "Includes nested to deeply.", "msyylex()");
@@ -718,7 +717,7 @@ char path[MS_MAXPATHLEN];
                                               }
 
 <INITIAL,URL_STRING>[a-z/\.][a-z0-9/\._\-\=]*   { 
-                                                    MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                    MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                             msyystring_buffer_size);
                                                     strcpy(msyystring_buffer, msyytext); 
                                                     return(MS_STRING); 
@@ -742,7 +741,7 @@ char path[MS_MAXPATHLEN];
 }
 
 <INITIAL,URL_VARIABLE,URL_STRING>.              { 
-                                                  MS_LEXER_STRING_REALLOC(msyystring_buffer, strlen(msyytext), 
+                                                  MS_LEXER_STRING_REALLOC(msyystring_buffer, msyyleng, 
                                                                           msyystring_buffer_size);
                                                   strcpy(msyystring_buffer, msyytext); 
                                                   return(0); 


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52305

Backport of https://github.com/MapServer/MapServer/pull/6712