### PR TITLE
[WMS] Do not require STYLES= in GetFeatureInfo request (fixes #6812)

### DIFF
--- a/mapwms.cpp
+++ b/mapwms.cpp
@@ -1776,8 +1776,7 @@ this request. Check wms/ows_enable_request settings.",
     }
 
     if (styles == nullptr && sld_url == nullptr && sld_body == nullptr &&
-        (strcasecmp(request, "GetMap") == 0 ||
-         strcasecmp(request, "GetFeatureInfo") == 0) &&
+        strcasecmp(request, "GetMap") == 0 &&
         msOWSLookupMetadata(&(map->web.metadata), "M",
                             "allow_getmap_without_styles") == nullptr) {
       msSetError(MS_WMSERR,

--- a/msautotest/wxs/wms_getfeatureinfo_encoding.map
+++ b/msautotest/wxs/wms_getfeatureinfo_encoding.map
@@ -4,7 +4,7 @@
 # REQUIRES: SUPPORTS=WMS
 # 
 # Check that WMS GetFeatureInfo response in GML format are encoded
-# RUN_PARMS: wms_getfeatureinfo_encoding.xml [MAPSERV] "QUERY_STRING=map=[MAPFILE]&service=WMS&request=GetFeatureInfo&version=1.3.0&CRS=EPSG:3857&width=200&height=200&layers=encoding_layer&bbox=-20,-20,20,20&format=image/png&query_layers=encoding_layer&i=100&j=100&&info_format=gml&styles=" > [RESULT_DEMIME]
+# RUN_PARMS: wms_getfeatureinfo_encoding.xml [MAPSERV] "QUERY_STRING=map=[MAPFILE]&service=WMS&request=GetFeatureInfo&version=1.3.0&CRS=EPSG:3857&width=200&height=200&layers=encoding_layer&bbox=-20,-20,20,20&format=image/png&query_layers=encoding_layer&i=100&j=100&&info_format=gml" > [RESULT_DEMIME]
 
 MAP
     IMAGETYPE png

--- a/msautotest/wxs/wms_getfeatureinfo_lon_wrap_180.map
+++ b/msautotest/wxs/wms_getfeatureinfo_lon_wrap_180.map
@@ -3,8 +3,8 @@
 #
 # REQUIRES: SUPPORTS=WMS
 # 
-# RUN_PARMS: wms_getfeatureinfo_lon_wrap_180_right_part_raster.xml [MAPSERV] "QUERY_STRING=map=[MAPFILE]&service=WMS&request=GetFeatureInfo&version=1.3.0&CRS=EPSG:4326&width=200&height=200&layers=test&bbox=-90,-90,90,90&format=image/png&query_layers=test&i=50&j=100&STYLES=" > [RESULT_DEMIME]
-# RUN_PARMS: wms_getfeatureinfo_lon_wrap_180_left_part_raster.xml [MAPSERV] "QUERY_STRING=map=[MAPFILE]&service=WMS&request=GetFeatureInfo&version=1.3.0&CRS=EPSG:4326&width=200&height=200&layers=test&bbox=-90,-90,90,90&format=image/png&query_layers=test&i=150&j=100&STYLES=" > [RESULT_DEMIME]
+# RUN_PARMS: wms_getfeatureinfo_lon_wrap_180_right_part_raster.xml [MAPSERV] "QUERY_STRING=map=[MAPFILE]&service=WMS&request=GetFeatureInfo&version=1.3.0&CRS=EPSG:4326&width=200&height=200&layers=test&bbox=-90,-90,90,90&format=image/png&query_layers=test&i=50&j=100" > [RESULT_DEMIME]
+# RUN_PARMS: wms_getfeatureinfo_lon_wrap_180_left_part_raster.xml [MAPSERV] "QUERY_STRING=map=[MAPFILE]&service=WMS&request=GetFeatureInfo&version=1.3.0&CRS=EPSG:4326&width=200&height=200&layers=test&bbox=-90,-90,90,90&format=image/png&query_layers=test&i=150&j=100" > [RESULT_DEMIME]
 
 MAP
 


### PR DESCRIPTION
This constraint was wrongly added in 8.0 per https://github.com/MapServer/MapServer/pull/6039