### PR TITLE
Upload to coveralls.io on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set RUN_COVERALLS Environment Variable
-        if: env.WITH_ASAN != 'true'
-        # if: (github.event.pull_request.merged == true || github.event_name == 'push') && env.WITH_ASAN != 'true'
-        run: echo "Setting UPLOAD_COVERALLS to true"
-        env:
-          UPLOAD_COVERALLS: true
+        if: (github.event.pull_request.merged == true || github.event_name == 'push') && env.WITH_ASAN != 'true'
+        run: |
+            echo "Setting UPLOAD_COVERALLS to true"
+            echo "UPLOAD_COVERALLS=true" >>${GITHUB_ENV}
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set RUN_COVERALLS Environment Variable
-        if: (github.event.pull_request.merged == true || github.event_name == 'push') && env.WITH_ASAN != 'true'
+        if: env.WITH_ASAN != 'true'
+        # if: (github.event.pull_request.merged == true || github.event_name == 'push') && env.WITH_ASAN != 'true'
         run: echo "Setting UPLOAD_COVERALLS to true"
         env:
           UPLOAD_COVERALLS: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,17 +22,25 @@ jobs:
       WITH_ASAN: ${{ matrix.WITH_ASAN }}
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       COVERALLS_SERVICE_NAME: "GitHub Actions"
+      UPLOAD_COVERALLS: "false"
 
     steps:
       - name: Checkout repository contents
         uses: actions/checkout@v3
 
+      - name: Set RUN_COVERALLS Environment Variable
+        if: (github.event.pull_request.merged == true || github.event_name == 'push') && env.WITH_ASAN != 'true'
+        run: echo "Setting UPLOAD_COVERALLS to true"
+        env:
+          UPLOAD_COVERALLS: true
+
       - name: Build
         run: |
+            echo "${{ env.UPLOAD_COVERALLS }}"
             docker run \
             -e WORK_DIR="$PWD" \
             -e WITH_ASAN="${{ env.WITH_ASAN }}" \
             -e COVERALLS_REPO_TOKEN="${{ env.COVERALLS_REPO_TOKEN }}" \
             -e COVERALLS_SERVICE_NAME="${{ env.COVERALLS_SERVICE_NAME }}" \
-            -e EVENT_NAME="${{ github.event_name }}" \
+            -e UPLOAD_COVERALLS="${{ env.UPLOAD_COVERALLS }}" \
             -v $PWD:$PWD ubuntu:20.04 $PWD/.github/workflows/start.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,6 @@ jobs:
 
       - name: Build
         run: |
-            echo "${{ env.UPLOAD_COVERALLS }}"
             docker run \
             -e WORK_DIR="$PWD" \
             -e WITH_ASAN="${{ env.WITH_ASAN }}" \

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -58,8 +58,8 @@ if [ "${WITH_ASAN:-}" = "true" ]; then
 else
     make -j4 test
 fi
-   
-if [ "${EVENT_NAME:-}" = "push" ] && [ "${WITH_ASAN:-}" != "true" ] && [ -n "${COVERALLS_REPO_TOKEN:-}" ]; then
+
+if "${UPLOAD_COVERALLS:-}" = "true" ]; then
     echo "uploading to coveralls"
     git config --global --add safe.directory "${WORK_DIR:=..}"
     ln -s ../../../src/mapparser.y build/CMakeFiles/mapserver.dir/


### PR DESCRIPTION
From https://github.com/MapServer/MapServer/pull/6996#issuecomment-1868267998

> Note that coveralls also work with pull requests (the resulting builds are presented in a separate way in coveralls.io). Which is very useful to check if a new feature/bug fix has sufficient test coverages.
> I'm not totally sure if this is possible with the way we use coveralls, but this is definitely handled by using the github action coverallsapp/github-action@v2 which doesn't require the coveralls secret but uses the regular github secret available in pull requests

This should make it easier to control when to upload - it should now be triggered on any github event, but it should be easy to modify the logic to filter certain events with the `UPLOAD_COVERALLS` variable. 