### PR TITLE
Allow Mapfile key to be only element in PATH_INFO

### DIFF
--- a/mapservutil.c
+++ b/mapservutil.c
@@ -341,8 +341,8 @@ int msCGIIsAPIRequest(mapservObj *mapserv)
 
   mapserv->request->path_info = getenv("PATH_INFO");
   if(mapserv->request->path_info != NULL && strlen(mapserv->request->path_info) > 0) {
-    tmp_api_path = msStringSplit(mapserv->request->path_info, '/', &tmp_api_path_length); // ignores consecutive delimeters
-    if(tmp_api_path_length >= 3) { // /{mapfile}/{signature} so 3 components at a minimum (1st component is a zero-length string)
+    tmp_api_path = msStringSplit(mapserv->request->path_info, '/', &tmp_api_path_length); // ignores consecutive delimiters
+    if(tmp_api_path_length >= 2) { // we can access a mapfile by key using /{mapfile-key} so 2 components at a minimum (1st component is a zero-length string)
 
       // capture only non-zero length components
       n = 0;

--- a/msautotest/api/expected/ogcapi_missing_api_signature1.txt
+++ b/msautotest/api/expected/ogcapi_missing_api_signature1.txt
@@ -3,5 +3,5 @@ Content-Type: text/html
 <HTML>
 <HEAD><TITLE>MapServer Message</TITLE></HEAD>
 <BODY BGCOLOR="#FFFFFF">
-msCGILoadMap(): Web application error. CGI variable &quot;map&quot; is not set.
+mapserv(): Web application error. Traditional BROWSE mode requires a TEMPLATE in the WEB section, but none was provided.
 </BODY></HTML>


### PR DESCRIPTION
Follow-up to #6862 - where a missing slash was causing tests to fail in #6919. 
This allows Mapfile keys to be used in a URL path, with or without a trailing slash:

```
http://example.com/mykey/?request=WMS...
http://example.com/mykey?request=WMS...
```

An OGCAPI test is also updated as part of this pull request as it is now valid to use a URL without an additional `ogcapi` in the path. 

I'm unsure why this test is currently passing in main but not when the repo structure was changed. @jmckenna - could you merge this and test with a rebase on #6919?
