### PR TITLE
Add a ignoremissing option to template items

### DIFF
--- a/msautotest/wxs/expected/wms_raster_query.html
+++ b/msautotest/wxs/expected/wms_raster_query.html
@@ -1,0 +1,18 @@
+Blue: 144<br/>
+Green: 69<br/>
+Red: 141<br/>
+
+Band 1: 141<br/>
+Band 2: 69<br/>
+Band 3: 144  <br/>
+Band 4: -1<br/>
+Band 5: 55<br/>
+Band 6: 99<br/>
+Band 7: 127<br/>
+Band 8: 38<br/>
+Band 9: 43<br/>
+Band 99: missing<br/>
+
+Value List: 141,69,144,106,55,99,127,38,43<br/>
+X: 16<br/>
+Y: 48.99<br/>

--- a/msautotest/wxs/expected/wms_raster_query.html
+++ b/msautotest/wxs/expected/wms_raster_query.html
@@ -1,3 +1,5 @@
+Content-Type: text/html
+
 Blue: 144<br/>
 Green: 69<br/>
 Red: 141<br/>

--- a/msautotest/wxs/expected/wms_raster_query.json
+++ b/msautotest/wxs/expected/wms_raster_query.json
@@ -1,0 +1,10 @@
+Content-Disposition: attachment; filename=result.dat
+Content-Type: application/json; subtype=geojson; charset=utf-8
+
+{
+"type": "FeatureCollection",
+"name": "raster",
+"features": [
+{ "type": "Feature", "properties": { "x": "15.937198", "y": "48.99088", "value_0": "141", "value_1": "69", "value_2": "144", "value_3": "106", "value_4": "55", "value_5": "99", "value_6": "127", "value_7": "38", "value_8": "43", "value_list": "141,69,144,106,55,99,127,38,43", "red": "141", "green": "69", "blue": "144" }, "geometry": { "type": "Point", "coordinates": [ 15.937197681359713, 48.990879590043257 ] } }
+]
+}

--- a/msautotest/wxs/templates/raster_query.html
+++ b/msautotest/wxs/templates/raster_query.html
@@ -1,0 +1,19 @@
+<!-- MapServer Template -->
+Blue: [blue]<br/>
+Green: [green]<br/>
+Red: [red]<br/>
+
+Band 1: [value_0]<br/>
+[item name="value_1" format="Band 2: $value" nullformat=""]<br/>
+Band 3: [item name="value_2" padding=5]<br/>
+Band 4: [item name="value_3" pattern="^\d*\.\d+$" nullformat="-1"]<br/>
+[item name="value_4" format="Band 5: $value"]<br/>
+[item name="value_5" format="Band 6: $value"]<br/>
+[item name="value_6" format="Band 7: $value"]<br/>
+[item name="value_7" format="Band 8: $value"]<br/>
+[item name="value_8" format="Band 9: $value"]<br/>
+Band 99: [item name="value_99" nullformat="missing" ignoremissing="true"]<br/>
+
+Value List: [value_list]<br/>
+X: [item name="x" precision=0]<br/>
+Y: [item name="y" precision=2]<br/>

--- a/msautotest/wxs/wms_raster_query.map
+++ b/msautotest/wxs/wms_raster_query.map
@@ -1,0 +1,53 @@
+#
+# Test Raster Queries using different output formats and templates
+#
+# REQUIRES: INPUT=GDAL SUPPORTS=WMS
+
+# RUN_PARMS: wms_raster_query.json [MAPSERV] QUERY_STRING="map=[MAPFILE]&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&FORMAT=image%2Fpng&TRANSPARENT=true&QUERY_LAYERS=raster&LAYERS=raster&STYLES=&FILTER=&INFO_FORMAT=geojson&I=50&J=50&CRS=EPSG%3A4326&WIDTH=101&HEIGHT=101&BBOX=48.79202566966527%2C15.757350496548119%2C49.16611202635983%2C16.13143685324268" > [RESULT_DEVERSION]
+# RUN_PARMS: wms_raster_query.html [MAPSERV] QUERY_STRING="map=[MAPFILE]&&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&FORMAT=image%2Fpng&TRANSPARENT=true&QUERY_LAYERS=raster&LAYERS=raster&STYLES=&FILTER=&INFO_FORMAT=text/html&I=50&J=50&CRS=EPSG%3A4326&WIDTH=101&HEIGHT=101&BBOX=48.79202566966527%2C15.757350496548119%2C49.16611202635983%2C16.13143685324268" > [RESULT_DEVERSION]
+
+MAP
+    NAME "TEST"
+    SIZE 105 61
+    EXTENT 14.4702712 47.8188382 18.0111282 49.8911432
+    OUTPUTFORMAT
+        NAME "GEOTIFF_8"
+        DRIVER "GDAL/GTiff"
+        MIMETYPE "image/tiff"
+        IMAGEMODE BYTE
+        EXTENSION "tif"
+    END
+    OUTPUTFORMAT
+        NAME "geojson"
+        DRIVER "OGR/GEOJSON"
+        MIMETYPE "application/json; subtype=geojson; charset=utf-8"
+        FORMATOPTION "FORM=SIMPLE"
+        FORMATOPTION "STORAGE=memory"
+        FORMATOPTION "LCO:NATIVE_MEDIA_TYPE=application/vnd.geo+json"
+    END
+    PROJECTION
+        "init=epsg:4326"
+    END
+    WEB
+        METADATA
+            "ows_enable_request" "*" 
+            "wms_getfeatureinfo_formatlist" "text/html,geojson" 
+        END
+    END
+    #METADATA
+    #WEB
+    LAYER
+        NAME "raster"
+        TYPE RASTER
+        STATUS ON
+        DATA "data/multiband.tif"
+        TEMPLATE "templates/raster_query.html"
+        PROJECTION
+            "init=epsg:4326"
+        END
+        METADATA
+            "gml_include_items" "all" 
+            "gml_types" "auto" 
+        END
+    END
+END


### PR DESCRIPTION
As discussed in #7014 this adds a new `ignoremissing` property to template items. Example usage:

```
[item name="value_99" nullformat="missing" ignoremissing="true"]
```

If the field `value_99` is missing from the features then the `nullformat` value will be displayed (in this case "missing").
This allows the same template to be used for different datasets which may have slightly different fields, without throwing an error. 

Docs to be updated at https://mapserver.org/mapfile/template.html#format if merged. 