### PR TITLE
Avoid segmentation fault when outputformat is defined for resultType=hits

### DIFF
--- a/msautotest/wxs/expected/wfsogr20_geojson_resulttype_hits.xml
+++ b/msautotest/wxs/expected/wfsogr20_geojson_resulttype_hits.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:wfs="http://www.opengis.net/wfs/2.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=popplace_fid&amp;OUTPUTFORMAT=XMLSCHEMA http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd"
+   timeStamp="2023-10-31T16:46:48" numberMatched="28" numberReturned="0">
+</wfs:FeatureCollection>
+

--- a/msautotest/wxs/expected/wfsogr20_geojson_resulttype_hits.xml
+++ b/msautotest/wxs/expected/wfsogr20_geojson_resulttype_hits.xml
@@ -5,6 +5,6 @@
    xmlns:wfs="http://www.opengis.net/wfs/2.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=popplace_fid&amp;OUTPUTFORMAT=XMLSCHEMA http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/2.1.2/feature.xsd"
-   timeStamp="2023-10-31T16:46:48" numberMatched="28" numberReturned="0">
+   timeStamp="" numberMatched="28" numberReturned="0">
 </wfs:FeatureCollection>
 

--- a/msautotest/wxs/expected/wfsogr20_geojson_resulttype_hits.xml
+++ b/msautotest/wxs/expected/wfsogr20_geojson_resulttype_hits.xml
@@ -1,3 +1,5 @@
+Content-Type: text/xml; charset=UTF-8
+
 <?xml version='1.0' encoding="UTF-8" ?>
 <wfs:FeatureCollection
    xmlns:ms="http://mapserver.gis.umn.edu/mapserver"

--- a/msautotest/wxs/wfs_ogr_geojson.map
+++ b/msautotest/wxs/wfs_ogr_geojson.map
@@ -11,7 +11,7 @@
 # RUN_PARMS: wfsogr20_geojson_with_predefine_native_data.json [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=popplace_fid&OUTPUTFORMAT=geojson_with_predefined_native_data&COUNT=10" > [RESULT]
 #
 # Check that OUTPUTFORMAT does not affect resultType=hits and returns XML
-# RUN_PARMS: wfsogr20_geojson_resulttype_hits.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAME=popplace_fid&OUTPUTFORMAT=geojson&RESULTTYPE=hits" > [RESULT]
+# RUN_PARMS: wfsogr20_geojson_resulttype_hits.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAME=popplace_fid&OUTPUTFORMAT=geojson&RESULTTYPE=hits" > [RESULT_DEVERSION]
 
 MAP
 

--- a/msautotest/wxs/wfs_ogr_geojson.map
+++ b/msautotest/wxs/wfs_ogr_geojson.map
@@ -9,6 +9,9 @@
 # RUN_PARMS: wfsogr20_geojson.json [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=popplace_fid&OUTPUTFORMAT=geojson&COUNT=10" > [RESULT]
 #
 # RUN_PARMS: wfsogr20_geojson_with_predefine_native_data.json [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=popplace_fid&OUTPUTFORMAT=geojson_with_predefined_native_data&COUNT=10" > [RESULT]
+#
+# Check that OUTPUTFORMAT does not affect resultType=hits and returns XML
+# RUN_PARMS: wfsogr20_geojson_resulttype_hits.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAME=popplace_fid&OUTPUTFORMAT=geojson&RESULTTYPE=hits" > [RESULT]
 
 MAP
 

--- a/src/mapwfs.cpp
+++ b/src/mapwfs.cpp
@@ -3885,6 +3885,11 @@ static int msWFSGetFeature(mapObj *map, wfsParamsObj *paramsObj,
                             MS_OWS_ERROR_INVALID_PARAMETER_VALUE,
                             paramsObj->pszVersion);
     }
+    // only GML is supported for resultType=hits, so ignore any other
+    // outputformat
+    if (iResultTypeHits == 1) {
+      psFormat = NULL;
+    }
   } else {
     outputformat = (OWSGMLVersion)status;
   }


### PR DESCRIPTION
Fix for #6403. This prevents a segmentation fault at: https://github.com/MapServer/MapServer/blob/6412a9287a2cb9e07e47f6570aaa8f4e701127bc/src/mapogroutput.cpp#L1043 as the results in the cache is NULL.

The fix removes/ignores any `outputformat=XXX` and so always returns the result count as XML. I'm unsure if the WFS spec defines what should happen in other format cases, but always returning XML at least prevents a server crash. 