### PR TITLE
Small changes missed in the initial 8.0 release.

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -6470,7 +6470,9 @@ static void mapSubstituteString(mapObj *map, const char *from, const char *to) {
       map->outputformatlist[l]->formatoptions[o] = msCaseReplaceSubstring(map->outputformatlist[l]->formatoptions[o], from, to);
     }
   }
+
   hashTableSubstituteString(&map->web.metadata, from, to);
+  if(map->web.template) map->web.template = msCaseReplaceSubstring(map->web.template, from, to);
 }
 
 static void applyOutputFormatDefaultSubstitutions(outputFormatObj *format, const char *option, hashTableObj *table)

--- a/mapservutil.c
+++ b/mapservutil.c
@@ -1038,7 +1038,9 @@ int msCGILoadForm(mapservObj *mapserv)
       continue;
     }
 
-    if(strcasecmp(mapserv->request->ParamNames[i],"mapsize") == 0) { /* size of new map (pixels) */
+    /* size of new map (pixels), map.size/map_size are included for backwards compatibility and may be removed in future release */
+    if(strcasecmp(mapserv->request->ParamNames[i],"mapsize") == 0 ||
+       strcasecmp(mapserv->request->ParamNames[i],"map.size") == 0 || strcasecmp(mapserv->request->ParamNames[i],"map_size") == 0) {
       tokens = msStringSplit(mapserv->request->ParamValues[i], ' ', &n);
 
       if(!tokens) {


### PR DESCRIPTION
This does a couple of things discovered through various upgrade work (by myself and others):

1. Allows map.size and map_size CGI parameters as aliases for mapsize. Older versions of OpenLayers (OL) supported a OpenLayers.Layer.MapServer layer type that used an alias instead of just mapsize. This should allow using MapServer 8 without having to re-work an old OL interface.
2. Allows runtime substitution on the web TEMPLATE property.

--Steve