### PR TITLE
Fix GetMetadata possible buffer overrun

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ check_function_exists("strlen"  HAVE_STRLEN)
 check_function_exists("strncasecmp"  HAVE_STRNCASECMP)
 
 check_symbol_exists(vsnprintf stdio.h HAVE_VSNPRINTF)
-IF(NOT HAVE_SNPRINTF)
+IF(NOT HAVE_VSNPRINTF)
     check_function_exists("vsnprintf"  HAVE_VSNPRINTF)
 ENDIF()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ check_function_exists("strlcpy"  HAVE_STRLCPY)
 check_function_exists("strlen"  HAVE_STRLEN)
 check_function_exists("strncasecmp"  HAVE_STRNCASECMP)
 
-check_symbol_exists(vsnprintf stdio.h HAVE_SNPRINTF)
+check_symbol_exists(vsnprintf stdio.h HAVE_VSNPRINTF)
 IF(NOT HAVE_SNPRINTF)
     check_function_exists("vsnprintf"  HAVE_VSNPRINTF)
 ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ endif("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
 
 include(CheckLibraryExists)
 include(CheckFunctionExists)
+include(CheckSymbolExists)
 include(CheckIncludeFile)
 include(CheckCSourceCompiles)
 
@@ -119,7 +120,12 @@ check_function_exists("strlcat"  HAVE_STRLCAT)
 check_function_exists("strlcpy"  HAVE_STRLCPY)
 check_function_exists("strlen"  HAVE_STRLEN)
 check_function_exists("strncasecmp"  HAVE_STRNCASECMP)
-check_function_exists("vsnprintf"  HAVE_VSNPRINTF)
+
+check_symbol_exists(vsnprintf stdio.h HAVE_SNPRINTF)
+IF(NOT HAVE_SNPRINTF)
+    check_function_exists("vsnprintf"  HAVE_VSNPRINTF)
+ENDIF()
+
 check_function_exists("lrintf" HAVE_LRINTF)
 check_function_exists("lrint" HAVE_LRINT)
 

--- a/mapmetadata.c
+++ b/mapmetadata.c
@@ -828,7 +828,7 @@ int msMetadataDispatch(mapObj *map, cgiRequestObj *cgi_request)
 
     context = msIO_getHandler(stdout);
 
-    xmlDocDumpFormatMemory(xml_document, &xml_buffer, &buffersize, "UTF-8", 1);
+    xmlDocDumpFormatMemoryEnc(xml_document, &xml_buffer, &buffersize, "UTF-8", 1);
     msIO_contextWrite(context, xml_buffer, buffersize);
 
     xmlFree(xml_buffer);

--- a/mapmetadata.c
+++ b/mapmetadata.c
@@ -821,11 +821,15 @@ int msMetadataDispatch(mapObj *map, cgiRequestObj *cgi_request)
     int buffersize = 0;
     xmlDocSetRootElement(xml_document, psRootNode);
 
-    msIO_setHeader("Content-type", "text/xml");
+    msIO_setHeader("Content-type", "text/xml; charset=UTF-8");
     msIO_sendHeaders();
 
-    xmlDocDumpFormatMemory(xml_document, &xml_buffer, &buffersize, 1);
-    msIO_printf("%s", (char *) xml_buffer);
+    msIOContext* context = NULL;
+
+    context = msIO_getHandler(stdout);
+
+    xmlDocDumpFormatMemory(xml_document, &xml_buffer, &buffersize, "UTF-8", 1);
+    msIO_contextWrite(context, xml_buffer, buffersize);
 
     xmlFree(xml_buffer);
   }

--- a/msautotest/mssql/expected/cluster_mssql_getmetadata.xml
+++ b/msautotest/mssql/expected/cluster_mssql_getmetadata.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd">
   <gmd:fileIdentifier>
     <gco:CharacterString>cities</gco:CharacterString>

--- a/msautotest/wxs/expected/ows_metadata_empty_layer_param.xml
+++ b/msautotest/wxs/expected/ows_metadata_empty_layer_param.xml
@@ -1,6 +1,6 @@
 Content-type: text/xml
 
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" version="1.1.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">
   <ows:Exception exceptionCode="MissingParameterValue" locator="layer">
     <ows:ExceptionText>Missing layer parameter</ows:ExceptionText>

