### PR TITLE
ZIP OGR output: use CPLAddFileInZip() to be able to generate SOZip-enabled files

### DIFF
--- a/mapogroutput.cpp
+++ b/mapogroutput.cpp
@@ -1309,7 +1309,30 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
 
     for( i = 0; file_list != NULL && file_list[i] != NULL; i++ ) {
 
-      CPLCreateFileInZip( hZip, CPLGetFilename(file_list[i]), NULL );
+      const std::string osArchiveFilename(CPLGetFilename(file_list[i]));
+#if GDAL_VERSION_MAJOR > 3 || (GDAL_VERSION_MAJOR == 3 && GDAL_VERSION_MINOR >= 7)
+      if( CPLAddFileInZip(hZip, osArchiveFilename.c_str(), file_list[i],
+                          nullptr, nullptr, nullptr, nullptr) != CE_None )
+      {
+          msSetError( MS_MISCERR,
+                      "CPLAddFileInZip() failed for %s",
+                      "msOGRWriteFromQuery()",
+                      file_list[i] );
+          CPLCloseZip( hZip );
+          msOGRCleanupDS( datasource_name );
+          return MS_FAILURE;
+      }
+#else
+      if( CPLCreateFileInZip( hZip, osArchiveFilename.c_str(), NULL ) != CE_None )
+      {
+          msSetError( MS_MISCERR,
+                      "CPLWriteFileInZip() failed for %s",
+                      "msOGRWriteFromQuery()",
+                      file_list[i] );
+          CPLCloseZip( hZip );
+          msOGRCleanupDS( datasource_name );
+          return MS_FAILURE;
+      }
 
       fp = VSIFOpenL( file_list[i], "r" );
       if( fp == NULL ) {
@@ -1317,17 +1340,29 @@ int msOGRWriteFromQuery( mapObj *map, outputFormatObj *format, int sendheaders )
         msSetError( MS_MISCERR,
                     "Failed to open result file '%s'.",
                     "msOGRWriteFromQuery()",
-                    file_list[0] );
+                    file_list[i] );
         msOGRCleanupDS( datasource_name );
         return MS_FAILURE;
       }
 
       while( (bytes_read = VSIFReadL( buffer, 1, sizeof(buffer), fp )) > 0 ) {
-        CPLWriteFileInZip( hZip, buffer, bytes_read );
+        if( CPLWriteFileInZip( hZip, buffer, bytes_read ) != CE_None )
+        {
+            msSetError( MS_MISCERR,
+                        "CPLWriteFileInZip() failed for %s",
+                        "msOGRWriteFromQuery()",
+                        file_list[i] );
+            VSIFCloseL( fp );
+            CPLCloseFileInZip( hZip );
+            CPLCloseZip( hZip );
+            msOGRCleanupDS( datasource_name );
+            return MS_FAILURE;
+        }
       }
       VSIFCloseL( fp );
 
       CPLCloseFileInZip( hZip );
+#endif
     }
     CPLCloseZip( hZip );
 


### PR DESCRIPTION
Intro
------

A [Seek-Optimized (SOZip)](https://sozip.org) is a [ZIP](https://en.wikipedia.org/wiki/ZIP_(file_format)) file that contains one or several [Deflate](https://www.ietf.org/rfc/rfc1951.txt)-compressed files that are organized and annotated such that a SOZip-aware reader can perform very fast random access (seek) within a compressed file.

SOZip makes it possible to access large compressed files directly from a .zip file without prior decompression. It is not a new file format, but a profile of the existing ZIP format, done in a fully backward compatible way. ZIP readers that are non-SOZip aware can read a SOZip-enabled file normally and ignore the extended features that support efficient seek capability.

For more details, consult the [specification](https://github.com/sozip/sozip-spec/blob/master/sozip_specification.md) and the [announcement](https://github.com/sozip/sozip-spec/blob/master/blog/01-announcement.md)

Content of this pull request
------------------------------------

This pull request uses the CPLAddFileInZip() function, submitted for inclusion in GDAL 3.7 per https://github.com/OSGeo/gdal/pull/7042, to automatically generate SOZip-enabled files (if sufficiently large)