### PR TITLE
Don't use deprecated distutils module.

### DIFF
--- a/mapscript/python/tests/timing/testing.py
+++ b/mapscript/python/tests/timing/testing.py
@@ -39,7 +39,7 @@
 
 import os
 import sys
-import distutils.util
+import sysconfig
 import unittest
 
 # define the path to mapserver test data
@@ -50,7 +50,7 @@ XMARKS_IMAGE = os.path.join(TESTS_PATH, 'xmarks.png')
 TEST_IMAGE = os.path.join(TESTS_PATH, 'test.png')
 
 # Put local build directory on head of python path
-platformdir = '-'.join((distutils.util.get_platform(), 
+platformdir = '-'.join((sysconfig.get_platform(), 
                         '.'.join(map(str, sys.version_info[0:2]))))
 sys.path.insert(0, os.path.join('build', 'lib.' + platformdir))
 


### PR DESCRIPTION
`mapscript/python/tests/timing/testing.py` still uses the deprecated distutils which will be removed in Python 3.12.

From [What’s New In Python 3.10](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated):
> The entire `distutils` package is deprecated, to be removed in Python 3.12. Its functionality for specifying package builds has already been completely replaced by third-party packages `setuptools` and `packaging`, and most other commonly used APIs are available elsewhere in the standard library (such as [platform](https://docs.python.org/3/library/platform.html#module-platform), [shutil](https://docs.python.org/3/library/shutil.html#module-shutil), [subprocess](https://docs.python.org/3/library/subprocess.html#module-subprocess) or [sysconfig](https://docs.python.org/3/library/sysconfig.html#module-sysconfig)). There are no plans to migrate any other functionality from distutils, and applications that are using other functions should plan to make private copies of the code. Refer to [PEP 632](https://peps.python.org/pep-0632/) for discussion.

[Porting from Distutils](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html#prefer-setuptools) has no suggestions for `distutils.util`, but [`sysconfig.get_platform()`](https://docs.python.org/3/library/sysconfig.html#sysconfig.get_platform) is a good alternative.