### PR TITLE
Remove trailing spaces from stroke-dasharray SLD output

### DIFF
--- a/msautotest/wxs/expected/wms_getstyles1.xml
+++ b/msautotest/wxs/expected/wms_getstyles1.xml
@@ -1,0 +1,19 @@
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<se:Name>Test1</se:Name>
+<UserStyle>
+<se:FeatureTypeStyle>
+<se:Rule>
+<se:LineSymbolizer>
+<se:Stroke>
+<se:SvgParameter name="stroke">#ff0000</se:SvgParameter>
+<se:SvgParameter name="stroke-width">2.00</se:SvgParameter>
+<se:SvgParameter name="stroke-dasharray">10.00 10.00</se:SvgParameter>
+</se:Stroke>
+</se:LineSymbolizer>
+</se:Rule>
+</se:FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>
+

--- a/msautotest/wxs/wms_styles.map
+++ b/msautotest/wxs/wms_styles.map
@@ -1,0 +1,30 @@
+#
+# Test WMS SLD returned by GetStyles requests
+#
+# REQUIRES: SUPPORTS=WMS
+#
+#
+# GetStyles
+# RUN_PARMS: wms_getstyles1.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test1" > [RESULT_DEMIME]
+
+MAP
+    NAME WMS_TEST
+
+    WEB
+      METADATA
+        "ows_enable_request" "*"
+      END
+    END
+
+    LAYER
+      NAME "Test1"
+      TYPE LINE
+      CLASS
+        STYLE
+          COLOR 255 0 0
+          WIDTH 2
+          PATTERN 10 10 END
+        END
+      END
+    END
+END

--- a/src/mapogcsld.cpp
+++ b/src/mapogcsld.cpp
@@ -3850,6 +3850,9 @@ char *msSLDGenerateLineSLD(styleObj *psStyle, layerObj *psLayer, int nVersion) {
       snprintf(szTmp, sizeof(szTmp), "%.2f ", psStyle->pattern[i]);
       pszDashArray = msStringConcatenate(pszDashArray, szTmp);
     }
+    // remove the final trailing space from the last pattern value
+    msStringTrimBlanks(pszDashArray);
+
     snprintf(szTmp, sizeof(szTmp), "<%s name=\"stroke-dasharray\">%s</%s>\n",
              sCssParam, pszDashArray, sCssParam);
     pszSLD = msStringConcatenate(pszSLD, szTmp);


### PR DESCRIPTION
The following `STYLE`

```
        STYLE
          COLOR 255 0 0
          WIDTH 2
          PATTERN 10 10 END
        END
```

Produces SLD output with trailing whitespace:

```xml
<se:SvgParameter name="stroke-dasharray">10.00 10.00 </se:SvgParameter>
```

When working with GeoStyler this style fails to render in OpenLayers. As I understand it this whitespace in nodes are part of the node value so the fix should be on the MapServer side. 

This change ensures the trailing space is trimmed. A new test mapfile has been created for tests for more advanced SLD output from styles. 