### PR TITLE
freeLabelLeader(): fix memleak (including in nominal code path)

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -1511,7 +1511,9 @@ int freeLabelLeader(labelLeaderObj *leader)
 {
   int i;
   for(i=0; i<leader->numstyles; i++) {
-    msFree(leader->styles[i]);
+    if(freeStyle(leader->styles[i]) == MS_SUCCESS) {
+      msFree(leader->styles[i]);
+    }
   }
   msFree(leader->styles);
 


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=52947