### PR TITLE
Check for DEBUG level before writing cache warnings to log

### DIFF
--- a/mapquery.c
+++ b/mapquery.c
@@ -177,9 +177,11 @@ static int canCacheShape(mapObj* map, queryCacheObj *queryCache, int shape_ram_s
       if( !queryCache->cachedShapeCountWarningEmitted )
       {
           queryCache->cachedShapeCountWarningEmitted = MS_TRUE;
-          msDebug("map->query.max_cached_shape_count = %d reached. "
+          if (map->debug >= MS_DEBUGLEVEL_V) {
+              msDebug("map->query.max_cached_shape_count = %d reached. "
                   "Next features will not be cached.\n",
                   map->query.max_cached_shape_count);
+          }
       }
       return MS_FALSE;
   }
@@ -190,10 +192,12 @@ static int canCacheShape(mapObj* map, queryCacheObj *queryCache, int shape_ram_s
       if( !queryCache->cachedShapeRAMWarningEmitted )
       {
           queryCache->cachedShapeRAMWarningEmitted = MS_TRUE;
-          msDebug("map->query.max_cached_shape_ram_amount = %d reached after %d cached features. "
+          if (map->debug >= MS_DEBUGLEVEL_V) {
+              msDebug("map->query.max_cached_shape_ram_amount = %d reached after %d cached features. "
                   "Next features will not be cached.\n",
                   map->query.max_cached_shape_ram_amount,
                   queryCache->cachedShapeCount);
+          }
       }
       return MS_FALSE;
   }


### PR DESCRIPTION
On a production server with feature caching the logs are currently filling up with lines similar to below:

```
[Mon Jan 23 09:15:24 2023].335000 map->query.max_cached_shape_count = 1000 reached. Next features will not be cached.
[Mon Jan 23 09:15:25 2023].190000 map->query.max_cached_shape_count = 1000 reached. Next features will not be cached.
[Mon Jan 23 09:15:26 2023].547000 map->query.max_cached_shape_count = 1000 reached. Next features will not be cached.
[Mon Jan 23 09:15:28 2023].588000 map->query.max_cached_shape_count = 1000 reached. Next features will not be cached.
[Mon Jan 23 09:15:29 2023].557000 map->query.max_cached_shape_count = 1000 reached. Next features will not be cached.
[Mon Jan 23 09:15:30 2023].604000 map->query.max_cached_shape_count = 1000 reached. Next features will not be cached.
[Mon Jan 23 09:15:31 2023].572000 map->query.max_cached_shape_count = 1000 reached. Next features will not be cached.
[Mon Jan 23 09:15:32 2023].567000 map->query.max_cached_shape_count = 1000 reached. Next features will not be cached.
[Mon Jan 23 09:15:33 2023].587000 map->query.max_cached_shape_count = 1000 reached. Next features will not be cached.
[Mon Jan 23 09:15:34 2023].673000 map->query.max_cached_shape_count = 1000 reached. Next features will not be cached.
```

This update checks for the `DEBUG` level of the map prior to writing these. It will need to be `MS_DEBUGLEVEL_V = 3` or above to include these. 