### PR TITLE
loadLayer(): fix memory leak in case of error in loadLayerCompositer()

### DIFF
--- a/mapfile.c
+++ b/mapfile.c
@@ -4071,7 +4071,7 @@ int loadLayer(layerObj *layer, mapObj *map)
         LayerCompositer *compositer = msSmallMalloc(sizeof(LayerCompositer));
         initLayerCompositer(compositer);
         if(MS_FAILURE == loadLayerCompositer(compositer)) {
-          msFree(compositer);
+          freeLayerCompositer(compositer);
           return -1;
           }
         if(!layer->compositer) {


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57056