--- a/msautotest/wxs/expected/ows_metadata_empty_layer_param.xml
+++ b/msautotest/wxs/expected/ows_metadata_empty_layer_param.xml
@@ -1,4 +1,4 @@
-Content-type: text/xml
+Content-type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" version="1.1.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">

--- a/msautotest/wxs/expected/ows_metadata_invalid_layer_param.xml
+++ b/msautotest/wxs/expected/ows_metadata_invalid_layer_param.xml
@@ -1,4 +1,4 @@
-Content-type: text/xml
+Content-type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" version="1.1.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">

--- a/msautotest/wxs/expected/ows_metadata_invalid_layer_param.xml
+++ b/msautotest/wxs/expected/ows_metadata_invalid_layer_param.xml
@@ -1,6 +1,6 @@
 Content-type: text/xml
 
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" version="1.1.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">
   <ows:Exception exceptionCode="InvalidParameterValue" locator="layer">
     <ows:ExceptionText>Layer not found</ows:ExceptionText>

--- a/msautotest/wxs/expected/ows_metadata_layer_raster.xml
+++ b/msautotest/wxs/expected/ows_metadata_layer_raster.xml
@@ -1,4 +1,4 @@
-Content-type: text/xml
+Content-type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd">

--- a/msautotest/wxs/expected/ows_metadata_layer_raster.xml
+++ b/msautotest/wxs/expected/ows_metadata_layer_raster.xml
@@ -1,6 +1,6 @@
 Content-type: text/xml
 
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd">
   <gmd:fileIdentifier>
     <gco:CharacterString>toronto</gco:CharacterString>

--- a/msautotest/wxs/expected/ows_metadata_layer_vector.xml
+++ b/msautotest/wxs/expected/ows_metadata_layer_vector.xml
@@ -1,4 +1,4 @@
-Content-type: text/xml
+Content-type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd">

--- a/msautotest/wxs/expected/ows_metadata_layer_vector.xml
+++ b/msautotest/wxs/expected/ows_metadata_layer_vector.xml
@@ -1,6 +1,6 @@
 Content-type: text/xml
 
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd">
   <gmd:fileIdentifier>
     <gco:CharacterString>province</gco:CharacterString>

--- a/msautotest/wxs/expected/ows_metadata_missing_layer_param.xml
+++ b/msautotest/wxs/expected/ows_metadata_missing_layer_param.xml
@@ -1,6 +1,6 @@
 Content-type: text/xml
 
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" version="1.1.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">
   <ows:Exception exceptionCode="MissingParameterValue" locator="layer">
     <ows:ExceptionText>Missing layer parameter</ows:ExceptionText>

--- a/msautotest/wxs/expected/ows_metadata_missing_layer_param.xml
+++ b/msautotest/wxs/expected/ows_metadata_missing_layer_param.xml
@@ -1,4 +1,4 @@
-Content-type: text/xml
+Content-type: text/xml; charset=UTF-8
 
 <?xml version="1.0" encoding="UTF-8"?>
 <ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows/1.1" version="1.1.0" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/1.1 http://schemas.opengis.net/ows/1.1.0/owsExceptionReport.xsd">


### PR DESCRIPTION
As part of updating Appveyor to the new GDAL/PROJ SDK one of the MS SQL Server tests was failing relating to a `GetMetadata` request:

> mapserv -nh "QUERY_STRING=map=C:/projects/mapserver/msautotest/mssql/cluster_mssql.map&REQUEST=GetMetadata&LAYER=cities"

Caused the following: `msIO_vfprintf(): General error message. Possible buffer overrun.`

Note on Windows (or at least Appveyor and a local machine) `HAVE_VSNPRINTF` is false. 

Only similar issue is #2599 - the string to write is larger than the buffer. Looking at other functions that write XML I tried the approach used for WFS 2.0 which fixed the issue. 

https://github.com/MapServer/MapServer/blob/68fd623eddc772137952509a8008209a02cd1e85/mapwfs20.c#L729-L736

Note this also updates the output to use UTF-8 (which is probably what we want for consistency?). 

I've no idea why updating GDAL or PROJ would cause this test to fail though (when fixed the output XML was identical apart from the UTF-8 tag added by the update) - if anyone can provide any insights I'd appreciate it.

Also there are several instances where `xmlDocDumpFormatMemoryEnc` is followed by `msIO_printf`. Are these also at reisk of buffer overruns and should they be changed to `msIO_contextWrite`?

