### PR TITLE
Add a CONFIG file fuzzer

### DIFF
--- a/fuzzers/CMakeLists.txt
+++ b/fuzzers/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach(FUZZER_NAME IN ITEMS shapefuzzer mapfuzzer)
+foreach(FUZZER_NAME IN ITEMS shapefuzzer mapfuzzer configfuzzer)
     if(FUZZER)
         add_executable(${FUZZER_NAME} ${FUZZER_NAME}.c)
         target_compile_options(${FUZZER_NAME} PRIVATE -Wall -Wextra -Werror=format-security)

--- a/fuzzers/README.md
+++ b/fuzzers/README.md
@@ -20,7 +20,9 @@ https://bugs.chromium.org/p/oss-fuzz/issues/list?q=mapserver
     $ fuzzers/shapefuzzer_reproducer path_to_reproducer_file
   ```
 
-- Run locally OSS Fuzz:
+- Run OSS Fuzz locally. Note you need to have Docker installed and the Docker daemon running for the Python script to run.
+  The helper.py script builds and runs the Docker images, then the fuzzers can be run.
+
   ```
     $ git clone https://github.com/google/oss-fuzz.git
     $ cd oss-fuzz

--- a/fuzzers/build.sh
+++ b/fuzzers/build.sh
@@ -74,7 +74,7 @@ cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_STATIC=ON \
 make -j$(nproc) mapserver_static
 
 #Fuzzers
-for fuzzer in mapfuzzer shapefuzzer; do
+for fuzzer in mapfuzzer shapefuzzer configfuzzer; do
     $CC $CFLAGS -Wall -Wextra -I. -I.. -I/usr/include/gdal/. -DPROJ_VERSION_MAJOR=6 -c ../fuzzers/${fuzzer}.c
 
     $CXX $CXXFLAGS $LIB_FUZZING_ENGINE ${fuzzer}.o -o ${fuzzer} \
@@ -89,3 +89,4 @@ cd ..
 
 zip -r $OUT/mapfuzzer_seed_corpus.zip tests/*.map
 zip -r $OUT/shapefuzzer_seed_corpus.zip tests/*.shp tests/*.shx tests/*.dbf
+zip -r $OUT/configfuzzer_seed_corpus.zip tests/*.conf etc/*.conf msautotest/config/*.conf

--- a/fuzzers/configfuzzer.c
+++ b/fuzzers/configfuzzer.c
@@ -1,0 +1,54 @@
+/* Copyright 2022 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <stdint.h>
+#include <string.h>
+
+#include "cpl_conv.h"
+#include "cpl_string.h"
+#include "src/mapserver.h"
+
+#define kMinInputLength 10
+#define kMaxInputLength 10240
+
+extern int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
+extern int LLVMFuzzerInitialize(int *argc, char ***argv);
+
+int LLVMFuzzerInitialize(int *argc, char ***argv) {
+  (void)argc;
+  (void)argv;
+  return 0;
+}
+
+extern int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+
+  if (Size < kMinInputLength || Size > kMaxInputLength) {
+    return 1;
+  }
+
+  char *filename =
+      msStrdup(CPLSPrintf("%s.config", CPLGenerateTempFilename(NULL)));
+  FILE *fp = fopen(filename, "wb");
+  if (!fp) {
+    msFree(filename);
+    return 1;
+  }
+  fwrite(Data, Size, 1, fp);
+  fclose(fp);
+
+  msFreeConfig(msLoadConfig(filename));
+  VSIUnlink(filename);
+  msFree(filename);
+  msResetErrorList();
+
+  return 0;
+}


### PR DESCRIPTION
This pull request adds a new fuzzer to the project for the MapServer CONFIG file.
It uses the same approach as the existing mapfuzzer for Mapfiles. 

As discussed at the [OSGeo Codesprint](https://wiki.osgeo.org/wiki/OSGeo_Community_Sprint_2023) a future aim is to get a fuzzer running for a MapServer QUERYSTRING. This however requires a more complicated approach, and setting up of a config file and Mapfile to work with the fuzzer. This pull request was useful to go through the full process before attempting a more complex fuzzer (with thanks to @rouault for the run through and guidance). 

I've built and left this running locally for over 4 hours without any issues being raised by the fuzzer, but I'll attempt to fix any issues raised when run on the full Google infrastructure. 

