### PR TITLE
Add pasteImage and saveWebImage to Mapscript imageObj

### DIFF
--- a/src/mapscript/python/tests/cases/image_test.py
+++ b/src/mapscript/python/tests/cases/image_test.py
@@ -154,6 +154,37 @@ class ImageWriteTestCase(MapTestCase):
             assert pyimg.size == (200, 200)
             assert pyimg.mode == "RGB"
 
+    def testSaveWebImage(self):
+        """save an image to the imagepath folder and return its URL"""
+
+        # set the imagepath and imageurl on the MAP WEB object
+        self.map.web.imagepath = ""
+        self.map.web.imageurl = "/output/"
+
+        image = self.map.draw()
+        url = image.saveWebImage()
+        assert url.startswith("/output/")
+        assert url.endswith(".png")
+
+    def testPasteImage(self):
+        """save an image to the imagepath folder and return its URL"""
+
+        image1 = self.map.draw()
+        image2 = self.map.draw()
+
+        ret = image1.pasteImage(image2, opacity=0.5, dstx=10, dsty=10)
+        assert ret == mapscript.MS_SUCCESS
+
+        filename = "testImagePaste.png"
+        fh = open(filename, "wb")
+        image1.write(fh)
+        fh.close()
+        if have_image:
+            pyimg = Image.open(filename)
+            assert pyimg.format == "PNG"
+            assert pyimg.size == (200, 200)
+            assert pyimg.mode == "RGB"
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/mapscript/swiginc/image.i
+++ b/src/mapscript/swiginc/image.i
@@ -255,7 +255,6 @@
         }
 
         imageUrlFull = msStrdup(msBuildPath(path, self->imageurl, imageFilename));
-        msFree(imageFile);        
         msFree(imageFilename);
         return imageUrlFull;
     }

--- a/src/mapscript/swiginc/image.i
+++ b/src/mapscript/swiginc/image.i
@@ -250,12 +250,14 @@
             msSetError(MS_IMGERR, "Failed writing image to %s",
                        "imageObj::saveWebImage",
                        imageFile);
+            msFree(imageFilename);
+            msFree(imageFile);
             return NULL;
         }
 
         imageUrlFull = msBuildPath(path, self->imageurl, imageFilename);
         msFree(imageFilename);
-
+        msFree(imageFile);
         return imageUrlFull;
     }
 }

--- a/src/mapscript/swiginc/image.i
+++ b/src/mapscript/swiginc/image.i
@@ -250,14 +250,14 @@
             msSetError(MS_IMGERR, "Failed writing image to %s",
                        "imageObj::saveWebImage",
                        imageFile);
+            msFree(imageFile);                       
             msFree(imageFilename);
-            msFree(imageFile);
             return NULL;
         }
 
-        imageUrlFull = msBuildPath(path, self->imageurl, imageFilename);
+        imageUrlFull = msStrdup(msBuildPath(path, self->imageurl, imageFilename));
+        msFree(imageFile);        
         msFree(imageFilename);
-        msFree(imageFile);
         return imageUrlFull;
     }
 }

--- a/src/mapscript/swiginc/image.i
+++ b/src/mapscript/swiginc/image.i
@@ -197,18 +197,17 @@
         return size;
     }
 
-    /* Pastes another imageObj on top of this imageObj.
-       If optional dstx,dsty are provided then they define the position where the
-       image should be copied (dstx,dsty = top-left corner position).
-       NOTE : this function only works for 8 bits GD images.
+    /**
+    Pastes another imageObj on top of this imageObj.
+    If optional dstx,dsty are provided then they define the position where the
+    image should be copied (dstx,dsty = top-left corner position).
     */
     int pasteImage(imageObj *imageSrc, double opacity=1.0, int dstx=0, int dsty=0)
     {
         rendererVTableObj *renderer = NULL;
         rasterBufferObj rb;
 
-        if (!MS_RENDERER_PLUGIN(self->format) ||
-            !MS_RENDERER_PLUGIN(self->format)) {
+        if (!MS_RENDERER_PLUGIN(self->format)) {
             msSetError(MS_IMGERR, "PasteImage function should only be used with renderer plugin drivers.",
                        "imageObj::pasteImage");
             return MS_FAILURE;
@@ -233,7 +232,10 @@
 
     }
 
-    /* Writes image to temp directory.  Returns image URL. */
+    /**
+    Writes the image to temp directory.
+    Returns the image URL.
+    */
     char *saveWebImage()
     {
         char *imageFile = NULL;
@@ -248,7 +250,7 @@
             msSetError(MS_IMGERR, "Failed writing image to %s",
                        "imageObj::saveWebImage",
                        imageFile);
-            return;
+            return NULL;
         }
 
         imageUrlFull = msBuildPath(path, self->imageurl, imageFilename);

--- a/src/mapscript/swiginc/image.i
+++ b/src/mapscript/swiginc/image.i
@@ -250,7 +250,6 @@
             msSetError(MS_IMGERR, "Failed writing image to %s",
                        "imageObj::saveWebImage",
                        imageFile);
-            msFree(imageFile);                       
             msFree(imageFilename);
             return NULL;
         }


### PR DESCRIPTION
Follow-up and replacement to #6932 (thanks to @jbfrd) . Additional tests added to the Python test suite. The MapScript API docs should update automatically based on the docstrings on the next release of MapServer / MapScript. 

The test paste function produces the following output (unlike msautotests there is no image comparison as part of the tests - the test just checks the function runs correctly):

![testImagePaste](https://github.com/MapServer/MapServer/assets/490840/c8ad25b2-e7e8-41c4-a0bd-e4937283e07b)
