### PR TITLE
fix write of CONNECTIONOPTIONS (fixes #6852)

### DIFF
--- a/mapcopy.c
+++ b/mapcopy.c
@@ -1121,6 +1121,7 @@ int msCopyLayer(layerObj *dst, const layerObj *src)
     msCopyHashTable(&(dst->metadata), &(src->metadata));
   }
   msCopyHashTable(&dst->validation,&src->validation);
+  msCopyHashTable(&dst->connectionoptions,&src->connectionoptions);
 
   MS_COPYSTELEM(debug);
 

--- a/mapfile.c
+++ b/mapfile.c
@@ -4507,7 +4507,7 @@ static void writeLayer(FILE *stream, int indent, layerObj *layer)
   writeLayerCompositer(stream, indent, layer->compositer);
   writeString(stream, indent, "CONNECTION", NULL, layer->connection);
   writeKeyword(stream, indent, "CONNECTIONTYPE", layer->connectiontype, 12, MS_OGR, "OGR", MS_POSTGIS, "POSTGIS", MS_WMS, "WMS", MS_ORACLESPATIAL, "ORACLESPATIAL", MS_WFS, "WFS", MS_PLUGIN, "PLUGIN", MS_UNION, "UNION", MS_UVRASTER, "UVRASTER", MS_CONTOUR, "CONTOUR", MS_KERNELDENSITY, "KERNELDENSITY", MS_IDW, "IDW", MS_FLATGEOBUF, "FLATGEOBUF");
-  writeHashTableInline(stream, indent, "CONNECTIONOPTIONS", &(layer->connectionoptions));
+  writeHashTable(stream, indent, "CONNECTIONOPTIONS", &(layer->connectionoptions));
   writeString(stream, indent, "DATA", NULL, layer->data);
   writeNumber(stream, indent, "DEBUG", 0, layer->debug); /* is this right? see loadLayer() */
   writeString(stream, indent, "ENCODING", NULL, layer->encoding);

--- a/mapscript/swiginc/class.i
+++ b/mapscript/swiginc/class.i
@@ -96,7 +96,13 @@
     classObj *cloneClass() 
 #else
     %newobject clone;
-    /// Return an independent copy of the class without a parent layer
+    /**
+    Return an independent copy of the class without a parent layer
+
+    .. note::
+
+        In the Java & PHP modules this method is named ``cloneClass``.    
+    */ 
     classObj *clone() 
 #endif
     {

--- a/mapscript/swiginc/layer.i
+++ b/mapscript/swiginc/layer.i
@@ -103,6 +103,10 @@
     %newobject clone;
     /**
     Return an independent copy of the layer with no parent map.
+
+    .. note::
+
+        In the Java & PHP modules this method is named ``cloneLayer``.    
     */
     layerObj *clone() 
 #endif

--- a/mapscript/swiginc/map.i
+++ b/mapscript/swiginc/map.i
@@ -74,11 +74,11 @@
 #else
     %newobject clone;
     /**
-    Returns a independent copy of the map, less any caches.
+    Return an independent copy of the map, less any caches.
 
     .. note::
 
-        In the Java module this method is named ``cloneMap``.
+        In the Java & PHP modules this method is named ``cloneMap``.
     */
     mapObj *clone() 
 #endif

--- a/mapscript/swiginc/shape.i
+++ b/mapscript/swiginc/shape.i
@@ -119,7 +119,13 @@
     shapeObj *cloneShape()
 #else
     %newobject clone;
-    /// Return an independent copy of the shape.
+    /**
+    Return an independent copy of the shape.
+
+    .. note::
+
+        In the Java & PHP modules this method is named ``cloneShape``.    
+    */    
     shapeObj *clone()
 #endif
     {

--- a/mapscript/swiginc/style.i
+++ b/mapscript/swiginc/style.i
@@ -95,7 +95,13 @@
     styleObj *cloneStyle() 
 #else
     %newobject clone;
-    /// Returns an independent copy of the style with no parent class. 
+    /**
+    Return an independent copy of the style with no parent class.
+
+    .. note::
+
+        In the Java & PHP modules this method is named ``cloneStyle``.    
+    */ 
     styleObj *clone() 
 #endif
     {


### PR DESCRIPTION
- tested with MS4W and PHP 8.1 on Windows
- (it helped by examining the initial commit for this at https://github.com/MapServer/MapServer/pull/5883/ )
- the layer is now written out as:
  ```
    CONNECTIONOPTIONS
      "xxx"	"xxx"
    END # CONNECTIONOPTIONS
 ```