### PR TITLE
doc: correct MS_SHP to MS_SHAPEFILE

### DIFF
--- a/mapscript/swiginc/shapefile.i
+++ b/mapscript/swiginc/shapefile.i
@@ -33,8 +33,8 @@
     * Create a new instance. Omit the type argument or use a value of -1 to open 
     * an existing shapefile.
     *
-    * Type should be one of :data:`MS_SHP_POINT`, :data:`MS_SHP_ARC`, 
-    * :data:`MS_SHP_POLYGON` or :data:`MS_SHP_MULTIPOINT`
+    * Type should be one of :data:`MS_SHAPEFILE_POINT`, :data:`MS_SHAPEFILE_ARC`,
+    * :data:`MS_SHAPEFILE_POLYGON` or :data:`MS_SHAPEFILE_MULTIPOINT`
     */
     shapefileObj(char *filename, int type=-1) 
     {    

--- a/mapscript/tcl/mapscript_wrap.html
+++ b/mapscript/tcl/mapscript_wrap.html
@@ -1898,19 +1898,19 @@ mapscript::ms_error_get </B></TT>
 <BLOCKQUOTE>[ Member : returns int  ]
 <BR></BLOCKQUOTE>
 
-<P><TT><B>mapscript::MS_SHP_POINT = 1</B></TT>
+<P><TT><B>mapscript::MS_SHAPEFILE_POINT = 1</B></TT>
 <BLOCKQUOTE>[ Constant : int  ]
 <BR></BLOCKQUOTE>
 
-<P><TT><B>mapscript::MS_SHP_ARC = 3</B></TT>
+<P><TT><B>mapscript::MS_SHAPEFILE_ARC = 3</B></TT>
 <BLOCKQUOTE>[ Constant : int  ]
 <BR></BLOCKQUOTE>
 
-<P><TT><B>mapscript::MS_SHP_POLYGON = 5</B></TT>
+<P><TT><B>mapscript::MS_SHAPEFILE_POLYGON = 5</B></TT>
 <BLOCKQUOTE>[ Constant : int  ]
 <BR></BLOCKQUOTE>
 
-<P><TT><B>mapscript::MS_SHP_MULTIPOINT = 8</B></TT>
+<P><TT><B>mapscript::MS_SHAPEFILE_MULTIPOINT = 8</B></TT>
 <BLOCKQUOTE>[ Constant : int  ]
 <BR></BLOCKQUOTE>
 


### PR DESCRIPTION
I believe the docs incorrectly reference `MS_SHP` vs `MS_SHAPEFILE` in two locations.  Certainly, `MS_SHP_POINT` is not defined in `mapshape.h`