### PR TITLE
support HTTP_MAPSERVER_CONFIG_FILE for suExec environment

### DIFF
--- a/mapserv-config.cpp
+++ b/mapserv-config.cpp
@@ -122,10 +122,10 @@ configObj *msLoadConfig(const char* ms_config_file)
     // get config filename from environment
     ms_config_file = getenv("MAPSERVER_CONFIG_FILE");
     // If MAPSERVER_CONFIG_FILE not set,
-    // Tries to use HTTP_X_MAPSERVER_CONFIG_FILE
-    // (under suExec environment, SetEnv can affect to only HTTP_X_*)
+    // Tries to use HTTP_MAPSERVER_CONFIG_FILE
+    // (under suExec environment, SetEnv passes only HTTP_* or SSL_*)
     if (ms_config_file == NULL) {
-      ms_config_file = getenv("HTTP_X_MAPSERVER_CONFIG_FILE");
+      ms_config_file = getenv("HTTP_MAPSERVER_CONFIG_FILE");
     }
   }
 

--- a/mapserv-config.cpp
+++ b/mapserv-config.cpp
@@ -121,6 +121,12 @@ configObj *msLoadConfig(const char* ms_config_file)
   if (ms_config_file == NULL) {
     // get config filename from environment
     ms_config_file = getenv("MAPSERVER_CONFIG_FILE");
+    // If MAPSERVER_CONFIG_FILE not set,
+    // Tries to use HTTP_X_MAPSERVER_CONFIG_FILE
+    // (under suExec environment, SetEnv can affect to only HTTP_X_*)
+    if (ms_config_file == NULL) {
+      ms_config_file = getenv("HTTP_X_MAPSERVER_CONFIG_FILE");
+    }
   }
 
   if(ms_config_file == NULL && MAPSERVER_CONFIG_FILE[0] != '\0') {


### PR DESCRIPTION
 For suExec environment, also HTTP_X_MAPSERVER_CONFIG_FILE ,which starts with "HTTP_X_", could be accepted.