### PR TITLE
fixed `=*` operator translation for Oracle database

### DIFF
--- a/src/maporaclespatial.c
+++ b/src/maporaclespatial.c
@@ -4331,9 +4331,12 @@ int msOracleSpatialLayerTranslateFilter(layerObj *layer, expressionObj *filter,
         native_string = msStringConcatenate(native_string, snippet);
         if (ieq == MS_TRUE) {
           native_string = msStringConcatenate(native_string, "$");
-          ieq = MS_FALSE;
         }
         native_string = msStringConcatenate(native_string, "'");
+        if (ieq == MS_TRUE) {
+          native_string = msStringConcatenate(native_string, ")");
+          ieq = MS_FALSE;
+        }
         msFree(snippet);
         break;
       case MS_TOKEN_LITERAL_BOOLEAN:


### PR DESCRIPTION
This PR fixes a query issue on Oracle databases.
An expression such as `'[FIELD]' =* 'value'` was translated into a SQL expression such as `REGEXP_LIKE( FIELD, '^value$'`, which lacks the closing parenthesis.
The fix has been verified and already used on a production server.
