### PR TITLE
CMake: Check compiler type for MSVC speicific option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,8 +293,10 @@ if(WIN32)
   set(REGEX_MALLOC 1)
   set(USE_GENERIC_MS_NINT 1)
   set(HAVE_STRING_H 0)
-  # Suppress warnings for regex.c
-  set_source_files_properties(${REGEX_SOURCES} PROPERTIES COMPILE_FLAGS /w)
+  if(MSVC)
+    # Suppress warnings for regex.c
+    set_source_files_properties(${REGEX_SOURCES} PROPERTIES COMPILE_FLAGS /w)
+  endif(MSVC)
 else(WIN32)
   set(REGEX_SOURCES "")
 endif(WIN32)


### PR DESCRIPTION

    The '/w' option is specific to MSVC in Windows. So, check the compiler
    type before adding that compiler flag. This fixes the following error
    in mingw toolchain.

    cc: error: no such file or directory: '/w'

