### PR TITLE
coveralls.io fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       WITH_ASAN: ${{ matrix.WITH_ASAN }}
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      COVERALLS_SERVICE_NAME: "GitHub Actions"
 
     steps:
       - name: Checkout repository contents
@@ -30,7 +31,8 @@ jobs:
         run: |
             docker run \
             -e WORK_DIR="$PWD" \
-            -e WITH_ASAN=${{ env.WITH_ASAN }} \
-            -e COVERALLS_REPO_TOKEN=${{ env.COVERALLS_REPO_TOKEN }} \
-            -e WORK_DIR="$PWD" \
+            -e WITH_ASAN="${{ env.WITH_ASAN }}" \
+            -e COVERALLS_REPO_TOKEN="${{ env.COVERALLS_REPO_TOKEN }}" \
+            -e COVERALLS_SERVICE_NAME="${{ env.COVERALLS_SERVICE_NAME }}" \
+            -e EVENT_NAME="${{ github.event_name }}" \
             -v $PWD:$PWD ubuntu:20.04 $PWD/.github/workflows/start.sh

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -58,15 +58,15 @@ if [ "${WITH_ASAN:-}" = "true" ]; then
 else
     make -j4 test
 fi
-
-if [ "${WITH_ASAN:-}" != "true" ]; then
+   
+if [ "${EVENT_NAME:-}" = "push" ] && [ "${WITH_ASAN:-}" != "true" ] && [ -n "${COVERALLS_REPO_TOKEN:-}" ]; then
+    echo "uploading to coveralls"
     git config --global --add safe.directory "${WORK_DIR:=..}"
     ln -s ../../../src/mapparser.y build/CMakeFiles/mapserver.dir/
     ln -s ../../../src/maplexer.l build/CMakeFiles/mapserver.dir/
-    # upload coverage - always return true if there are errors
+
     coveralls --exclude renderers --exclude mapscript --exclude apache --exclude build/mapscript/mapscriptJAVA_wrap.c \
     --exclude build/mapscript/mapscriptPYTHON_wrap.c --exclude map2img.c --exclude legend.c --exclude scalebar.c \
     --exclude msencrypt.c --exclude sortshp.c --exclude shptreevis.c --exclude shptree.c --exclude testexpr.c \
-    --exclude testcopy.c --exclude shptreetst.c --exclude tile4ms.c --extension .c --extension .cpp || true
+    --exclude testcopy.c --exclude shptreetst.c --exclude tile4ms.c --extension .c --extension .cpp
 fi
-


### PR DESCRIPTION
Follow-up to #6993 to fix coveralls.io updates, noted by @rouault in https://github.com/MapServer/MapServer/pull/6993#issuecomment-1867815481

There was an issue with quoting around the security token. I've also updated the service name which defaults to `travis-ci` in cpp-coveralls - https://github.com/eddyxu/cpp-coveralls/blob/47f638727512126bc16b1365560854a86db70e7e/cpp_coveralls/__init__.py#L79

The upload now will only happen when merging,and on the main branch rather than ignoring errors. 

Tested in my fork with a token and coveralls.io setup, and working fine: https://coveralls.io/github/geographika/mapserver



