### PR TITLE
Remove spaces in SLD exports for multipart expressions

### DIFF
--- a/msautotest/wxs/expected/wms_getstyles_expressions21.xml
+++ b/msautotest/wxs/expected/wms_getstyles_expressions21.xml
@@ -1,0 +1,24 @@
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<se:Name>Test21</se:Name>
+<UserStyle>
+<se:FeatureTypeStyle>
+<se:Rule>
+<ogc:Filter><ogc:And><ogc:PropertyIsGreaterThan><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>1</ogc:Literal></ogc:PropertyIsGreaterThan><ogc:PropertyIsLessThanOrEqualTo><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>10</ogc:Literal></ogc:PropertyIsLessThanOrEqualTo></ogc:And></ogc:Filter>
+<se:PointSymbolizer>
+<se:Graphic>
+<se:Mark>
+<se:WellKnownName>square</se:WellKnownName>
+<se:Fill>
+<se:SvgParameter name="fill">#dc0000</se:SvgParameter>
+</se:Fill>
+</se:Mark>
+<se:Size>1</se:Size>
+</se:Graphic>
+</se:PointSymbolizer>
+</se:Rule>
+</se:FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>
+

--- a/msautotest/wxs/expected/wms_getstyles_expressions22.xml
+++ b/msautotest/wxs/expected/wms_getstyles_expressions22.xml
@@ -1,0 +1,24 @@
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<se:Name>Test22</se:Name>
+<UserStyle>
+<se:FeatureTypeStyle>
+<se:Rule>
+<ogc:Filter><ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>locationtype</ogc:PropertyName><ogc:Literal>primary location </ogc:Literal></ogc:PropertyIsEqualTo><ogc:PropertyIsEqualTo><ogc:PropertyName>locationtype</ogc:PropertyName><ogc:Literal> secondary location</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Or></ogc:Filter>
+<se:PointSymbolizer>
+<se:Graphic>
+<se:Mark>
+<se:WellKnownName>square</se:WellKnownName>
+<se:Fill>
+<se:SvgParameter name="fill">#dc0000</se:SvgParameter>
+</se:Fill>
+</se:Mark>
+<se:Size>1</se:Size>
+</se:Graphic>
+</se:PointSymbolizer>
+</se:Rule>
+</se:FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>
+

--- a/msautotest/wxs/expected/wms_getstyles_expressions23.xml
+++ b/msautotest/wxs/expected/wms_getstyles_expressions23.xml
@@ -1,0 +1,24 @@
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<se:Name>Test23</se:Name>
+<UserStyle>
+<se:FeatureTypeStyle>
+<se:Rule>
+<ogc:Filter><ogc:And><ogc:PropertyIsGreaterThan><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>1</ogc:Literal></ogc:PropertyIsGreaterThan><ogc:PropertyIsLessThanOrEqualTo><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>10</ogc:Literal></ogc:PropertyIsLessThanOrEqualTo></ogc:And></ogc:Filter>
+<se:PointSymbolizer>
+<se:Graphic>
+<se:Mark>
+<se:WellKnownName>square</se:WellKnownName>
+<se:Fill>
+<se:SvgParameter name="fill">#dc0000</se:SvgParameter>
+</se:Fill>
+</se:Mark>
+<se:Size>1</se:Size>
+</se:Graphic>
+</se:PointSymbolizer>
+</se:Rule>
+</se:FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>
+

--- a/msautotest/wxs/wms_styles_expressions.map
+++ b/msautotest/wxs/wms_styles_expressions.map
@@ -25,6 +25,9 @@
 # RUN_PARMS: wms_getstyles_expressions18.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test18" > [RESULT_DEMIME]
 # RUN_PARMS: wms_getstyles_expressions19.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test19" > [RESULT_DEMIME]
 # RUN_PARMS: wms_getstyles_expressions20.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test20" > [RESULT_DEMIME]
+# RUN_PARMS: wms_getstyles_expressions21.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test21" > [RESULT_DEMIME]
+# RUN_PARMS: wms_getstyles_expressions22.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test22" > [RESULT_DEMIME]
+# RUN_PARMS: wms_getstyles_expressions23.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test23" > [RESULT_DEMIME]
 
 MAP
     NAME WMS_TEST
@@ -284,6 +287,45 @@ MAP
       TYPE POINT
       CLASS
         EXPRESSION ( [locationtype] = "primary location " )
+        STYLE
+            COLOR 220 0 0
+            WIDTH 1
+        END
+      END
+    END
+    
+    # test for multiple expressions with brackets and spaces
+    LAYER
+      NAME "Test21"
+      TYPE POINT
+      CLASS
+        EXPRESSION ( ( [FID] > 1 ) AND ( [FID] <= 10 ) )
+        STYLE
+            COLOR 220 0 0
+            WIDTH 1
+        END
+      END
+    END
+
+    # test for multiple string expressions with brackets and spaces
+    LAYER
+      NAME "Test22"
+      TYPE POINT
+      CLASS
+        EXPRESSION ( ( [locationtype] = "primary location " ) OR ( [locationtype] = " secondary location" ) )
+        STYLE
+            COLOR 220 0 0
+            WIDTH 1
+        END
+      END
+    END
+
+    # test for multiple expressions with spaces but not brackets
+    LAYER
+      NAME "Test23"
+      TYPE POINT
+      CLASS
+        EXPRESSION ( [FID] > 1 AND [FID] <= 10 )
         STYLE
             COLOR 220 0 0
             WIDTH 1

--- a/src/mapogcsld.cpp
+++ b/src/mapogcsld.cpp
@@ -4942,8 +4942,11 @@ static char *msSLDGetAttributeNameOrValue(const char *pszExpression,
           break;
         else if (pszAttributeValue[i] == '"' && bDoubleQuote)
           break;
-        else if (pszAttributeValue[i] == ')')
+        else if (pszAttributeValue[i] == ')') {
+          // remove any spaces prior to the closing bracket
+          msStringTrimBlanks(pszFinalAttributeValue);
           break;
+        }
         pszFinalAttributeValue[iAtt++] = pszAttributeValue[i];
       }
       pszFinalAttributeValue[iAtt] = '\0';


### PR DESCRIPTION
A case that was missed in #6983 - multipart expressions such as the following:

`EXPRESSION ( ( [FID] > 1 ) AND ( [FID] <= 10 ) )`

Were still retaining spaces:

```xml
<ogc:And><ogc:PropertyIsGreaterThan><ogc:PropertyName>FID</ogc:PropertyName><ogc:Literal>1 </ogc:Literal>
</ogc:PropertyIsGreaterThan><ogc:PropertyIsLessThanOrEqualTo><ogc:PropertyName>FID</ogc:PropertyName>
<ogc:Literal>10 </ogc:Literal></ogc:PropertyIsLessThanOrEqualTo></ogc:And>
```

This change removes the spaces. A test also added to ensure that strings with spaces e.g. "my value " retain the trailing space. 