### PR TITLE
Optimise WMS requests by ignoring any fields that won't be used

### DIFF
--- a/maplayer.c
+++ b/maplayer.c
@@ -809,7 +809,13 @@ static void buildLayerItemList(layerObj *layer)
 
   /* layer classes */
   for(i=0; i<layer->numclasses; i++) {
-    
+
+    // if classgroup has been set we can ignore any fields required
+    // for rendering unused classes
+    if (layer->class[i]->group && layer->classgroup &&
+        strcasecmp(layer->class[i]->group, layer->classgroup) != 0)
+        continue;
+
     if(layer->class[i]->expression.type == MS_EXPRESSION) /* class expression */
       msTokenizeExpression(&(layer->class[i]->expression), layer->items, &(layer->numitems));
 


### PR DESCRIPTION
Similar to #6785 but for WMS requests. 

If a WMS request includes specific STYLES e.g. `&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&STYLES=MyStyle&TILED=false&LAYERS=MyLayer&` then MapServer sets the `CLASSGROUP` of the `LAYER` to the selected style. In this example `MyStyle`. 

The generic `buildLayerItemList` currently goes through all classes in a layer to find any references to fields (anything in [SquareBrackets]) and adds them to the SELECT clause sent to the datasource. 

This update checks if `CLASSGROUP` has been set, and if it has then ignores any `CLASS` that doesn't have a matching `GROUP` name. Fields in these unused classes aren't required and not selecting them can improve performance. This is most noticeable in layers which have many classes and groups. 

In my real-world test case the database SELECT query goes from selecting 21 fields to selecting 2, and due to the complex nature of the LAYER database view (from 2 seconds per view load to 0.1). 

Will see if any tests are broken by this change. GetFeatureInfo requests are ok as they always select all fields rather than building a list. 