### PR TITLE
Remove call to deprecated xmlSchemaCleanupTypes()

### DIFF
--- a/mapowscommon.c
+++ b/mapowscommon.c
@@ -718,7 +718,6 @@ int msOWSSchemaValidation(const char* xml_schema, const char* xml)
 
   /* If XML Schema hasn't been rightly loaded */
   if (schema == NULL) {
-    xmlSchemaCleanupTypes();
     xmlMemoryDump();
     xmlCleanupParser();
     return ret;


### PR DESCRIPTION
xmlSchemaCleanupTypes() is deprecated since libxml 2.10, and will be removed in a future version (as a public callable function)

This function is called by xmlCleanupParser() since https://github.com/GNOME/libxml2/commit/36e5cd5064d3477a0500f6183d68b18b7493568a#diff-65f1a082f56ebd52b4eaabdbe54d6e516736c8d9186b8c82c8ca55ad3cac105eR12119 14 years ago, so no need to call it explicitly.

Fixes #6614