### PR TITLE
 Include list expressions in GetStyles SLD output

### DIFF
--- a/msautotest/wxs/expected/wms_getstyles_expressions13.xml
+++ b/msautotest/wxs/expected/wms_getstyles_expressions13.xml
@@ -1,0 +1,26 @@
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<se:Name>Test13</se:Name>
+<UserStyle>
+<se:FeatureTypeStyle>
+<se:Rule>
+<ogc:Filter><ogc:Or><ogc:Filter><ogc:PropertyIsEqualTo><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>2</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Filter>
+<ogc:Filter><ogc:PropertyIsEqualTo><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>4</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Filter>
+<ogc:Filter><ogc:PropertyIsEqualTo><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>6</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Filter>
+</ogc:Or></ogc:Filter><se:PointSymbolizer>
+<se:Graphic>
+<se:Mark>
+<se:WellKnownName>square</se:WellKnownName>
+<se:Fill>
+<se:SvgParameter name="fill">#dc0000</se:SvgParameter>
+</se:Fill>
+</se:Mark>
+<se:Size>1</se:Size>
+</se:Graphic>
+</se:PointSymbolizer>
+</se:Rule>
+</se:FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>
+

--- a/msautotest/wxs/expected/wms_getstyles_expressions13.xml
+++ b/msautotest/wxs/expected/wms_getstyles_expressions13.xml
@@ -4,9 +4,9 @@
 <UserStyle>
 <se:FeatureTypeStyle>
 <se:Rule>
-<ogc:Filter><ogc:Or><ogc:Filter><ogc:PropertyIsEqualTo><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>2</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Filter>
-<ogc:Filter><ogc:PropertyIsEqualTo><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>4</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Filter>
-<ogc:Filter><ogc:PropertyIsEqualTo><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>6</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Filter>
+<ogc:Filter><ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>2</ogc:Literal></ogc:PropertyIsEqualTo>
+<ogc:PropertyIsEqualTo><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>4</ogc:Literal></ogc:PropertyIsEqualTo>
+<ogc:PropertyIsEqualTo><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>6</ogc:Literal></ogc:PropertyIsEqualTo>
 </ogc:Or></ogc:Filter><se:PointSymbolizer>
 <se:Graphic>
 <se:Mark>

--- a/msautotest/wxs/expected/wms_getstyles_expressions14.xml
+++ b/msautotest/wxs/expected/wms_getstyles_expressions14.xml
@@ -1,0 +1,24 @@
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<se:Name>Test14</se:Name>
+<UserStyle>
+<se:FeatureTypeStyle>
+<se:Rule>
+<ogc:Filter><ogc:PropertyIsEqualTo><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>2</ogc:Literal></ogc:PropertyIsEqualTo>
+</ogc:Filter><se:PointSymbolizer>
+<se:Graphic>
+<se:Mark>
+<se:WellKnownName>square</se:WellKnownName>
+<se:Fill>
+<se:SvgParameter name="fill">#dc0000</se:SvgParameter>
+</se:Fill>
+</se:Mark>
+<se:Size>1</se:Size>
+</se:Graphic>
+</se:PointSymbolizer>
+</se:Rule>
+</se:FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>
+

--- a/msautotest/wxs/expected/wms_getstyles_expressions15.xml
+++ b/msautotest/wxs/expected/wms_getstyles_expressions15.xml
@@ -1,0 +1,23 @@
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<se:Name>Test15</se:Name>
+<UserStyle>
+<se:FeatureTypeStyle>
+<se:Rule>
+<se:PointSymbolizer>
+<se:Graphic>
+<se:Mark>
+<se:WellKnownName>square</se:WellKnownName>
+<se:Fill>
+<se:SvgParameter name="fill">#dc0000</se:SvgParameter>
+</se:Fill>
+</se:Mark>
+<se:Size>1</se:Size>
+</se:Graphic>
+</se:PointSymbolizer>
+</se:Rule>
+</se:FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>
+

--- a/msautotest/wxs/expected/wms_getstyles_expressions16.xml
+++ b/msautotest/wxs/expected/wms_getstyles_expressions16.xml
@@ -1,0 +1,25 @@
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<se:Name>Test16</se:Name>
+<UserStyle>
+<se:FeatureTypeStyle>
+<se:Rule>
+<ogc:Filter><ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>locationtype</ogc:PropertyName><ogc:Literal>primary location</ogc:Literal></ogc:PropertyIsEqualTo>
+<ogc:PropertyIsEqualTo><ogc:PropertyName>locationtype</ogc:PropertyName><ogc:Literal>secondary location</ogc:Literal></ogc:PropertyIsEqualTo>
+</ogc:Or></ogc:Filter><se:PointSymbolizer>
+<se:Graphic>
+<se:Mark>
+<se:WellKnownName>square</se:WellKnownName>
+<se:Fill>
+<se:SvgParameter name="fill">#dc0000</se:SvgParameter>
+</se:Fill>
+</se:Mark>
+<se:Size>1</se:Size>
+</se:Graphic>
+</se:PointSymbolizer>
+</se:Rule>
+</se:FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>
+

