### PR TITLE
cmake: Define STDC_HEADERS for regex in mingw toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,10 @@ if(WIN32)
     # Suppress warnings for regex.c
     set_source_files_properties(${REGEX_SOURCES} PROPERTIES COMPILE_FLAGS /w)
   endif(MSVC)
+  if(MINGW)
+    # mingw provides stdlib.h
+    add_definitions(-DSTDC_HEADERS=1)
+  endif(MINGW)
 else(WIN32)
   set(REGEX_SOURCES "")
 endif(WIN32)


### PR DESCRIPTION

    Defining STDC_HEADERS macro includes stdlib.h in regex.c which is
    required for free, abort etc. function declarations. This fixes the
    following compiler error with mingw clang.

    regex.c:2042:3: error: call to undeclared library function 'free' with type
    'void (void *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    regex.c:2784:11: error: call to undeclared library function 'abort' with type
    'void (void) __attribute__((noreturn))'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]

