### PR TITLE
upgrade TravisCI to test PHP 8.2.x mapscript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,14 @@ matrix:
         - PYTHON_VERSION=3.7.13
         - CRYPTOGRAPHY_DONT_BUILD_RUST=1 # to avoid issue when building Cryptography python module (https://travis-ci.com/github/MapServer/MapServer/jobs/482212623)
 
-    - php: 8.0
-      env:
-        - BUILD_NAME=PHP_8.0
-        - PYTHON_VERSION=3.8
-
-    - php: 8.1.12
+    - php: 8.1
       env:
         - BUILD_NAME=PHP_8.1
+        - PYTHON_VERSION=3.8
+
+    - php: 8.2.0
+      env:
+        - BUILD_NAME=PHP_8.2
         - PYTHON_VERSION=3.9
 
 cache:

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -15,6 +15,7 @@ sudo apt-get install -y --allow-unauthenticated build-essential protobuf-c-compi
 sudo apt-get install -y --allow-unauthenticated libmono-system-drawing4.0-cil mono-mcs
 sudo apt-get install -y --allow-unauthenticated libperl-dev
 sudo apt-get install -y --allow-unauthenticated openjdk-8-jdk
+sudo apt-get install -y --allow-unauthenticated libonig5
 
 #install recent cmake on GH build action
 if [ -z ${TRAVIS+x} ]; then

--- a/msautotest/php/reprojectionObjTest.php
+++ b/msautotest/php/reprojectionObjTest.php
@@ -55,7 +55,7 @@ class reprojectionObjTest extends \PHPUnit\Framework\TestCase
     
     # destroy variables, if not can lead to segmentation fault
     public function tearDown(): void {
-        unset($reprojector, $this->reprojection, $this->map, $this->layer, $this->sourceProjection, $this->outputProjection, $point);
+        unset($reprojector, $this->map, $this->layer, $this->sourceProjection, $this->outputProjection, $point);
     }    
     
 }

--- a/msautotest/php/reprojectionObjTest.php
+++ b/msautotest/php/reprojectionObjTest.php
@@ -27,7 +27,7 @@ class reprojectionObjTest extends \PHPUnit\Framework\TestCase
     public function testReprojectionInstance()
     {
 
-        $this->assertInstanceOf("reprojectionObj",  $this->reprojection = new reprojectionObj( $this->sourceProjection,  $this->outputProjection ));
+        $this->assertInstanceOf("reprojectionObj", new reprojectionObj( $this->sourceProjection,  $this->outputProjection ));
     }
 
     public function testProjectMethodSpeed()


### PR DESCRIPTION
- this means tests will include PHP 7.4, 8.1, 8.2 (8.0 tests are dropped)
- even though PHP 7.4 is EOL, it is still the default for Ubuntu Focal, the host testing environment (so leaving 7.4 tests in, for now)