### PR TITLE
Fix routine name in msDrawLineSymbol error message

### DIFF
--- a/maprendering.c
+++ b/maprendering.c
@@ -661,7 +661,7 @@ line_cleanup:
     } else if( MS_RENDERER_IMAGEMAP(image->format) )
       msDrawLineSymbolIM(map, image, p, style, scalefactor);
     else {
-      msSetError(MS_RENDERERERR, "unsupported renderer", "msDrawShadeSymbol()");
+      msSetError(MS_RENDERERERR, "unsupported renderer", "msDrawLineSymbol()");
       status = MS_FAILURE;
     }
   } else {


### PR DESCRIPTION
The wrong routine name is reported in `msDrawLineSymbol`. 