### PR TITLE
Update MS SQL Server connection error logging

### DIFF
--- a/maperror.c
+++ b/maperror.c
@@ -329,30 +329,30 @@ char *msGetErrorString(const char *delimiter)
   return(errstr);
 }
 
+void msRedactString(char* str, const char* keyword, const char delimeter)
+{
+    char* ptr = NULL;
+    char* password = NULL;
+
+    password = strstr(str, keyword);
+    if (password != NULL) {
+        char* ptr = password + strlen(keyword);
+        while (*ptr != '\0' && *ptr != delimeter) {
+            *ptr = '*';
+            ptr++;
+        }
+    }
+}
+
 void msRedactCredentials(char* str)
 {
 
-  char* ptr=NULL;
-  char* password=NULL;
-
-  password = strstr(str, "password=");
-  if (password != NULL) {
-    char* ptr = password + strlen("password=");
-    while (*ptr != '\0' && *ptr != ' ') {
-      *ptr = '*';
-      ptr++;
-    }
-  }
-
-  password = strstr(str, "pwd=");
-  if (password != NULL) {
-      ptr = password + strlen("pwd=");
-      while (*ptr != '\0' && *ptr != ' ') {
-          *ptr = '*';
-          ptr++;
-      }
-  }
-
+  // postgres formats
+  msRedactString(str, "password=", ' ');
+  // mssql use semi-colons as delimeters for parameters
+  msRedactString(str, "password=", ';');
+  // ODBC connections can use pwd rather than password
+  msRedactString(str, "pwd=", ';');
 }
 
 void msSetError(int code, const char *message_fmt, const char *routine, ...)

--- a/maperror.c
+++ b/maperror.c
@@ -331,7 +331,11 @@ char *msGetErrorString(const char *delimiter)
 
 void msRedactCredentials(char* str)
 {
-  char* password = strstr(str, "password=");
+
+  char* ptr=NULL;
+  char* password=NULL;
+
+  password = strstr(str, "password=");
   if (password != NULL) {
     char* ptr = password + strlen("password=");
     while (*ptr != '\0' && *ptr != ' ') {
@@ -339,6 +343,16 @@ void msRedactCredentials(char* str)
       ptr++;
     }
   }
+
+  password = strstr(str, "pwd=");
+  if (password != NULL) {
+      ptr = password + strlen("pwd=");
+      while (*ptr != '\0' && *ptr != ' ') {
+          *ptr = '*';
+          ptr++;
+      }
+  }
+
 }
 
 void msSetError(int code, const char *message_fmt, const char *routine, ...)

