### PR TITLE
flatgeobuf: add missing error name for MS_FGBERR

### DIFF
--- a/src/maperror.c
+++ b/src/maperror.c
@@ -86,7 +86,8 @@ static char *const ms_errorCodes[MS_NUMERRORCODES] = {
     "OpenGL renderer error.",
     "Renderer error.",
     "V8 engine error.",
-    "OCG API error."};
+    "OCG API error.",
+    "Flatgeobuf error."};
 
 #ifndef USE_THREAD
 


### PR DESCRIPTION
For native flatgeobuf support a new error code was added but no name / description text to the `ms_errorCodes` array.

To reproduce it would be enough to trigger any `msSetError` which uses `MS_FGBERR` but I think the change is clear enough by itself. In all cases I saw this error the string "(null)" was printed instead because printf was involved at some point and the memory after the last array entry was always null. (and I produced a lot of those error messages while reproducing #7040)