### PR TITLE
Remove Flake8 from Python builds

### DIFF
--- a/src/mapscript/python/CMakeLists.txt
+++ b/src/mapscript/python/CMakeLists.txt
@@ -73,15 +73,6 @@ add_custom_command(
 
 add_custom_command(
     DEPENDS mapscriptvenv.stamp
-    OUTPUT mapscriptlinting.stamp
-    WORKING_DIRECTORY ${OUTPUT_FOLDER}
-    COMMAND ${Python_VENV_SCRIPTS}/flake8 $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/tests --max-line-length=140
-    COMMAND ${Python_VENV_SCRIPTS}/flake8 $<TARGET_FILE_DIR:${SWIG_MODULE_pythonmapscript_REAL_NAME}>/mapscript/examples --max-line-length=120
-    COMMENT "Linting test suite and examples with flake8" # note only one comment is output per custom command block
-)
-
-add_custom_command(
-    DEPENDS mapscriptlinting.stamp
     OUTPUT mapscriptwheel.stamp
     WORKING_DIRECTORY ${OUTPUT_FOLDER}
     COMMAND ${Python_VENV_SCRIPTS}/python setup.py bdist_wheel > wheel_build.log

--- a/src/mapscript/python/requirements-dev.txt
+++ b/src/mapscript/python/requirements-dev.txt
@@ -1,6 +1,4 @@
 pytest
 pillow
-wheel>=0.31.1
-setuptools>=40.2.0
-flake8==3.9.2; python_version == '2.7'
-flake8==5.0.3; python_version >= '3.0'
+wheel>=0.38.0
+setuptools>=45.0.0


### PR DESCRIPTION
Python linting and formatting is added to pre-commits in #6937 so no need to run as part of builds.
Also update requirements-dev.txt to remove flake8 and use newer versions of wheel and setuptools now Python 2.7 support is dropped. 