### PR TITLE
Ruby bindings: Return 0 on exceptions, not NULL

### DIFF
--- a/src/mapscript/ruby/rbmodule.i
+++ b/src/mapscript/ruby/rbmodule.i
@@ -129,7 +129,7 @@ static void _raise_ms_exception() {
             default:
                 _raise_ms_exception();
                 msResetErrorList();
-                return NULL;
+                return 0;
         }
 
     }


### PR DESCRIPTION
At least Ruby 3.2 anf SWIG 4.1 expect an integer here, resulting in an int-conversion error with current/upcoming compilers.  Return 0 instead of NULL works with pointer return types, too, should there be a supported Ruby version which uses a pointer in this context.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
