### PR TITLE
mapfile parser: fix double-free when included file doesn't exist

### DIFF
--- a/maplexer.c
+++ b/maplexer.c
@@ -4418,16 +4418,16 @@ YY_RULE_SETUP
                                                    return(-1);
                                                  }
 
-                                                 include_stack[include_stack_ptr] = YY_CURRENT_BUFFER; /* save state */
-                                                 include_lineno[include_stack_ptr] = msyylineno;
-                                                 include_stack_ptr++;
-
                                                  msyyin = fopen(msBuildPath(path, msyybasepath, msyytext), "r");
                                                  if(!msyyin) {
                                                    msSetError(MS_IOERR, "Error opening included file \"%s\".", "msyylex()", msyytext);
                                                    msyyin = YY_CURRENT_BUFFER->yy_input_file;
                                                    return(-1);
                                                  }
+
+                                                 include_stack[include_stack_ptr] = YY_CURRENT_BUFFER; /* save state */
+                                                 include_lineno[include_stack_ptr] = msyylineno;
+                                                 include_stack_ptr++;
 
                                                  msyy_switch_to_buffer( msyy_create_buffer(msyyin, YY_BUF_SIZE) );
                                                  msyylineno = 1;

--- a/maplexer.l
+++ b/maplexer.l
@@ -655,16 +655,16 @@ char path[MS_MAXPATHLEN];
                                                    return(-1);
                                                  }
 
-                                                 include_stack[include_stack_ptr] = YY_CURRENT_BUFFER; /* save state */
-                                                 include_lineno[include_stack_ptr] = msyylineno;
-                                                 include_stack_ptr++;
-
                                                  msyyin = fopen(msBuildPath(path, msyybasepath, msyytext), "r");
                                                  if(!msyyin) {
                                                    msSetError(MS_IOERR, "Error opening included file \"%s\".", "msyylex()", msyytext);
                                                    msyyin = YY_CURRENT_BUFFER->yy_input_file;
                                                    return(-1);
                                                  }
+
+                                                 include_stack[include_stack_ptr] = YY_CURRENT_BUFFER; /* save state */
+                                                 include_lineno[include_stack_ptr] = msyylineno;
+                                                 include_stack_ptr++;
 
                                                  msyy_switch_to_buffer( msyy_create_buffer(msyyin, YY_BUF_SIZE) );
                                                  msyylineno = 1;


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57788