### PR TITLE
No longer output MS version numbers in client responses

### DIFF
--- a/maperror.c
+++ b/maperror.c
@@ -534,8 +534,6 @@ char *msGetVersion()
 {
   static char version[2048];
 
-  if(CPLGetConfigOption("MS_NO_VERSION", NULL) != NULL) return ""; // supressing version information
-
   sprintf(version, "MapServer version %s", MS_VERSION);
 
   // add versions of required dependencies

--- a/mapogcsos.c
+++ b/mapogcsos.c
@@ -1258,9 +1258,6 @@ int msSOSGetCapabilities(mapObj *map, sosParamsObj *sosparams, cgiRequestObj *re
   xsi_schemaLocation = msStringConcatenate(xsi_schemaLocation, "/sosGetCapabilities.xsd");
   xmlNewNsProp(psRootNode, NULL, BAD_CAST "xsi:schemaLocation", BAD_CAST xsi_schemaLocation);
 
-  const char *version = msGetVersion();
-  if(version[0] != '\0') xmlAddChild(psRootNode, xmlNewComment(BAD_CAST version));
-
   /*service identification*/
   xmlAddChild(psRootNode, msOWSCommonServiceIdentification(psNsOws, map, "SOS", pszSOSVersion, "SO", NULL));
 

--- a/mapservutil.c
+++ b/mapservutil.c
@@ -60,14 +60,11 @@ void msCGIWriteError(mapservObj *mapserv)
     return;
   }
 
-  const char *version = msGetVersion();
-
   if(!mapserv || !mapserv->map) {
     msIO_setHeader("Content-Type","text/html");
     msIO_sendHeaders();
     msIO_printf("<HTML>\n");
     msIO_printf("<HEAD><TITLE>MapServer Message</TITLE></HEAD>\n");
-    if(version[0] != '\0') msIO_printf("<!-- %s -->\n", version);
     msIO_printf("<BODY BGCOLOR=\"#FFFFFF\">\n");
     msWriteErrorXML(stdout);
     msIO_printf("</BODY></HTML>");
@@ -81,7 +78,6 @@ void msCGIWriteError(mapservObj *mapserv)
       msIO_sendHeaders();
       msIO_printf("<HTML>\n");
       msIO_printf("<HEAD><TITLE>MapServer Message</TITLE></HEAD>\n");
-      if(version[0] != '\0') msIO_printf("<!-- %s -->\n", version);
       msIO_printf("<BODY BGCOLOR=\"#FFFFFF\">\n");
       msWriteErrorXML(stdout);
       msIO_printf("</BODY></HTML>");
@@ -94,7 +90,6 @@ void msCGIWriteError(mapservObj *mapserv)
         msIO_sendHeaders();
         msIO_printf("<HTML>\n");
         msIO_printf("<HEAD><TITLE>MapServer Message</TITLE></HEAD>\n");
-        if(version[0] != '\0') msIO_printf("<!-- %s -->\n", version);
         msIO_printf("<BODY BGCOLOR=\"#FFFFFF\">\n");
         msWriteErrorXML(stdout);
         msIO_printf("</BODY></HTML>");
@@ -104,7 +99,6 @@ void msCGIWriteError(mapservObj *mapserv)
       msIO_sendHeaders();
       msIO_printf("<HTML>\n");
       msIO_printf("<HEAD><TITLE>MapServer Message</TITLE></HEAD>\n");
-      if(version[0] != '\0') msIO_printf("<!-- %s -->\n", version);
       msIO_printf("<BODY BGCOLOR=\"#FFFFFF\">\n");
       msWriteErrorXML(stdout);
       msIO_printf("</BODY></HTML>");

--- a/mapwfs.cpp
+++ b/mapwfs.cpp
@@ -820,10 +820,6 @@ int msWFSGetCapabilities(mapObj *map, wfsParamsObj *wfsparams, cgiRequestObj *re
               wmtver, updatesequence ? updatesequence : "0",
               msOWSGetSchemasLocation(map), wmtver);
 
-  /* Report MapServer Version Information */
-  const char *version = msGetVersion();
-  if(version[0] != '\0') msIO_printf("\n<!-- %s -->\n\n", version);
-
   /*
   ** SERVICE definition
   */

--- a/mapwms.cpp
+++ b/mapwms.cpp
@@ -2900,12 +2900,6 @@ int msWMSGetCapabilities(mapObj *map, int nVersion, cgiRequestObj *req, owsReque
 
   msIO_printf(">\n");
 
-
-
-  /* Report MapServer Version Information */
-  const char *version = msGetVersion();
-  if(version[0] != '\0') msIO_printf("\n<!-- %s -->\n\n", version);
-
   /* WMS definition */
   msIO_printf("<Service>\n");
 

--- a/msautotest/api/expected/ogcapi_invalid_api_signature1.txt
+++ b/msautotest/api/expected/ogcapi_invalid_api_signature1.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msCGIDispatchAPIRequest(): Web application error. Invalid API signature.
 </BODY></HTML>

--- a/msautotest/api/expected/ogcapi_invalid_api_signature2.txt
+++ b/msautotest/api/expected/ogcapi_invalid_api_signature2.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msCGIDispatchAPIRequest(): Web application error. Invalid API signature.
 </BODY></HTML>

--- a/msautotest/api/expected/ogcapi_invalid_mapfile.txt
+++ b/msautotest/api/expected/ogcapi_invalid_mapfile.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msLoadMap(): Unable to access file. (invalid.map)
 </BODY></HTML>

--- a/msautotest/api/expected/ogcapi_missing_api_signature1.txt
+++ b/msautotest/api/expected/ogcapi_missing_api_signature1.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msCGILoadMap(): Web application error. CGI variable &quot;map&quot; is not set.
 </BODY></HTML>

--- a/msautotest/api/expected/ogcapi_missing_api_signature2.txt
+++ b/msautotest/api/expected/ogcapi_missing_api_signature2.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msCGILoadMap(): Web application error. CGI variable &quot;map&quot; is not set.
 </BODY></HTML>

--- a/msautotest/config/expected/empty1_conf.txt
+++ b/msautotest/config/expected/empty1_conf.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msLoadConfig(): Unknown identifier. First token must be CONFIG, this doesn&#39;t look like a mapserver config file.
 </BODY></HTML>

--- a/msautotest/config/expected/empty2_conf.txt
+++ b/msautotest/config/expected/empty2_conf.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msCGILoadMap(): Web application error. Required configuration value MS_MAP_PATTERN not set.
 </BODY></HTML>

--- a/msautotest/config/expected/invalid1_conf.txt
+++ b/msautotest/config/expected/invalid1_conf.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msLoadConfig(): Unknown identifier. Parsing error near (INVALID):(line 2)
 </BODY></HTML>

--- a/msautotest/config/expected/invalid2_conf.txt
+++ b/msautotest/config/expected/invalid2_conf.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msLoadConfig(): Premature End-of-File. 
 </BODY></HTML>

--- a/msautotest/config/expected/missing_conf.txt
+++ b/msautotest/config/expected/missing_conf.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msLoadConfig(): Unable to access file. See mapserver.org/mapfile/config.html for more information.
 </BODY></HTML>

--- a/msautotest/config/expected/ms_map_no_path1_conf.txt
+++ b/msautotest/config/expected/ms_map_no_path1_conf.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msCGILoadMap(): Web application error. CGI variable &quot;map&quot; not found in configuration and this server is not configured for full paths.
 </BODY></HTML>

--- a/msautotest/config/expected/ms_map_no_path2_conf_failure1.txt
+++ b/msautotest/config/expected/ms_map_no_path2_conf_failure1.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msCGILoadMap(): Web application error. CGI variable &quot;map&quot; not found in configuration and this server is not configured for full paths.
 </BODY></HTML>

--- a/msautotest/config/expected/ms_map_no_path2_conf_failure2.txt
+++ b/msautotest/config/expected/ms_map_no_path2_conf_failure2.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msCGILoadMap(): Web application error. CGI variable &quot;map&quot; not found in configuration and this server is not configured for full paths.
 </BODY></HTML>

--- a/msautotest/config/expected/ms_map_pattern_conf.txt
+++ b/msautotest/config/expected/ms_map_pattern_conf.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msCGILoadMap(): Web application error. CGI variable &quot;map&quot; fails to validate.
 </BODY></HTML>

--- a/msautotest/config/expected/ms_map_pattern_conf_bad_regex.txt
+++ b/msautotest/config/expected/ms_map_pattern_conf_bad_regex.txt
@@ -1,7 +1,8 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msCGILoadMap(): Web application error. CGI variable &quot;map&quot; fails to validate.
 msEvalRegex(): Regular expression error. Failed to compile expression ([A-Z*).
 </BODY></HTML>

--- a/msautotest/config/expected/ms_no_post_conf_failure.txt
+++ b/msautotest/config/expected/ms_no_post_conf_failure.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 loadParams(): Web application error. This script should be referenced with a METHOD of GET or METHOD of POST.
 </BODY></HTML>

--- a/msautotest/config/expected/ms_no_version_conf.txt
+++ b/msautotest/config/expected/ms_no_version_conf.txt
@@ -3,5 +3,5 @@ Content-Type: text/html
 <HTML>
 <HEAD><TITLE>MapServer Message</TITLE></HEAD>
 <BODY BGCOLOR="#FFFFFF">
-msCGILoadMap(): Web application error. CGI variable &quot;map&quot; not found in configuration and this server is not configured for full paths.
+msLoadConfig(): Unable to access file. See mapserver.org/mapfile/config.html for more information.
 </BODY></HTML>

--- a/msautotest/config/expected/ms_no_version_conf.txt
+++ b/msautotest/config/expected/ms_no_version_conf.txt
@@ -1,7 +1,0 @@
-Content-Type: text/html
-
-<HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD>
-<BODY BGCOLOR="#FFFFFF">
-msLoadConfig(): Unable to access file. See mapserver.org/mapfile/config.html for more information.
-</BODY></HTML>

--- a/msautotest/config/hello_world.map
+++ b/msautotest/config/hello_world.map
@@ -13,7 +13,6 @@
 # RUN_PARMS: ms_map_pattern_conf_bad_regex.txt [MAPSERV] -conf ms_map_pattern_bad_regex.conf QUERY_STRING="map=[MAPFILE]&mode=map" > [RESULT_DEVERSION]
 # RUN_PARMS: ms_no_post_conf_success.png [MAPSERV] -conf ms_no_post.conf QUERY_STRING="map=HELLO_WORLD&mode=map" > [RESULT_DEMIME]
 # RUN_PARMS: ms_no_post_conf_failure.txt [MAPSERV] -conf ms_no_post.conf [POST]map=HELLO_WORLD&mode=map[/POST] > [RESULT_DEVERSION]
-# RUN_PARMS: ms_no_version_conf.txt [MAPSERV] -conf ms_no_version.conf QUERY_STRING="map=TRIGGER_ERROR&mode=map" > [RESULT]
 
 MAP
   NAME 'hello_world'

--- a/msautotest/config/ms_no_version.conf
+++ b/msautotest/config/ms_no_version.conf
@@ -1,9 +1,0 @@
-CONFIG
-  ENV
-    MS_NO_VERSION "1"
-    MS_MAP_NO_PATH "1"
-  END
-  MAPS
-    HELLO_WORLD "hello_world.map"
-  END
-END

--- a/msautotest/misc/expected/centerline3_exception.txt
+++ b/msautotest/misc/expected/centerline3_exception.txt
@@ -1,7 +1,8 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msDrawMap(): Image handling error. Failed to draw layer named &#39;centerline3&#39;.
 msGeomTransformShape(): Expression parser error. Failed to process shape expression: centerline([shape])
 yyparse(): Expression parser error. Executing centerline failed.

--- a/msautotest/misc/expected/centerline4_exception.txt
+++ b/msautotest/misc/expected/centerline4_exception.txt
@@ -1,7 +1,8 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msDrawMap(): Image handling error. Failed to draw layer named &#39;centerline4&#39;.
 msGeomTransformShape(): Expression parser error. Failed to process shape expression: centerline([shape])
 yyparse(): Expression parser error. Executing centerline failed.

--- a/msautotest/misc/expected/centerline5_exception.txt
+++ b/msautotest/misc/expected/centerline5_exception.txt
@@ -1,7 +1,8 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msDrawMap(): Image handling error. Failed to draw layer named &#39;centerline5&#39;.
 msGeomTransformShape(): Expression parser error. Failed to process shape expression: centerline(densify([shape],-5))
 yyparse(): Expression parser error. Executing densify failed.

--- a/msautotest/misc/expected/flatgeobuf-wfs-cap.xml
+++ b/msautotest/misc/expected/flatgeobuf-wfs-cap.xml
@@ -8,7 +8,6 @@ Content-Type: text/xml; charset=UTF-8
    xmlns:ogc="http://www.opengis.net/ogc" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-capabilities.xsd">
-
 <Service>
   <Name>MapServer WFS</Name>
   <Title>Test FlatGeobuf WFS output</Title>

--- a/msautotest/misc/expected/runtime_sub_test001.txt
+++ b/msautotest/misc/expected/runtime_sub_test001.txt
@@ -1,7 +1,8 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msDrawMap(): Image handling error. Failed to draw layer named &#39;layer1&#39;.
 [stripped line matching "ShapefileOpen"]
 [stripped line matching "ShapefileOpen"]

--- a/msautotest/misc/expected/runtime_sub_test003.txt
+++ b/msautotest/misc/expected/runtime_sub_test003.txt
@@ -1,7 +1,8 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msDrawMap(): Image handling error. Failed to draw layer named &#39;layer2&#39;.
 [stripped line matching "ShapefileOpen"]
 [stripped line matching "ShapefileOpen"]

--- a/msautotest/misc/expected/runtime_sub_test005.txt
+++ b/msautotest/misc/expected/runtime_sub_test005.txt
@@ -1,7 +1,8 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msDrawMap(): Image handling error. Failed to draw layer named &#39;layer3&#39;.
 [stripped line matching "ShapefileOpen"]
 [stripped line matching "ShapefileOpen"]

--- a/msautotest/misc/expected/runtime_sub_test_caps.xml
+++ b/msautotest/misc/expected/runtime_sub_test_caps.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://foo/?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
 <!-- WARNING: Mandatory metadata "wms_title" or "ows_title" was missing in this context. -->

--- a/msautotest/renderers/expected/font-fail-file.txt
+++ b/msautotest/renderers/expected/font-fail-file.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msGetFontFace(): General error message. Freetype was unable to load font file &quot;/path/to/inexistant/file.ttf&quot; for key &quot;bogus&quot;
 </BODY></HTML>

--- a/msautotest/renderers/expected/font-fail-key.txt
+++ b/msautotest/renderers/expected/font-fail-key.txt
@@ -1,6 +1,7 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msGetFontFace(): General error message. Could not find font with key &quot;foobar&quot; in fontset
 </BODY></HTML>

--- a/msautotest/renderers/expected/legend_bad_imagetype.txt
+++ b/msautotest/renderers/expected/legend_bad_imagetype.txt
@@ -1,7 +1,8 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 msCGILoadForm(): Web application error. Invalid imagetype value.
 
 </BODY></HTML>

--- a/msautotest/wxs/expected/ows_all_wms_capabilities.xml
+++ b/msautotest/wxs/expected/ows_all_wms_capabilities.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="123"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/ows?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
 <!-- WARNING: Mandatory metadata "wms_title" or "ows_title" was missing in this context. -->

--- a/msautotest/wxs/expected/ows_all_wms_capabilities_post.xml
+++ b/msautotest/wxs/expected/ows_all_wms_capabilities_post.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="123"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/ows?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
 <!-- WARNING: Mandatory metadata "wms_title" or "ows_title" was missing in this context. -->

--- a/msautotest/wxs/expected/ows_context_caps.xml
+++ b/msautotest/wxs/expected/ows_context_caps.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Map Context demo</Title>

--- a/msautotest/wxs/expected/ows_metadata_wfs_capabilities100.xml
+++ b/msautotest/wxs/expected/ows_metadata_wfs_capabilities100.xml
@@ -8,7 +8,6 @@ Content-Type: text/xml; charset=UTF-8
    xmlns:ogc="http://www.opengis.net/ogc" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-capabilities.xsd">
-
 <Service>
   <Name>MapServer WFS</Name>
   <Title>Test simple OWS</Title>

--- a/msautotest/wxs/expected/ows_metadata_wms_capabilities111.xml
+++ b/msautotest/wxs/expected/ows_metadata_wms_capabilities111.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1" updateSequence="123">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Test simple OWS</Title>

--- a/msautotest/wxs/expected/ows_metadata_wms_capabilities130.xml
+++ b/msautotest/wxs/expected/ows_metadata_wms_capabilities130.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="123"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/ows?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>Test simple OWS</Title>

--- a/msautotest/wxs/expected/ows_wms_capabilities.xml
+++ b/msautotest/wxs/expected/ows_wms_capabilities.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/ows?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
 <!-- WARNING: Mandatory metadata "wms_title" or "ows_title" was missing in this context. -->

--- a/msautotest/wxs/expected/ows_wms_rootlayer_name_capabilities.xml
+++ b/msautotest/wxs/expected/ows_wms_rootlayer_name_capabilities.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/ows?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
 <!-- WARNING: Mandatory metadata "wms_title" or "ows_title" was missing in this context. -->

--- a/msautotest/wxs/expected/ows_wms_rootlayer_name_empty_capabilities.xml
+++ b/msautotest/wxs/expected/ows_wms_rootlayer_name_empty_capabilities.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/ows?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
 <!-- WARNING: Mandatory metadata "wms_title" or "ows_title" was missing in this context. -->

--- a/msautotest/wxs/expected/sos_cap.xml
+++ b/msautotest/wxs/expected/sos_cap.xml
@@ -2,7 +2,7 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <sos:Capabilities xmlns:gml="http://www.opengis.net/gml" xmlns:om="http://www.opengis.net/om/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:swe="http://www.opengis.net/swe/1.0.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ogc="http://www.opengis.net/ogc" xmlns:sos="http://www.opengis.net/sos/1.0" version="1.0.0" updateSequence="foo" xsi:schemaLocation="http://www.opengis.net/sos/1.0 http://schemas.opengis.net/sos/1.0.0/sosGetCapabilities.xsd">
-   <ows:ServiceIdentification>
+  <ows:ServiceIdentification>
     <ows:Title>Test SOS Title</ows:Title>
     <ows:Abstract>Test SOS Abstract</ows:Abstract>
     <ows:Keywords>

--- a/msautotest/wxs/expected/sos_cap0.xml
+++ b/msautotest/wxs/expected/sos_cap0.xml
@@ -2,7 +2,7 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <sos:Capabilities xmlns:gml="http://www.opengis.net/gml" xmlns:om="http://www.opengis.net/om/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:swe="http://www.opengis.net/swe/1.0.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ogc="http://www.opengis.net/ogc" xmlns:sos="http://www.opengis.net/sos/1.0" version="1.0.0" updateSequence="foo" xsi:schemaLocation="http://www.opengis.net/sos/1.0 http://schemas.opengis.net/sos/1.0.0/sosGetCapabilities.xsd">
-   <ows:ServiceIdentification>
+  <ows:ServiceIdentification>
     <ows:Title>Test SOS Title</ows:Title>
     <ows:Abstract>Test SOS Abstract</ows:Abstract>
     <ows:Keywords>

--- a/msautotest/wxs/expected/sos_cap1.xml
+++ b/msautotest/wxs/expected/sos_cap1.xml
@@ -2,7 +2,7 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <sos:Capabilities xmlns:gml="http://www.opengis.net/gml" xmlns:om="http://www.opengis.net/om/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:swe="http://www.opengis.net/swe/1.0.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ogc="http://www.opengis.net/ogc" xmlns:sos="http://www.opengis.net/sos/1.0" version="1.0.0" updateSequence="foo" xsi:schemaLocation="http://www.opengis.net/sos/1.0 http://schemas.opengis.net/sos/1.0.0/sosGetCapabilities.xsd">
-   <ows:ServiceIdentification>
+  <ows:ServiceIdentification>
     <ows:Title>Test SOS Title</ows:Title>
     <ows:Abstract>Test SOS Abstract</ows:Abstract>
     <ows:Keywords>

--- a/msautotest/wxs/expected/sos_caps_updatesequence.xml
+++ b/msautotest/wxs/expected/sos_caps_updatesequence.xml
@@ -2,7 +2,7 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <sos:Capabilities xmlns:gml="http://www.opengis.net/gml" xmlns:om="http://www.opengis.net/om/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:swe="http://www.opengis.net/swe/1.0.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ogc="http://www.opengis.net/ogc" xmlns:sos="http://www.opengis.net/sos/1.0" version="1.0.0" updateSequence="foo" xsi:schemaLocation="http://www.opengis.net/sos/1.0 http://schemas.opengis.net/sos/1.0.0/sosGetCapabilities.xsd">
-   <ows:ServiceIdentification>
+  <ows:ServiceIdentification>
     <ows:Title>Test SOS Title</ows:Title>
     <ows:Abstract>Test SOS Abstract</ows:Abstract>
     <ows:Keywords>

--- a/msautotest/wxs/expected/wfs10_test_xml_escaping.xml
+++ b/msautotest/wxs/expected/wfs10_test_xml_escaping.xml
@@ -6,7 +6,6 @@
    xmlns:ogc="http://www.opengis.net/ogc" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-capabilities.xsd">
-
 <Service>
   <Name>MapServer WFS</Name>
   <Title>title &amp; title</Title>

--- a/msautotest/wxs/expected/wfs_cap.xml
+++ b/msautotest/wxs/expected/wfs_cap.xml
@@ -8,7 +8,6 @@ Content-Type: text/xml; charset=UTF-8
    xmlns:ogc="http://www.opengis.net/ogc" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-capabilities.xsd">
-
 <Service>
   <Name>MapServer WFS</Name>
   <Title>Test simple wfs</Title>

--- a/msautotest/wxs/expected/wfs_cap_ogr.xml
+++ b/msautotest/wxs/expected/wfs_cap_ogr.xml
@@ -8,7 +8,6 @@ Content-Type: text/xml; charset=UTF-8
    xmlns:ogc="http://www.opengis.net/ogc" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-capabilities.xsd">
-
 <Service>
   <Name>MapServer WFS</Name>
   <Title>Test simple wfs</Title>

--- a/msautotest/wxs/expected/wfs_caps_updatesequence.xml
+++ b/msautotest/wxs/expected/wfs_caps_updatesequence.xml
@@ -8,7 +8,6 @@ Content-Type: text/xml; charset=UTF-8
    xmlns:ogc="http://www.opengis.net/ogc" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-capabilities.xsd">
-
 <Service>
   <Name>MapServer WFS</Name>
   <Title>Test simple wfs</Title>

--- a/msautotest/wxs/expected/wfs_caps_updatesequence_ogr.xml
+++ b/msautotest/wxs/expected/wfs_caps_updatesequence_ogr.xml
@@ -8,7 +8,6 @@ Content-Type: text/xml; charset=UTF-8
    xmlns:ogc="http://www.opengis.net/ogc" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-capabilities.xsd">
-
 <Service>
   <Name>MapServer WFS</Name>
   <Title>Test simple wfs</Title>

--- a/msautotest/wxs/expected/wfs_get_caps.xml
+++ b/msautotest/wxs/expected/wfs_get_caps.xml
@@ -8,7 +8,6 @@ Content-Type: text/xml; charset=UTF-8
    xmlns:ogc="http://www.opengis.net/ogc" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-capabilities.xsd">
-
 <Service>
   <Name>MapServer WFS</Name>
   <Title>Sample OWS for MapServer OGC Web Services Workshop</Title>

--- a/msautotest/wxs/expected/wfs_multiple_metadataurl_100_cap.xml
+++ b/msautotest/wxs/expected/wfs_multiple_metadataurl_100_cap.xml
@@ -8,7 +8,6 @@ Content-Type: text/xml; charset=UTF-8
    xmlns:ogc="http://www.opengis.net/ogc" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-capabilities.xsd">
-
 <Service>
   <Name>MapServer WFS</Name>
   <Title>Test simple wfs</Title>

--- a/msautotest/wxs/expected/wfs_ogr_drv_nocreatedatasource_caps.xml
+++ b/msautotest/wxs/expected/wfs_ogr_drv_nocreatedatasource_caps.xml
@@ -1,7 +1,8 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 loadOutputFormat(): General error message. OUTPUTFORMAT (nocreatedatasource) clause references driver (OGR/SDTS), but this driver isn&#39;t configured.
 msInitDefaultOGROutputFormat(): General error message. OGR `SDTS&#39; driver does not support output.
 </BODY></HTML>

--- a/msautotest/wxs/expected/wfs_ogr_nonexistingdrv_caps.xml
+++ b/msautotest/wxs/expected/wfs_ogr_nonexistingdrv_caps.xml
@@ -1,7 +1,8 @@
 Content-Type: text/html
 
 <HTML>
-<HEAD><TITLE>MapServer Message</TITLE></HEAD><BODY BGCOLOR="#FFFFFF">
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
 loadOutputFormat(): General error message. OUTPUTFORMAT (nonexistingdrv) clause references driver (OGR/nonexistingdrv), but this driver isn&#39;t configured.
 msInitDefaultOGROutputFormat(): General error message. No OGR driver named `nonexistingdrv&#39; available.
 </BODY></HTML>

--- a/msautotest/wxs/expected/wfsogr10_caps.xml
+++ b/msautotest/wxs/expected/wfsogr10_caps.xml
@@ -8,7 +8,6 @@ Content-Type: text/xml; charset=UTF-8
    xmlns:ogc="http://www.opengis.net/ogc" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-capabilities.xsd">
-
 <Service>
   <Name>MapServer WFS</Name>
   <Title>Test simple wfs</Title>

--- a/msautotest/wxs/expected/wms111_test_xml_escaping.xml
+++ b/msautotest/wxs/expected/wms111_test_xml_escaping.xml
@@ -5,7 +5,6 @@
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1" updateSequence="123">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>title &amp; title</Title>

--- a/msautotest/wxs/expected/wms130_test_xml_escaping.xml
+++ b/msautotest/wxs/expected/wms130_test_xml_escaping.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="123"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/ows_test_xml_escaping?myparam=something&amp;service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>title &amp; title</Title>

--- a/msautotest/wxs/expected/wms_cap.xml
+++ b/msautotest/wxs/expected/wms_cap.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1" updateSequence="123">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_cap130.xml
+++ b/msautotest/wxs/expected/wms_cap130.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="123"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wms_simple?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_cap130_postgis.xml
+++ b/msautotest/wxs/expected/wms_cap130_postgis.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="123"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wms_simple?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_cap_latestversion.xml
+++ b/msautotest/wxs/expected/wms_cap_latestversion.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="123"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wms_simple?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_cap_latestversion_postgis.xml
+++ b/msautotest/wxs/expected/wms_cap_latestversion_postgis.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="123"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wms_simple?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_cap_postgis.xml
+++ b/msautotest/wxs/expected/wms_cap_postgis.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1" updateSequence="123">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_caps_updatesequence.xml
+++ b/msautotest/wxs/expected/wms_caps_updatesequence.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1" updateSequence="123">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_caps_updatesequence_postgis.xml
+++ b/msautotest/wxs/expected/wms_caps_updatesequence_postgis.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1" updateSequence="123">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_dimension_cap.xml
+++ b/msautotest/wxs/expected/wms_dimension_cap.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.0">
-
 <Service>
   <Name>OGC:WMS</Name>
 <!-- WARNING: Mandatory metadata "wms_title" or "ows_title" was missing in this context. -->

--- a/msautotest/wxs/expected/wms_dimension_cap130.xml
+++ b/msautotest/wxs/expected/wms_dimension_cap130.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/mswms?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
 <!-- WARNING: Mandatory metadata "wms_title" or "ows_title" was missing in this context. -->

--- a/msautotest/wxs/expected/wms_empty_cap100.xml
+++ b/msautotest/wxs/expected/wms_empty_cap100.xml
@@ -5,7 +5,6 @@
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.0.0">
-
 <Service>
   <Name>GetMap</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_empty_cap111.xml
+++ b/msautotest/wxs/expected/wms_empty_cap111.xml
@@ -5,7 +5,6 @@
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_empty_cap130.xml
+++ b/msautotest/wxs/expected/wms_empty_cap130.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wms_empty?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_empty_cap_latestversion.xml
+++ b/msautotest/wxs/expected/wms_empty_cap_latestversion.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wms_empty?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_get_capabilities_tileindexmixedsrs.xml
+++ b/msautotest/wxs/expected/wms_get_capabilities_tileindexmixedsrs.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.0">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>title</Title>

--- a/msautotest/wxs/expected/wms_get_caps.xml
+++ b/msautotest/wxs/expected/wms_get_caps.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1" updateSequence="123">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Sample OWS for MapServer OGC Web Services Workshop</Title>

--- a/msautotest/wxs/expected/wms_inspire_cap.xml
+++ b/msautotest/wxs/expected/wms_inspire_cap.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0"   xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0/inspire_vs.xsd http://mapserver.gis.umn.edu/mapserver http://www.geodaten-mv.de/dienste/inspirevs_test?language=ger&amp;service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>INSPIRE Testdienst</Title>

--- a/msautotest/wxs/expected/wms_inspire_cap_111.xml
+++ b/msautotest/wxs/expected/wms_inspire_cap_111.xml
@@ -5,7 +5,6 @@
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>INSPIRE Testdienst</Title>

--- a/msautotest/wxs/expected/wms_inspire_cap_111_eng.xml
+++ b/msautotest/wxs/expected/wms_inspire_cap_111_eng.xml
@@ -5,7 +5,6 @@
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>INSPIRE test service</Title>

--- a/msautotest/wxs/expected/wms_inspire_cap_111_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_cap_111_ger.xml
@@ -5,7 +5,6 @@
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>INSPIRE Testdienst</Title>

--- a/msautotest/wxs/expected/wms_inspire_cap_eng.xml
+++ b/msautotest/wxs/expected/wms_inspire_cap_eng.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0"   xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0/inspire_vs.xsd http://mapserver.gis.umn.edu/mapserver http://www.geodaten-mv.de/dienste/inspirevs_test?language=eng&amp;service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>INSPIRE test service</Title>

--- a/msautotest/wxs/expected/wms_inspire_cap_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_cap_ger.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0"   xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0/inspire_vs.xsd http://mapserver.gis.umn.edu/mapserver http://www.geodaten-mv.de/dienste/inspirevs_test?language=ger&amp;service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>INSPIRE Testdienst</Title>

--- a/msautotest/wxs/expected/wms_inspire_scenario1_cap130.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario1_cap130.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="myupdatesequence"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0"   xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0/inspire_vs.xsd http://mapserver.gis.umn.edu/mapserver http://path/to/onlineresource...?language=eng&amp;service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>myservicetitle</Title>

--- a/msautotest/wxs/expected/wms_inspire_scenario1_cap130_eng.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario1_cap130_eng.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="myupdatesequence"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0"   xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0/inspire_vs.xsd http://mapserver.gis.umn.edu/mapserver http://path/to/onlineresource...?language=eng&amp;service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>myservicetitle</Title>

--- a/msautotest/wxs/expected/wms_inspire_scenario1_cap130_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario1_cap130_ger.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="myupdatesequence"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0"   xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0/inspire_vs.xsd http://mapserver.gis.umn.edu/mapserver http://path/to/onlineresource...?language=ger&amp;service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>myservicetitleger</Title>

--- a/msautotest/wxs/expected/wms_inspire_scenario2_cap111.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario2_cap111.xml
@@ -5,7 +5,6 @@
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1" updateSequence="myupdatesequence">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>myservicetitle</Title>

--- a/msautotest/wxs/expected/wms_inspire_scenario2_cap111_eng.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario2_cap111_eng.xml
@@ -5,7 +5,6 @@
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1" updateSequence="myupdatesequence">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>myservicetitle</Title>

--- a/msautotest/wxs/expected/wms_inspire_scenario2_cap111_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario2_cap111_ger.xml
@@ -5,7 +5,6 @@
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1" updateSequence="myupdatesequence">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>myservicetitleger</Title>

--- a/msautotest/wxs/expected/wms_inspire_scenario2_cap130.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario2_cap130.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="myupdatesequence"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0"   xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0/inspire_vs.xsd http://mapserver.gis.umn.edu/mapserver http://path/to/onlineresource...?language=eng&amp;service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>myservicetitle</Title>

--- a/msautotest/wxs/expected/wms_inspire_scenario2_cap130_eng.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario2_cap130_eng.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="myupdatesequence"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0"   xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0/inspire_vs.xsd http://mapserver.gis.umn.edu/mapserver http://path/to/onlineresource...?language=eng&amp;service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>myservicetitle</Title>

--- a/msautotest/wxs/expected/wms_inspire_scenario2_cap130_ger.xml
+++ b/msautotest/wxs/expected/wms_inspire_scenario2_cap130_ger.xml
@@ -1,6 +1,5 @@
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="myupdatesequence"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0"   xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs/1.0"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0  http://inspire.ec.europa.eu/schemas/inspire_vs/1.0/inspire_vs.xsd http://mapserver.gis.umn.edu/mapserver http://path/to/onlineresource...?language=ger&amp;service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>myservicetitleger</Title>

--- a/msautotest/wxs/expected/wms_layer_groups_caps111.xml
+++ b/msautotest/wxs/expected/wms_layer_groups_caps111.xml
@@ -5,7 +5,6 @@
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1">
-
 <Service>
   <Name>OGC:WMS</Name>
 <!-- WARNING: Mandatory metadata "wms_title" or "ows_title" was missing in this context. -->

--- a/msautotest/wxs/expected/wms_multiple_metadataurl_cap.xml
+++ b/msautotest/wxs/expected/wms_multiple_metadataurl_cap.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1" updateSequence="123">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_north_polar_stereo_extent.xml
+++ b/msautotest/wxs/expected/wms_north_polar_stereo_extent.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wms_simple?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_nosld_cap.xml
+++ b/msautotest/wxs/expected/wms_nosld_cap.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_nosld_cap_postgis.xml
+++ b/msautotest/wxs/expected/wms_nosld_cap_postgis.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_rast_cap.xml
+++ b/msautotest/wxs/expected/wms_rast_cap.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.1" updateSequence="123">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Test simple wms</Title>

--- a/msautotest/wxs/expected/wms_time_cap.xml
+++ b/msautotest/wxs/expected/wms_time_cap.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.0" updateSequence="123">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Test WMS time support</Title>

--- a/msautotest/wxs/expected/wms_time_cap130.xml
+++ b/msautotest/wxs/expected/wms_time_cap130.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="123"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://ogc.dmsolutions.ca/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://ogc.dmsolutions.ca/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/mswms_time?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>Test WMS time support</Title>

--- a/msautotest/wxs/expected/wms_time_cap130_postgis_postgis.xml
+++ b/msautotest/wxs/expected/wms_time_cap130_postgis_postgis.xml
@@ -2,7 +2,6 @@ Content-Type: text/xml; charset=UTF-8
 
 <?xml version='1.0' encoding="UTF-8" standalone="no" ?>
 <WMS_Capabilities version="1.3.0" updateSequence="123"  xmlns="http://www.opengis.net/wms"   xmlns:sld="http://www.opengis.net/sld"   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"   xsi:schemaLocation="http://www.opengis.net/wms http://ogc.dmsolutions.ca/wms/1.3.0/capabilities_1_3_0.xsd  http://www.opengis.net/sld http://ogc.dmsolutions.ca/sld/1.1.0/sld_capabilities.xsd  http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/mswms_time?service=WMS&amp;version=1.3.0&amp;request=GetSchemaExtension">
-
 <Service>
   <Name>WMS</Name>
   <Title>Test WMS time support</Title>

--- a/msautotest/wxs/expected/wms_time_cap_postgis_postgis.xml
+++ b/msautotest/wxs/expected/wms_time_cap_postgis_postgis.xml
@@ -7,7 +7,6 @@ Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
  ]>  <!-- end of DOCTYPE declaration -->
 
 <WMT_MS_Capabilities version="1.1.0" updateSequence="123">
-
 <Service>
   <Name>OGC:WMS</Name>
   <Title>Test WMS time support</Title>


### PR DESCRIPTION
Arising from discussions at #6794 and on the [dev mailing list](https://lists.osgeo.org/pipermail/mapserver-dev/2023-January/016910.html) - this pull request removes MapServer version information from being sent in responses. 

Currently, version information such as that below is added to XML responses such as WMS Get Capabilities responses, and any error responses:

```
<!-- MapServer version 8.0.0 OUTPUT=PNG OUTPUT=JPEG OUTPUT=KML SUPPORTS=PROJ SUPPORTS=AGG SUPPORTS=FREETYPE SUPPORTS=CAIRO SUPPORTS=SVG_SYMBOLS SUPPORTS=RSVG SUPPORTS=ICONV SUPPORTS=FRIBIDI SUPPORTS=WMS_SERVER SUPPORTS=WMS_CLIENT SUPPORTS=WFS_SERVER SUPPORTS=WFS_CLIENT SUPPORTS=WCS_SERVER SUPPORTS=SOS_SERVER SUPPORTS=OGCAPI_SERVER SUPPORTS=FASTCGI SUPPORTS=GEOS SUPPORTS=PBF INPUT=JPEG INPUT=POSTGIS INPUT=OGR INPUT=GDAL INPUT=SHAPEFILE INPUT=FLATGEOBUF -->
```

This can be suppressed by setting the `ENV` variable `MS_NO_VERSION`, but by default versions are sent. If this pull request is merged, then `MS_NO_VERSION` is no longer used in the codebase and can be removed from the docs. 

Version information will still be available from all command line applications (`map2img`, `mapserver -v` etc.). 
It will also be available using [Templates](https://mapserver.org/mapfile/template.html#general) and the `[version]` tag. This will allow an admin to create their own server configuration pages if required. 

As a result of these changes, the `[RESULT_DEVERSION]` tag is no longer required for the msautotests and the function in [mstestlib.py](https://github.com/MapServer/MapServer/blob/8f88dcde2b1f2fd3832e8496847272b03aa8eeb1/msautotest/pymod/mstestlib.py#L186) is no longer required. 

One effect of this change is that the tests that used `[RESULT_DEVERSION]` stripped the version but not any additional lines added by inserting the version number. These expected results have been updated. 

A future pull request could address removing the `[RESULT_DEVERSION]` tag from all test cases. 
