### PR TITLE
Add Proj and GDAL versions to MapServer version output

### DIFF
--- a/maperror.c
+++ b/maperror.c
@@ -538,9 +538,10 @@ char *msGetVersion()
 
   sprintf(version, "MapServer version %s", MS_VERSION);
 
-  static char projVersion[20];
-  sprintf(projVersion, " Proj version %d.%d", PROJ_VERSION_MAJOR, PROJ_VERSION_MINOR);
-  strcat(version, projVersion);
+  // add versions of required dependencies
+  static char PROJVersion[20];
+  sprintf(PROJVersion, " PROJ version %d.%d", PROJ_VERSION_MAJOR, PROJ_VERSION_MINOR);
+  strcat(version, PROJVersion);
 
   static char GDALVersion[20];
   sprintf(GDALVersion, " GDAL version %d.%d", GDAL_VERSION_MAJOR, GDAL_VERSION_MINOR);

--- a/maperror.c
+++ b/maperror.c
@@ -532,11 +532,19 @@ void msWriteErrorImage(mapObj *map, char *filename, int blank)
 
 char *msGetVersion()
 {
-  static char version[1024];
+  static char version[2048];
 
   if(CPLGetConfigOption("MS_NO_VERSION", NULL) != NULL) return ""; // supressing version information
 
   sprintf(version, "MapServer version %s", MS_VERSION);
+
+  static char projVersion[20];
+  sprintf(projVersion, " Proj version %d.%d", PROJ_VERSION_MAJOR, PROJ_VERSION_MINOR);
+  strcat(version, projVersion);
+
+  static char GDALVersion[20];
+  sprintf(GDALVersion, " GDAL version %d.%d", GDAL_VERSION_MAJOR, GDAL_VERSION_MINOR);
+  strcat(version, GDALVersion);
 
 #if (defined USE_PNG)
   strcat(version, " OUTPUT=PNG");


### PR DESCRIPTION
This pull request adds the version numbers of PROJ and GDAL to the version output for MapServer (using `mapserv -v` on the command line, and also present in some error messages). Both are required dependencies (at least since 8.0) so will always have a value. 

As different versions of PROJ and GDAL can have an impact on how MapServer behaves, and what is supported, it is useful to be able to easily access this information, and allow users to report it when having problems. 

The output will now look similar to the following:

```
MapServer version 8.1-dev PROJ version 7.2 GDAL version 3.4 OUTPUT=PNG 
OUTPUT=JPEG OUTPUT=KML SUPPORTS=PROJ SUPPORTS=AGG SUPPORTS=FREETYPE
SUPPORTS=CAIRO SUPPORTS=SVG_SYMBOLS SUPPORTS=SVGCAIRO SUPPORTS=ICONV 
SUPPORTS=FRIBIDI SUPPORTS=WMS_SERVER SUPPORTS=WMS_CLIENT SUPPORTS=WFS_SERVER
SUPPORTS=WFS_CLIENT SUPPORTS=WCS_SERVER SUPPORTS=SOS_SERVER
SUPPORTS=OGCAPI_SERVER SUPPORTS=FASTCGI SUPPORTS=THREADS
SUPPORTS=GEOS SUPPORTS=PBF INPUT=JPEG INPUT=POSTGIS
INPUT=OGR INPUT=GDAL INPUT=SHAPEFILE INPUT=FLATGEOBUF
```

Note the additional text - `PROJ version 7.2 GDAL version 3.4`. 

For production environments it is recommended that the `MS_NO_VERSION` environment variable is set to avoid these details being displayed to client applications:

https://github.com/MapServer/MapServer/blob/9209de5962ffc5287ab2c52f597b58f1751e2e1d/etc/mapserver-sample.conf#L42-L43