### PR TITLE
map2img: improve error handling for missing option arguments

### DIFF
--- a/msautotest/misc/expected/map2img-argparse-c.txt
+++ b/msautotest/misc/expected/map2img-argparse-c.txt
@@ -1,0 +1,1 @@
+Argument -c requires an additional argument.

--- a/msautotest/misc/expected/map2img-argparse-d.txt
+++ b/msautotest/misc/expected/map2img-argparse-d.txt
@@ -1,0 +1,1 @@
+Argument -d needs 2 space separated arguments.

--- a/msautotest/misc/expected/map2img-argparse-e.txt
+++ b/msautotest/misc/expected/map2img-argparse-e.txt
@@ -1,0 +1,1 @@
+Argument -e needs 4 space separated arguments.

--- a/msautotest/misc/expected/map2img-argparse-layer_debug.txt
+++ b/msautotest/misc/expected/map2img-argparse-layer_debug.txt
@@ -1,0 +1,1 @@
+Argument -layer_debug needs 2 space separated arguments.

--- a/msautotest/misc/expected/map2img-argparse-o.txt
+++ b/msautotest/misc/expected/map2img-argparse-o.txt
@@ -1,0 +1,1 @@
+Argument -o requires an additional argument.

--- a/msautotest/misc/expected/map2img-argparse-s.txt
+++ b/msautotest/misc/expected/map2img-argparse-s.txt
@@ -1,0 +1,1 @@
+Argument -s needs 2 space separated arguments.

--- a/msautotest/misc/map2img-argparse.map
+++ b/msautotest/misc/map2img-argparse.map
@@ -1,0 +1,38 @@
+#
+# Tests map2img incomplete arguments
+#
+# RUN_PARMS: map2img-argparse-s.txt [MAP2IMG] -m [MAPFILE] -s 640 > [RESULT] 2>&1 [ASAN_SKIP_LOG]
+# RUN_PARMS: map2img-argparse-e.txt [MAP2IMG] -m [MAPFILE] -e 0 1 > [RESULT] 2>&1 [ASAN_SKIP_LOG]
+# RUN_PARMS: map2img-argparse-o.txt [MAP2IMG] -m [MAPFILE] -o > [RESULT] 2>&1 [ASAN_SKIP_LOG]
+# RUN_PARMS: map2img-argparse-c.txt [MAP2IMG] -m [MAPFILE] -c > [RESULT] 2>&1 [ASAN_SKIP_LOG]
+# RUN_PARMS: map2img-argparse-d.txt [MAP2IMG] -m [MAPFILE] -d otherlayer > [RESULT] 2>&1 [ASAN_SKIP_LOG]
+# RUN_PARMS: map2img-argparse-layer_debug.txt [MAP2IMG] -m [MAPFILE] -layer_debug 3 > [RESULT] 2>&1 [ASAN_SKIP_LOG]
+
+MAP
+  NAME HELLO
+  STATUS ON
+  EXTENT 59 10 60 11
+  SIZE 400 300
+  IMAGECOLOR 200 255 255
+
+  IMAGETYPE png
+
+  LAYER
+    NAME "credits"
+    STATUS DEFAULT
+    TRANSFORM FALSE
+    TYPE POINT
+    FEATURE
+      POINTS
+        200 250
+      END
+      TEXT 'Hello world'
+    END
+    CLASS
+      LABEL
+        TYPE BITMAP
+        COLOR 0 0 0
+      END
+    END
+  END
+END

--- a/msautotest/pymod/mstestlib.py
+++ b/msautotest/pymod/mstestlib.py
@@ -651,6 +651,12 @@ def _run(map, out_file, command, extra_args):
 
     (command, strip_items) = collect_strip_requests(command)
 
+    # option to skip asan log output capturing for tests wanting to capture stderr in result file
+    asan_skip_log = False
+    if command.find("[ASAN_SKIP_LOG]") != -1:
+        asan_skip_log = True
+        command = command.replace("[ASAN_SKIP_LOG]", "")
+
     if valgrind:
         valgrind_log = "result/%s.txt" % (out_file + ".vgrind.txt")
         command = command.strip()
@@ -666,7 +672,7 @@ def _run(map, out_file, command, extra_args):
                 + '" | valgrind --tool=memcheck -q --suppressions=../valgrind-suppressions.txt --leak-check=full --show-reachable=yes %s 2>%s'
                 % (command, valgrind_log)
             )
