### PR TITLE
Add WFS Client Test

### DIFF
--- a/msautotest/wxs/expected/wfs_client_100.xml
+++ b/msautotest/wxs/expected/wfs_client_100.xml
@@ -1,0 +1,52 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd 
+                       http://mapserver.gis.umn.edu/mapserver http://localhost/wfsclient?SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=continents&amp;OUTPUTFORMAT=XMLSCHEMA">
+      <gml:boundedBy>
+      	<gml:Box srsName="EPSG:4326">
+      		<gml:coordinates>-86.923950,46.381596 -60.381756,65.176476</gml:coordinates>
+      	</gml:Box>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:continents>
+        <gml:boundedBy>
+        	<gml:Box srsName="EPSG:4326">
+        		<gml:coordinates>-60.393715,46.381596 -60.381756,46.394154</gml:coordinates>
+        	</gml:Box>
+        </gml:boundedBy>
+        <ms:msGeometry>
+        <gml:Polygon srsName="EPSG:4326">
+          <gml:outerBoundaryIs>
+            <gml:LinearRing>
+              <gml:coordinates>-60.393715,46.386185 -60.387363,46.393707 -60.382725,46.394154 -60.381756,46.391628 -60.390778,46.381596 -60.393715,46.386185 </gml:coordinates>
+            </gml:LinearRing>
+          </gml:outerBoundaryIs>
+        </gml:Polygon>
+        </ms:msGeometry>
+      </ms:continents>
+    </gml:featureMember>
+    <gml:featureMember>
+      <ms:continents>
+        <gml:boundedBy>
+        	<gml:Box srsName="EPSG:4326">
+        		<gml:coordinates>-86.923950,65.167961 -86.892601,65.176476</gml:coordinates>
+        	</gml:Box>
+        </gml:boundedBy>
+        <ms:msGeometry>
+        <gml:Polygon srsName="EPSG:4326">
+          <gml:outerBoundaryIs>
+            <gml:LinearRing>
+              <gml:coordinates>-86.903679,65.171326 -86.896553,65.171494 -86.892601,65.169724 -86.905548,65.167961 -86.923950,65.173294 -86.921654,65.176186 -86.906311,65.176476 -86.903679,65.171326 </gml:coordinates>
+            </gml:LinearRing>
+          </gml:outerBoundaryIs>
+        </gml:Polygon>
+        </ms:msGeometry>
+      </ms:continents>
+    </gml:featureMember>
+</wfs:FeatureCollection>
+

--- a/msautotest/wxs/wfs_client_100.map
+++ b/msautotest/wxs/wfs_client_100.map
@@ -1,0 +1,54 @@
+#
+# Test WFS 1.0.0 Client
+#
+# REQUIRES: OUTPUT=PNG SUPPORTS=WFS_CLIENT SUPPORTS=WFS
+# GetFeature
+# RUN_PARMS: wfs_client_100.xml [MAPSERV] -conf ../etc/mapserv.conf QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=continents" > [RESULT_DEMIME]
+
+MAP
+    NAME WFS_CLIENT_TEST_100
+    STATUS ON
+    SIZE 400 300
+    EXTENT -180 -90 180 90
+    UNITS DD
+    PROJECTION
+        "init=epsg:4326"
+    END
+    SYMBOLSET etc/symbols.sym
+    FONTSET etc/fonts.txt
+
+    WEB
+        IMAGEPATH "./tmp"
+        METADATA
+            "ows_updatesequence"    "123"
+            "wfs_title"    "Test WFS 1.0.0 client"
+            "wfs_srs"    "EPSG:4326"
+            "ows_enable_request"    "*"
+            "ows_onlineresource" "http://localhost/wfsclient?"
+        END
+    END
+
+    LAYER
+      NAME "continents"
+      TYPE POLYGON
+      STATUS ON
+      CONNECTION "https://demo.mapserver.org/cgi-bin/wfs?"
+      CONNECTIONTYPE WFS
+      METADATA
+        "wfs_typename"          "continents"
+        "wfs_version"           "1.0.0"
+        "wfs_connectiontimeout" "60"
+        "wfs_maxfeatures"       "2"
+      END
+      PROJECTION
+        "init=epsg:4326"
+      END
+      CLASS
+        NAME "Continents"
+        STYLE
+          COLOR 255 128 128
+          OUTLINECOLOR 96 96 96
+        END
+      END
+    END # Layer
+END

