### PR TITLE
WMS client (cascaded WMS): restrict the list of GDAL drivers used to …

### DIFF
--- a/msautotest/wxs/wms_client_111.map
+++ b/msautotest/wxs/wms_client_111.map
@@ -55,6 +55,7 @@ MAP
 			"wms_server_version"	"1.1.1"
 			"wms_format"	"image/png"
 			"wms_enable_request" "*"
+			"wms_allowed_gdal_drivers" "PNG" # would be set automatically given wms_format=image/png
 		END
 	END
 END		


### PR DESCRIPTION
…read the GetMap response; add a 'wms_allowed_gdal_drivers' LAYER.METADATA option that takes a comma separated list of GDAL driver names