### PR TITLE
Ignore Python 3.11 on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,6 +49,7 @@ init:
 build_script:
   - ps: Write-Host "Build tags - $env:APPVEYOR_REPO_TAG $env:APPVEYOR_REPO_TAG_NAME"
   - rename C:\Python310 Python310_Ignore
+  - rename C:\Python311 Python311_Ignore  
   - set "BUILD_FOLDER=%APPVEYOR_BUILD_FOLDER:\=/%"
   - if "%platform%" == "x64" SET VS_FULL=%VS_VERSION%
   - if "%platform%" == "x64" SET VS_ARCH=x64


### PR DESCRIPTION
When searching for Python versions 3.10 and 3.11 are picked up instead of 2.7 on Appveyor. Quick fix for now is to ignore these two Python versions until they are supported by MapScript and/or 2.7 is deprecated. 