### PR TITLE
Optimise WFS requests by reducing fields selected

### DIFF
--- a/mapwfs.cpp
+++ b/mapwfs.cpp
@@ -2540,6 +2540,8 @@ this request. Check wfs/ows_enable_request settings.", "msWFSGetFeature()",
         layerObj *lp;
         lp = GET_LAYER(map, j);
         if (lp->status == MS_ON) {
+          // classes don't affect retrieval of features, so set the count to 0
+          // this avoids selecting any fields referenced in a CLASS from the data source
           lp->numclasses = 0;
           int status = msWFSRunBasicGetFeature(map, lp, paramsObj, nWFSVersion);
           if( status != MS_SUCCESS )

--- a/mapwfs.cpp
+++ b/mapwfs.cpp
@@ -2540,6 +2540,7 @@ this request. Check wfs/ows_enable_request settings.", "msWFSGetFeature()",
         layerObj *lp;
         lp = GET_LAYER(map, j);
         if (lp->status == MS_ON) {
+          lp->numclasses = 0;
           int status = msWFSRunBasicGetFeature(map, lp, paramsObj, nWFSVersion);
           if( status != MS_SUCCESS )
               return status;


### PR DESCRIPTION
Similar to #6131 and #6131 - this change avoids selecting fields from a database which aren't required. 

As discussed in the comments at https://github.com/MapServer/MapServer/pull/6131#issuecomment-675750118

> any fields referenced in a CLASS are selected at the database level even if never used for a WFS request (this was also the case in > my previous pull request) - I presume there is no way to get round this due to buildLayerItemList

Simply setting the number of classes to 0 prior to retrieving features from the database avoids adding in all fields referenced in CLASSes in a LAYER. For example if a layer has a CLASS similar to below then `Myfield` is added to the database `SELECT` query (in [buildLayerItemList](https://github.com/MapServer/MapServer/blob/8d6c9ecdd29c75b3976788a0d287860a922145c3/maplayer.c#L795):

```
        CLASS
            NAME "Example"
            EXPRESSION ( [Myfield] = 1)
            STYLE
            ...
            END
        END
```

Setting `numclasses ` to 0 avoids adding any of these fields in, which aren't required by a WFS query. 

In a sample application for a layer with lots of classes these can greatly reduce the number of fields requested from the database ,which are then discarded, and can show some significant performance improvements. 

I can't see any side-effects of this change, but I may be missing something. 