-    elif run_under_asan:
+    elif run_under_asan and not asan_skip_log:
         asan_log = "result/" + out_file + ".asan.txt"
         command = command.strip()
         command += " 2>%s" % asan_log
@@ -701,7 +707,7 @@ def _run(map, out_file, command, extra_args):
             if not quiet:
                 print("     Valgrind log non empty.")
 
-    elif run_under_asan:
+    elif run_under_asan and not asan_skip_log:
         if os.path.getsize(asan_log) == 0:
             os.remove(asan_log)
         else:

--- a/src/apps/map2img.c
+++ b/src/apps/map2img.c
@@ -34,6 +34,32 @@
 
 #include "limits.h"
 
+/**
+ * Check if the required number of arguments are available for the
+ * parsed option or otherwise print an error message and exit.
+ *
+ * @param option option name for the error message
+ * @param num_required_arguments number of arguments required by option
+ * @param num_remaining_arguments number of arguments following the option
+ * @param config optional config object to free if we exit
+ * @param map optional map object to free if we exit
+ */
+static void hasMoreArgumentsOrExit(const char *option,
+                                   int num_required_arguments,
+                                   int num_remaining_arguments,
+                                   configObj *config, mapObj *map) {
+  if (num_remaining_arguments < num_required_arguments) {
+    if (num_required_arguments == 1)
+      fprintf(stderr, "Argument %s requires an additional argument.\n", option);
+    else
+      fprintf(stderr, "Argument %s needs %i space separated arguments.\n",
+              option, num_required_arguments);
+    msCleanup();
+    msFreeConfig(config);
+    exit(1);
+  }
+}
+
 int main(int argc, char *argv[]) {
   int i, j, k;
 
@@ -96,6 +122,7 @@ int main(int argc, char *argv[]) {
   const char *config_filename = NULL;
   for (i = 1; i < argc; i++) {
     if (strcmp(argv[i], "-c") == 0) { /* user specified number of draws */
+      hasMoreArgumentsOrExit("-c", 1, argc - i - 1, config, map);
       iterations = atoi(argv[i + 1]);
       if (iterations < 0 || iterations > INT_MAX - 1) {
         printf("Invalid number of iterations");
@@ -105,7 +132,8 @@ int main(int argc, char *argv[]) {
       continue;
     }
 
-    if (i < argc - 1 && strcmp(argv[i], "-all_debug") == 0) { /* global debug */
+    if (strcmp(argv[i], "-all_debug") == 0) { /* global debug */
+      hasMoreArgumentsOrExit("-all_debug", 1, argc - i - 1, config, map);
       int debug_level = atoi(argv[++i]);
 
       some_debug_requested = TRUE;
@@ -122,7 +150,8 @@ int main(int argc, char *argv[]) {
       continue;
     }
 
-    if (i < argc - 1 && strcmp(argv[i], "-conf") == 0) {
+    if (strcmp(argv[i], "-conf") == 0) {
+      hasMoreArgumentsOrExit("-conf", 1, argc - i - 1, config, map);
       config_filename = argv[i + 1];
       ++i;
       continue;
@@ -159,6 +188,7 @@ int main(int argc, char *argv[]) {
          i++) { /* Step though the user arguments, 1st to find map file */
 
       if (strcmp(argv[i], "-m") == 0) {
+        hasMoreArgumentsOrExit("-m", 1, argc - i - 1, config, map);
         map = msLoadMap(argv[i + 1], NULL, config);
         if (!map) {
           msWriteError(stderr);
@@ -184,6 +214,7 @@ int main(int argc, char *argv[]) {
       }
 
       if (strcmp(argv[i], "-p") == 0) {
+        hasMoreArgumentsOrExit("-p", 1, argc - i - 1, config, map);
         int pause_length = atoi(argv[i + 1]);
         time_t start_time = time(NULL);
 
@@ -196,11 +227,13 @@ int main(int argc, char *argv[]) {
       }
 
       if (strcmp(argv[i], "-o") == 0) { /* load the output image filename */
+        hasMoreArgumentsOrExit("-o", 1, argc - i - 1, config, map);
         outfile = argv[i + 1];
         i += 1;
       }
 
       if (strcmp(argv[i], "-i") == 0) {
+        hasMoreArgumentsOrExit("-i", 1, argc - i - 1, config, map);
         outputFormatObj *format;
 
         format = msSelectOutputFormat(map, argv[i + 1]);
@@ -216,6 +249,7 @@ int main(int argc, char *argv[]) {
       }
 
       if (strcmp(argv[i], "-d") == 0) { /* swap layer data */
+        hasMoreArgumentsOrExit("-d", 2, argc - i - 1, config, map);
         for (j = 0; j < map->numlayers; j++) {
           if (strcmp(GET_LAYER(map, j)->name, argv[i + 1]) == 0) {
             free(GET_LAYER(map, j)->data);
@@ -226,8 +260,8 @@ int main(int argc, char *argv[]) {
         i += 2;
       }
 
-      if (i < argc - 1 &&
-          strcmp(argv[i], "-all_debug") == 0) { /* global debug */
+      if (strcmp(argv[i], "-all_debug") == 0) { /* global debug */
+        hasMoreArgumentsOrExit("-all_debug", 1, argc - i - 1, config, map);
         int debug_level = atoi(argv[++i]);
 
         /* msSetGlobalDebugLevel() already called. Just need to force debug
@@ -239,11 +273,13 @@ int main(int argc, char *argv[]) {
         }
       }
 
-      if (i < argc - 1 && strcmp(argv[i], "-map_debug") == 0) { /* debug */
+      if (strcmp(argv[i], "-map_debug") == 0) { /* debug */
+        hasMoreArgumentsOrExit("-map_debug", 1, argc - i - 1, config, map);
         map->debug = atoi(argv[++i]);
       }
 
-      if (i < argc - 1 && strcmp(argv[i], "-layer_debug") == 0) { /* debug */
+      if (strcmp(argv[i], "-layer_debug") == 0) { /* debug */
+        hasMoreArgumentsOrExit("-layer_debug", 2, argc - i - 1, config, map);
         const char *layer_name = argv[++i];
         int debug_level = atoi(argv[++i]);
         int got_layer = 0;
@@ -261,13 +297,7 @@ int main(int argc, char *argv[]) {
       }
 
       if (strcmp(argv[i], "-e") == 0) { /* change extent */
-        if (argc <= i + 4) {
-          fprintf(stderr,
-                  "Argument -e needs 4 space separated numbers as argument.\n");
-          msCleanup();
-          msFreeConfig(config);
-          exit(1);
-        }
+        hasMoreArgumentsOrExit("-e", 4, argc - i - 1, config, map);
         map->extent.minx = atof(argv[i + 1]);
         map->extent.miny = atof(argv[i + 2]);
         map->extent.maxx = atof(argv[i + 3]);
@@ -276,11 +306,13 @@ int main(int argc, char *argv[]) {
       }
 
       if (strcmp(argv[i], "-s") == 0) {
+        hasMoreArgumentsOrExit("-s", 2, argc - i - 1, config, map);
         msMapSetSize(map, atoi(argv[i + 1]), atoi(argv[i + 2]));
         i += 2;
       }
 
       if (strcmp(argv[i], "-l") == 0) { /* load layer list */
+        hasMoreArgumentsOrExit("-l", 1, argc - i - 1, config, map);
         layers = msStringSplit(argv[i + 1], ' ', &(num_layers));
 
         for (j = 0; j < num_layers; j++) { /* loop over -l */
@@ -296,6 +328,8 @@ int main(int argc, char *argv[]) {
           }
           if (layer_found == 0) {
             fprintf(stderr, "Layer (-l) \"%s\" not found\n", layers[j]);
+            msFreeCharArray(layers, num_layers);
+            msFreeMap(map);
             msCleanup();
             msFreeConfig(config);
             exit(1);


### PR DESCRIPTION
The map2img command is too optimistic when parsing commandline arguments. In many cases it simply access the option argument without checking if it was actually provided leading sometimes to segfaults for incomplete commandlines.

Note that my change not only improves error handling for options which had non so far but also slightly changes behaviour for some other options.
The `-e` has already a check and custom error message. That message changes a bit with my commit.
Also other options (e.g. all the debug options) had a check before but simply skipped the option if the argument was missing. E.g. `map2img -m file.map -all_debug` would silently ignore the debug argument due to the missing level value before but report an error with my change.