--- a/msautotest/wxs/expected/wms_getstyles_expressions17.xml
+++ b/msautotest/wxs/expected/wms_getstyles_expressions17.xml
@@ -1,0 +1,25 @@
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<se:Name>Test17</se:Name>
+<UserStyle>
+<se:FeatureTypeStyle>
+<se:Rule>
+<ogc:Filter><ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>poi</ogc:PropertyName><ogc:Literal>"main" square</ogc:Literal></ogc:PropertyIsEqualTo>
+<ogc:PropertyIsEqualTo><ogc:PropertyName>poi</ogc:PropertyName><ogc:Literal>city's centre</ogc:Literal></ogc:PropertyIsEqualTo>
+</ogc:Or></ogc:Filter><se:PointSymbolizer>
+<se:Graphic>
+<se:Mark>
+<se:WellKnownName>square</se:WellKnownName>
+<se:Fill>
+<se:SvgParameter name="fill">#dc0000</se:SvgParameter>
+</se:Fill>
+</se:Mark>
+<se:Size>1</se:Size>
+</se:Graphic>
+</se:PointSymbolizer>
+</se:Rule>
+</se:FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>
+

--- a/msautotest/wxs/wms_styles_expressions.map
+++ b/msautotest/wxs/wms_styles_expressions.map
@@ -17,6 +17,9 @@
 # RUN_PARMS: wms_getstyles_expressions10.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test10" > [RESULT_DEMIME]
 # RUN_PARMS: wms_getstyles_expressions11.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test11" > [RESULT_DEMIME]
 # RUN_PARMS: wms_getstyles_expressions12.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test12" > [RESULT_DEMIME]
+# RUN_PARMS: wms_getstyles_expressions13.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test13" > [RESULT_DEMIME]
+# RUN_PARMS: wms_getstyles_expressions14.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test14" > [RESULT_DEMIME]
+# RUN_PARMS: wms_getstyles_expressions15.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test15" > [RESULT_DEMIME]
 
 MAP
     NAME WMS_TEST
@@ -166,6 +169,48 @@ MAP
       TYPE POINT
       CLASS
         EXPRESSION (NOT([FID] = 1))
+        STYLE
+            COLOR 220 0 0
+            WIDTH 1
+        END
+      END
+    END
+
+    # list expression
+    LAYER
+      NAME "Test13"
+      TYPE POINT
+      CLASSITEM "FID"
+      CLASS
+        EXPRESSION {2,4,6}
+        STYLE
+            COLOR 220 0 0
+            WIDTH 1
+        END
+      END
+    END
+
+    # list expression with one value
+    LAYER
+      NAME "Test14"
+      TYPE POINT
+      CLASSITEM "FID"
+      CLASS
+        EXPRESSION {2}
+        STYLE
+            COLOR 220 0 0
+            WIDTH 1
+        END
+      END
+    END
+
+    # empty list expression
+    LAYER
+      NAME "Test15"
+      TYPE POINT
+      CLASSITEM "FID"
+      CLASS
+        EXPRESSION {}
         STYLE
             COLOR 220 0 0
             WIDTH 1

--- a/msautotest/wxs/wms_styles_expressions.map
+++ b/msautotest/wxs/wms_styles_expressions.map
@@ -20,6 +20,8 @@
 # RUN_PARMS: wms_getstyles_expressions13.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test13" > [RESULT_DEMIME]
 # RUN_PARMS: wms_getstyles_expressions14.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test14" > [RESULT_DEMIME]
 # RUN_PARMS: wms_getstyles_expressions15.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test15" > [RESULT_DEMIME]
+# RUN_PARMS: wms_getstyles_expressions16.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test16" > [RESULT_DEMIME]
+# RUN_PARMS: wms_getstyles_expressions17.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test17" > [RESULT_DEMIME]
 
 MAP
     NAME WMS_TEST
@@ -217,4 +219,32 @@ MAP
         END
       END
     END
