### PR TITLE
CI: workaround add-apt-repository ppa:ubuntugis/ubuntugis-unstable failures

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -19,7 +19,10 @@ jobs:
 
       - name: Install Libraries
         run: |
-          sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+          # This currently fails as of https://lists.osgeo.org/pipermail/ubuntu/2023-October/002046.html
+          # sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B827C12C2D425E227EDCA75089EBE08314DF160
+          sudo add-apt-repository -y http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu/
           sudo apt-get update
           sudo apt-get install --allow-unauthenticated protobuf-c-compiler libprotobuf-c-dev bison flex libfribidi-dev cmake librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal-dev libproj-dev libxml2-dev libexempi-dev lcov lftp postgis libharfbuzz-dev gdal-bin ccache curl postgresql-server-dev-12 postgresql-12-postgis-3 postgresql-12-postgis-3-scripts swig
       - name: Build MapServer

--- a/ci/travis/before_install.sh
+++ b/ci/travis/before_install.sh
@@ -7,7 +7,10 @@ dpkg -l | grep postgresql || /bin/true
 dpkg -l | grep postgis || /bin/true
 sudo apt-get remove --purge postgresql* libpq-dev libpq5 cmake || /bin/true
 
-sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+# This currently fails as of https://lists.osgeo.org/pipermail/ubuntu/2023-October/002046.html
+# sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B827C12C2D425E227EDCA75089EBE08314DF160
+sudo add-apt-repository -y http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu/
 sudo apt-get update
 sudo apt-get install -y --allow-unauthenticated build-essential protobuf-c-compiler libprotobuf-c-dev bison flex libfribidi-dev librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal-dev libproj-dev libxml2-dev libexempi-dev lcov lftp postgis libharfbuzz-dev gdal-bin proj-bin ccache curl postgresql-server-dev-12 postgresql-12-postgis-3 postgresql-12-postgis-3-scripts g++ ca-certificates
 # following are already installed on Travis CI


### PR DESCRIPTION
Port of GDAL similar changes of https://github.com/OSGeo/gdal/pull/8571. Credits to @lnicola