### PR TITLE
Fix wfs paging on oracle

### DIFF
--- a/maporaclespatial.c
+++ b/maporaclespatial.c
@@ -2086,6 +2086,7 @@ int msOracleSpatialLayerWhichShapes( layerObj *layer, rectObj rect, int isQuery)
     msFree(tmp1_str);
 
     tmp_str = msStringConcatenate(tmp_str,  query_str2);
+    memset(query_str,0,strlen(query_str));
     query_str = msStringConcatenate(query_str, tmp_str);
     msFree(tmp_str);
   }


### PR DESCRIPTION
When using wfs paging mapserver create a wrong query, for example for query:

```
DATA "GEOM FROM (
    select * from my_table
) USING SRID 21781 NONE"
```

mapserver create wrong query

```
SELECT "ID", rownum, GEOM FROM (
	select * from my_table
)SELECT * from (SELECT atmp.*, ROWNUM rnum from (SELECT "ID", rownum, GEOM FROM (
	select * from my_table
) order by rowid) atmp where ROWNUM<=2) where rnum >=1
```

basically concatenate the "normal" query with paging query. The correct query should be

```
SELECT * from (SELECT atmp.*, ROWNUM rnum from (SELECT "ID", rownum, GEOM FROM (
	select * from my_table
) order by rowid) atmp where ROWNUM<=2) where rnum >=1
```