### PR TITLE
Output doxygen comments in Python MapScript module

### DIFF
--- a/mapscript/python/CMakeLists.txt
+++ b/mapscript/python/CMakeLists.txt
@@ -10,8 +10,9 @@ include_directories(${PROJECT_SOURCE_DIR}/mapscript/python)
 
 set(SwigFile ${PROJECT_SOURCE_DIR}/mapscript/mapscript.i)
 
-# add annotations to py file output - requires >= SWIG 4.1
+# add and comments annotations to py file output - requires >= SWIG 4.1
 if (WITH_PYMAPSCRIPT_ANNOTATIONS AND ${Python_VERSION_MAJOR} GREATER_EQUAL 3)
+  set_property(SOURCE ${SwigFile} APPEND PROPERTY SWIG_FLAGS -doxygen)
   if (${Python_VERSION_MINOR} GREATER_EQUAL 6)
      set_property(SOURCE ${SwigFile} APPEND PROPERTY SWIG_FLAGS -features python:annotations=c)
   else ()


### PR DESCRIPTION
An oversight on my part - the MapScript comments were not added to the Python module. This pull request fixes that, and I'll make an update to the docs shortly to correct this for the 8.0.1 release. 