--- a/maperror.c
+++ b/maperror.c
@@ -331,10 +331,8 @@ char *msGetErrorString(const char *delimiter)
 
 void msRedactString(char* str, const char* keyword, const char delimeter)
 {
-    char* ptr = NULL;
-    char* password = NULL;
 
-    password = strstr(str, keyword);
+    char* password = strstr(str, keyword);
     if (password != NULL) {
         char* ptr = password + strlen(keyword);
         while (*ptr != '\0' && *ptr != delimeter) {

--- a/mapmssql2008.c
+++ b/mapmssql2008.c
@@ -991,35 +991,24 @@ int msMSSQL2008LayerOpen(layerObj *layer)
     if(!layerinfo->conn || layerinfo->conn->errorMessage[0]) {
       char *errMess = "Out of memory";
 
-      msDebug("FAILURE!!!");
-      maskeddata = (char *)msSmallMalloc(strlen(layer->connection) + 1);
-      strcpy(maskeddata, layer->connection);
-      index = strstr(maskeddata, "password=");
-      if(index != NULL) {
-        index = (char *)(index + 9);
-        count = (int)(strstr(index, " ") - index);
-        for(i = 0; i < count; i++) {
-          strlcpy(index, "*", (int)1);
-          index++;
-        }
-      }
+      if (layer->debug)
+          msDebug("MSMSSQL2008LayerOpen: Connection failure.\n");
 
       if (layerinfo->conn) {
         errMess = layerinfo->conn->errorMessage;
       }
 
-      msSetError(MS_QUERYERR,
-                 "Couldnt make connection to MS SQL Server 2008 with connect string '%s'.\n<br>\n"
-                 "Error reported was '%s'.\n<br>\n\n"
-                 "This error occured when trying to make a connection to the specified SQL server.  \n"
-                 "<br>\nMost commonly this is caused by <br>\n"
-                 "(1) incorrect connection string <br>\n"
-                 "(2) you didn't specify a 'user id=...' in your connection string <br>\n"
-                 "(3) SQL server isnt running <br>\n"
-                 "(4) TCPIP not enabled for SQL Client or server <br>\n\n",
-                 "msMSSQL2008LayerOpen()", maskeddata, errMess);
+      msDebug("Couldn't make connection to MS SQL Server with connect string '%s'.\n"
+                 "Error reported was '%s'.\n\n"
+                 "This error occured when trying to make a connection to the specified SQL server.\n"
+                 "Most commonly this is caused by \n"
+                 "(1) incorrect connection string \n"
+                 "(2) you didn't specify a 'user id=...' in your connection string \n"
+                 "(3) SQL server isnt running \n"
+                 "(4) TCPIP not enabled for SQL Client or server \n\n",
+                 errMess, layer->connection);
+      msSetError(MS_QUERYERR, "Database connection failed. Check server logs for more details.Is SQL Server running? Is it allowing connections? Does the specified user exist? Is the password valid? Is the database on the standard port?", "MSMSSQL2008LayerOpen()");
 
-      msFree(maskeddata);
       msMSSQL2008CloseConnection(layerinfo->conn);
       msFree(layerinfo);
       return MS_FAILURE;

--- a/mapmssql2008.c
+++ b/mapmssql2008.c
@@ -926,8 +926,6 @@ static int columnName(msODBCconn *conn, int index, char *buffer, int bufferLengt
 int msMSSQL2008LayerOpen(layerObj *layer)
 {
   msMSSQL2008LayerInfo  *layerinfo;
-  char                *index, *maskeddata;
-  int                 i, count;
   char *conn_decrypted = NULL;
 
   if(layer->debug) {
@@ -1001,13 +999,13 @@ int msMSSQL2008LayerOpen(layerObj *layer)
       msDebug("Couldn't make connection to MS SQL Server with connect string '%s'.\n"
                  "Error reported was '%s'.\n\n"
                  "This error occured when trying to make a connection to the specified SQL server.\n"
-                 "Most commonly this is caused by \n"
+                 "Most commonly this is caused by: \n"
                  "(1) incorrect connection string \n"
                  "(2) you didn't specify a 'user id=...' in your connection string \n"
                  "(3) SQL server isnt running \n"
                  "(4) TCPIP not enabled for SQL Client or server \n\n",
                  layer->connection, errMess);
-      msSetError(MS_QUERYERR, "Database connection failed. Check server logs for more details.Is SQL Server running? Is it allowing connections? Does the specified user exist? Is the password valid? Is the database on the standard port?", "MSMSSQL2008LayerOpen()");
+      msSetError(MS_QUERYERR, "Database connection failed. Check server logs for more details. Is SQL Server running? Is it allowing connections? Does the specified user exist? Is the password valid? Is the database on the standard port?", "MSMSSQL2008LayerOpen()");
 
       msMSSQL2008CloseConnection(layerinfo->conn);
       msFree(layerinfo);

--- a/mapmssql2008.c
+++ b/mapmssql2008.c
@@ -1006,7 +1006,7 @@ int msMSSQL2008LayerOpen(layerObj *layer)
                  "(2) you didn't specify a 'user id=...' in your connection string \n"
                  "(3) SQL server isnt running \n"
                  "(4) TCPIP not enabled for SQL Client or server \n\n",
-                 errMess, layer->connection);
+                 layer->connection, errMess);
       msSetError(MS_QUERYERR, "Database connection failed. Check server logs for more details.Is SQL Server running? Is it allowing connections? Does the specified user exist? Is the password valid? Is the database on the standard port?", "MSMSSQL2008LayerOpen()");
 
       msMSSQL2008CloseConnection(layerinfo->conn);


### PR DESCRIPTION
Pull request to address #6772. Similar to #6616. 

Currently the following text is sent to any client application if a MS SQL database connection fails:

```
msMSSQL2008LayerOpen(): Query error. Couldnt make connection to MS SQL Server 2008 with connect string 'SERVER=(local)\SQL2019;DATABASE=msautotest;uid=sa;pwd=Password12!;'.
<br>
Error reported was '[Microsoft][ODBC SQL Server Driver][DBMSLPCN]SQL Server does not exist or access denied.'.
<br>

This error occured when trying to make a connection to the specified SQL server.
<br>
Most commonly this is caused by <br>
(1) incorrect connection string <br>
(2) you didn't specify a 'user id=...' in your connection string <br>
(3) SQL server isnt running <br>
(4) TCPIP not enabled for SQL Client or server <br>
```

This update logs connection details, with `pwd` redacted, and reports a more generic error message to a client application, avoiding divulging the full connection string:

Error to client:

```
MSMSSQL2008LayerOpen(): Query error. Database connection failed. Check server logs for more details.Is SQL Server running? Is it allowing connections? Does the specified user exist? Is the password valid? Is the database on the standard port?
```

Logged in server logs:

```
[Tue Jan  3 21:20:19 2023].609000 Couldn't make connection to MS SQL Server with connect string 'SERVER=(local)\SQL2019;DATABASE=msautotest;uid=sa;pwd=******************** reported was '[Microsoft][ODBC SQL Server Driver][DBMSLPCN]SQL Server does not exist or access denied.'.

This error occured when trying to make a connection to the specified SQL server.
Most commonly this is caused by 
(1) incorrect connection string 
(2) you didn't specify a 'user id=...' in your connection string 
(3) SQL server isnt running 
(4) TCPIP not enabled for SQL Client or server
```

@rouault - I simply added another loop to the `msRedactCredentials` to check for `pwd`, maybe adding another function and calling it for each reserved word would be better?

Also as the loop replaces everything with asterisks up to the end of the string or a space there are a few perhaps undesired behaviours?

* `"SERVER=(local)\SQL2019;DATABASE=msautotest;uid=sa;pwd=Password12!;otherparameter=hello;"`

Logs the following, redacting the end parameters:

* 'SERVER=(local)\SQL2019;DATABASE=msautotest;uid=sa;pwd=*****************************************`

A space in the password reveals the rest of the password (I guess as this is the delimeter for Postgres connection strings):

* `"SERVER=(local)\SQL2019;DATABASE=msautotest;uid=sa;pwd=Passw ord12!;otherparameter=hello;"`

Logs:

* `'SERVER=(local)\SQL2019;DATABASE=msautotest;uid=sa;pwd=***** ord12!;otherparameter=hello;'`

Maybe passing a delimeter char to the function would be a possible solution? Or I could simply add a new MSSQL connection string redactor function to `mapmssql2008.c`?