--- a/src/maphttp.c
+++ b/src/maphttp.c
@@ -435,6 +435,7 @@ int msHTTPExecuteRequests(httpRequestObj *pasReqInfo, int numRequests,
   int i, nStatus = MS_SUCCESS, nTimeout, still_running = 0, num_msgs = 0;
   CURLM *multi_handle;
   CURLMsg *curl_msg;
+  struct curl_slist *headers = NULL;
   char debug = MS_FALSE;
   const char *pszCurlCABundle = NULL;
 
@@ -684,8 +685,6 @@ int msHTTPExecuteRequests(httpRequestObj *pasReqInfo, int numRequests,
 
     if (pasReqInfo[i].pszPostRequest != NULL) {
       char szBuf[100];
-
-      struct curl_slist *headers = NULL;
       snprintf(szBuf, 100, "Content-Type: %s",
                pasReqInfo[i].pszPostContentType);
       headers = curl_slist_append(headers, szBuf);
@@ -697,7 +696,6 @@ int msHTTPExecuteRequests(httpRequestObj *pasReqInfo, int numRequests,
         msDebug("HTTP: POST = %s", pasReqInfo[i].pszPostRequest);
       }
       unchecked_curl_easy_setopt(http_handle, CURLOPT_HTTPHEADER, headers);
-      /* curl_slist_free_all(headers); */ /* free the header list */
     }
 
     /* Added by RFC-42 HTTP Cookie Forwarding */
@@ -914,6 +912,11 @@ int msHTTPExecuteRequests(httpRequestObj *pasReqInfo, int numRequests,
     /* Cleanup this handle */
     unchecked_curl_easy_setopt(http_handle, CURLOPT_URL, "");
     curl_multi_remove_handle(multi_handle, http_handle);
+
+    if (headers) {
+      curl_slist_free_all(headers); /* free the header list */
+    }
+
     curl_easy_cleanup(http_handle);
     psReq->curl_handle = NULL;
   }

--- a/src/maphttp.h
+++ b/src/maphttp.h
@@ -75,8 +75,9 @@ typedef struct http_request_info {
   int debug; /* Debug mode?  MS_TRUE/MS_FALSE */
 
   /* Private members */
-  void *curl_handle; /* CURLM * handle */
-  FILE *fp;          /* FILE * used during download */
+  void *curl_headers; /* property to store a curl_slist handle */
+  void *curl_handle;  /* CURLM * handle */
+  FILE *fp;           /* FILE * used during download */
 
   char *result_data; /* output if pszOutputFile is NULL */
   int result_size;


### PR DESCRIPTION
While setting up a layer using the [WFS Client](https://www.mapserver.org/ogc/wfs_client.html) I noticed there were no tests in place. 

I've added one (that cascades a WFS service) that works fine locally but fails in the CI. Failing logs as follows:

```
+[Thu Jun 15 13:04:38 2023].66359 HTTP: Before download loop
+[Thu Jun 15 13:04:38 2023].433103 msHTTPWriteFct(id=0, 2496 bytes)
+[Thu Jun 15 13:04:38 2023].433165 HTTP: After download loop
+[Thu Jun 15 13:04:38 2023].433176 msHTTPExecuteRequests() timing summary per layer (connect_time + time_to_first_packet + download_time = total_time in seconds)
+[Thu Jun 15 13:04:38 2023].433242 Layer 0: 0.082 + 0.285 + 0.082 = 0.449s
+[Thu Jun 15 13:04:38 2023].435265 msOGRFileOpen(/tmp/648b0c66_a1b5_5.tmp.gml)...
+[Thu Jun 15 13:04:38 2023].435303 OGROPen(/tmp/648b0c66_a1b5_5.tmp.gml)
+[Thu Jun 15 13:04:38 2023].816213 msConnPoolRegister(continents,https://demo.mapserver.org/cgi-bin/wfs?,0x5642047d0220)
+[Thu Jun 15 13:04:38 2023].816273 msOGRFileWhichShapes: Setting spatial filter to -180 -90 180 90
+[Thu Jun 15 13:04:38 2023].816337 msOGRFileWhichShapes: Setting spatial filter to -86.92396 46.381586 -60.381746 65.176486
+[Thu Jun 15 13:04:38 2023].816521 msOGRFileNextShape: Returning shape=23774, tile=0
+[Thu Jun 15 13:04:38 2023].816556 msOGRFileNextShape: Returning shape=18417, tile=0
+[Thu Jun 15 13:04:38 2023].816575 msOGRFileNextShape(): OGR error. OGR GetNextFeature() error'd. Check logs.
+[Thu Jun 15 13:04:38 2023].816582 msOGRFileNextShape(): HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)
+[Thu Jun 15 13:04:38 2023].816591 msWFSGetFeature(): WFS server error. ms_error->code not found
```

I'm thinking it could be a SSL/Cert issue, but the WMS Client uses the same server and the tests work fine. 