+    
+    # string list expression
+    LAYER
+      NAME "Test16"
+      TYPE POINT
+      CLASSITEM "locationtype"
+      CLASS
+        EXPRESSION {primary location,secondary location}
+        STYLE
+            COLOR 220 0 0
+            WIDTH 1
+        END
+      END
+    END    
+
+    # string list expression with quotes
+    LAYER
+      NAME "Test17"
+      TYPE POINT
+      CLASSITEM "poi"
+      CLASS
+        EXPRESSION {"main" square,city's centre}
+        STYLE
+            COLOR 220 0 0
+            WIDTH 1
+        END
+      END
+    END 
 END

--- a/src/mapogcsld.c
+++ b/src/mapogcsld.c
@@ -5389,22 +5389,34 @@ char *msSLDGetFilter(classObj *psClass, const char *pszWfsFilter) {
 
         char *pszTmp = NULL;
         char *pszTmpFilters = NULL;
-        char *token = strtok((char *)psClass->expression.string, ",");
+        int nArgs = 0;
+        int i = 0;
         int tokenCount = 0;
+        char **papszArgs;
+
+        papszArgs =
+            msStringTokenize(psClass->expression.string, ",", &nArgs, MS_TRUE);
 
         // loop through all values in the list and create a PropertyIsEqualTo
         // for each value
-        while (token != NULL) {
-          tokenCount++;
+        for (i = 0; i < nArgs; i++) {
+
+          if (strlen(papszArgs[i]) == 0) {
+            free(papszArgs[i]);
+            continue;
+          }
+
           snprintf(szBuffer, sizeof(szBuffer),
                    "<ogc:PropertyIsEqualTo><ogc:PropertyName>%s</"
                    "ogc:PropertyName><ogc:Literal>%s</ogc:Literal></"
                    "ogc:PropertyIsEqualTo>\n",
-                   psClass->layer->classitem, token);
+                   psClass->layer->classitem, papszArgs[i]);
 
           pszTmpFilters = msStringConcatenate(pszTmpFilters, szBuffer);
-          token = strtok(NULL, ",");
+          tokenCount++;
+          free(papszArgs[i]);
         }
+        free(papszArgs);
 
         pszTmp = msStringConcatenate(pszTmp, "<ogc:Filter>");
 

--- a/src/mapogcsld.c
+++ b/src/mapogcsld.c
@@ -5383,6 +5383,48 @@ char *msSLDGetFilter(classObj *psClass, const char *pszWfsFilter) {
     } else if (psClass->expression.type == MS_EXPRESSION) {
       pszFilter =
           msSLDParseLogicalExpression(psClass->expression.string, pszWfsFilter);
+    } else if (psClass->expression.type == MS_LIST) {
+      if (psClass->layer && psClass->layer->classitem &&
+          psClass->expression.string) {
+
+        char *pszTmp = NULL;
+        char *pszTmpFilters = NULL;
+        char *token = strtok((char *)psClass->expression.string, ",");
+        int tokenCount = 0;
+
+        // loop through all values in the list and create a PropertyIsEqualTo
+        // for each value
+        while (token != NULL) {
+          tokenCount++;
+          snprintf(szBuffer, sizeof(szBuffer),
+                   "<ogc:PropertyIsEqualTo><ogc:PropertyName>%s</"
+                   "ogc:PropertyName><ogc:Literal>%s</ogc:Literal></"
+                   "ogc:PropertyIsEqualTo>\n",
+                   psClass->layer->classitem, token);
+
+          pszTmpFilters = msStringConcatenate(pszTmpFilters, szBuffer);
+          token = strtok(NULL, ",");
+        }
+
+        pszTmp = msStringConcatenate(pszTmp, "<ogc:Filter>");
+
+        // no need for an OR clause if there is only one item in the list
+        if (tokenCount == 1) {
+          pszTmp = msStringConcatenate(pszTmp, pszTmpFilters);
+        } else if (tokenCount > 1) {
+          pszTmp = msStringConcatenate(pszTmp, "<ogc:Or>");
+          pszTmp = msStringConcatenate(pszTmp, pszTmpFilters);
+          pszTmp = msStringConcatenate(pszTmp, "</ogc:Or>");
+        }
+
+        pszTmp = msStringConcatenate(pszTmp, "</ogc:Filter>");
+
+        // don't filter when the list is empty
+        if (tokenCount > 0) {
+          pszFilter = msStrdup(pszTmp);
+        }
+        free(pszTmp);
+      }
     } else if (psClass->expression.type == MS_REGEX) {
       if (psClass->layer && psClass->layer->classitem &&
           psClass->expression.string) {

--- a/src/mapogcsld.c
+++ b/src/mapogcsld.c
@@ -5389,34 +5389,30 @@ char *msSLDGetFilter(classObj *psClass, const char *pszWfsFilter) {
 
         char *pszTmp = NULL;
         char *pszTmpFilters = NULL;
-        int nArgs = 0;
+
+        char **listExpressionValues = NULL;
+        int numListExpressionValues = 0;
         int i = 0;
         int tokenCount = 0;
-        char **papszArgs;
 
-        papszArgs =
-            msStringTokenize(psClass->expression.string, ",", &nArgs, MS_TRUE);
+        listExpressionValues = msStringSplit(psClass->expression.string, ',',
+                                             &numListExpressionValues);
 
         // loop through all values in the list and create a PropertyIsEqualTo
         // for each value
-        for (i = 0; i < nArgs; i++) {
+        for (i = 0; i < numListExpressionValues; i++) {
+          if (listExpressionValues[i] && listExpressionValues[i][0] != '\0') {
 
-          if (strlen(papszArgs[i]) == 0) {
-            free(papszArgs[i]);
-            continue;
+            snprintf(szBuffer, sizeof(szBuffer),
+                     "<ogc:PropertyIsEqualTo><ogc:PropertyName>%s</"
+                     "ogc:PropertyName><ogc:Literal>%s</ogc:Literal></"
+                     "ogc:PropertyIsEqualTo>\n",
+                     psClass->layer->classitem, listExpressionValues[i]);
+
+            pszTmpFilters = msStringConcatenate(pszTmpFilters, szBuffer);
+            tokenCount++;
           }
-
-          snprintf(szBuffer, sizeof(szBuffer),
-                   "<ogc:PropertyIsEqualTo><ogc:PropertyName>%s</"
-                   "ogc:PropertyName><ogc:Literal>%s</ogc:Literal></"
-                   "ogc:PropertyIsEqualTo>\n",
-                   psClass->layer->classitem, papszArgs[i]);
-
-          pszTmpFilters = msStringConcatenate(pszTmpFilters, szBuffer);
-          tokenCount++;
-          free(papszArgs[i]);
         }
-        free(papszArgs);
 
         pszTmp = msStringConcatenate(pszTmp, "<ogc:Filter>");
 
@@ -5435,6 +5431,7 @@ char *msSLDGetFilter(classObj *psClass, const char *pszWfsFilter) {
         if (tokenCount > 0) {
           pszFilter = msStrdup(pszTmp);
         }
+        msFreeCharArray(listExpressionValues, numListExpressionValues);
         free(pszTmp);
         free(pszTmpFilters);
       }

--- a/src/mapogcsld.c
+++ b/src/mapogcsld.c
@@ -5424,6 +5424,7 @@ char *msSLDGetFilter(classObj *psClass, const char *pszWfsFilter) {
           pszFilter = msStrdup(pszTmp);
         }
         free(pszTmp);
+        free(pszTmpFilters);
       }
     } else if (psClass->expression.type == MS_REGEX) {
       if (psClass->layer && psClass->layer->classitem &&


### PR DESCRIPTION
Fix for #6911. This update generates SLD for a class using [list expressions](https://www.mapserver.org/mapfile/expressions.html#list-expressions):

```
  CLASSITEM "FID"
  CLASS
    EXPRESSION {2,4,6}
    STYLE
        COLOR 220 0 0
        WIDTH 1
    END
```

Will include the following SLD with a request such as `map=mymap&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=MyLayer`

```xml
  <ogc:Filter>
    <ogc:Or>
      <ogc:PropertyIsEqualTo>
        <ogc:PropertyName>FID</ogc:PropertyName>
        <ogc:Literal>2</ogc:Literal>
      </ogc:PropertyIsEqualTo>
      <ogc:PropertyIsEqualTo>
        <ogc:PropertyName>FID</ogc:PropertyName>
        <ogc:Literal>4</ogc:Literal>
      </ogc:PropertyIsEqualTo>
      <ogc:PropertyIsEqualTo>
        <ogc:PropertyName>FID</ogc:PropertyName>
        <ogc:Literal>6</ogc:Literal>
      </ogc:PropertyIsEqualTo>
    </ogc:Or>
  </ogc:Filter>
```

Note when a a list expression is used a `CLASSITEM` has to be set on the layer. 
Tests include lists with 0 and 1 items - the first will not produce a filter, and the second will produce a single filter. When multiple items are in the list (the typical use case) multiple filters will be produced wrapped in an OR tag. 

