### PR TITLE
Fix usage of FILE* and VSILFILE*

### DIFF
--- a/mapcontext.c
+++ b/mapcontext.c
@@ -1274,7 +1274,7 @@ int msLoadMapContext(mapObj *map, char *filename, int unique_layer_names)
 int msSaveMapContext(mapObj *map, char *filename)
 {
 #if defined(USE_WMS_LYR)
-  VSILFILE *stream;
+  FILE *stream;
   char szPath[MS_MAXPATHLEN];
   int nStatus;
 

--- a/mapgdal.cpp
+++ b/mapgdal.cpp
@@ -524,7 +524,7 @@ int msSaveImageGDAL( mapObj *map, imageObj *image, const char *filenameIn )
   /*      stdout and delete the file.                                     */
   /* -------------------------------------------------------------------- */
   if( bFileIsTemporary ) {
-    FILE *fp;
+    VSILFILE *fp;
     unsigned char block[4000];
     int bytes_read;
 

--- a/mapogroutput.cpp
+++ b/mapogroutput.cpp
@@ -1209,7 +1209,7 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
   else if( EQUAL(form,"simple") ) {
     char buffer[1024];
     int  bytes_read;
-    FILE *fp;
+    VSILFILE *fp;
     const char *jsonp;
 
     jsonp = msGetOutputFormatOption( format, "JSONP", NULL );
@@ -1257,7 +1257,7 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
     CSLDestroy(papszAdditionalFiles);
 
     for( i = 0; file_list != NULL && file_list[i] != NULL; i++ ) {
-      FILE *fp;
+      VSILFILE *fp;
       int bytes_read;
       char buffer[1024];
 
@@ -1294,7 +1294,7 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
   /*      Handle the case of a zip file result.                           */
   /* -------------------------------------------------------------------- */
   else if( EQUAL(form,"zip") ) {
-    FILE *fp;
+    VSILFILE *fp;
     char *zip_filename = msTmpFile(map, NULL, "/vsimem/ogrzip/", "zip" );
     void *hZip;
     int bytes_read;

--- a/mapwcs11.cpp
+++ b/mapwcs11.cpp
@@ -1340,7 +1340,7 @@ int  msWCSReturnCoverage11( wcsParamsObj *params, mapObj *map,
 
     for( i = 0; i < count; i++ ) {
       const char *mimetype = NULL;
-      FILE *fp;
+      VSILFILE *fp;
       unsigned char block[4000];
       int bytes_read;
 

--- a/mapwcs20.cpp
+++ b/mapwcs20.cpp
@@ -2438,7 +2438,7 @@ static int msWCSWriteFile20(mapObj* map, imageObj* image, wcs20ParamsObjPtr para
 
     for( i = 0; i < count; i++ ) {
       const char *mimetype = NULL;
-      FILE *fp;
+      VSILFILE *fp;
       unsigned char block[4000];
       int bytes_read;
 

--- a/mapwmslayer.c
+++ b/mapwmslayer.c
@@ -1480,7 +1480,7 @@ int msDrawWMSLayerLow(int nLayerId, httpRequestObj *pasReqInfo,
     if (msDrawLayer(map, lp, img) != 0)
       status = MS_FAILURE;
   } else {
-    FILE *fp;
+    VSILFILE *fp;
     char *wldfile;
     /* OK, we have to resample the raster to map projection... */
     lp->transform = MS_TRUE;


### PR DESCRIPTION
In GDAL 3.7dev, VSILFILE* is no longer an alias for FILE* (see https://github.com/OSGeo/gdal/pull/6883), so we have to adjust our usage to be correct.

This MapServer change is backward compatible with GDAL < 3.7 too

CC @szekerest 