### PR TITLE
loadColor(): fix memory leak if LABEL.COLOR is repeated

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -466,6 +466,7 @@ int loadColor(colorObj *color, attributeBindingObj *binding)
     }
   } else {
     assert(binding);
+    msFree(binding->item);
     binding->item = msStrdup(msyystring_buffer);
     binding->index = -1;
   }


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52371