### PR TITLE
appveyor.yml: remove support for testing python 2.7 builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,6 @@ environment:
   # VS 2019
   VS_VERSION: Visual Studio 16 2019
   matrix:
-  - platform: x86
-    Python_ROOT_DIR: c:/python27
-  - platform: x64
-    Python_ROOT_DIR: c:/python27-x64
   - platform: x64
     Python_ROOT_DIR: c:/python36-x64
   - platform: x64


### PR DESCRIPTION
Python 2.7 is out-of-life for more than 3 years now...