### PR TITLE
Fix SVG symbol sizing when width and height are with physical units 

### DIFF
--- a/src/mapcairo.c
+++ b/src/mapcairo.c
@@ -1024,7 +1024,16 @@ int msPreloadSVGSymbol(symbolObj *symbol) {
         height.unit == RSVG_UNIT_PX) {
       symbol->sizex = width.length;
       symbol->sizey = height.length;
-    } else if (!has_viewbox) {
+    } else if (has_width && width.unit != RSVG_UNIT_PERCENT && has_height &&
+               height.unit != RSVG_UNIT_PERCENT) {
+      gdouble width_px;
+      gdouble height_px;
+      rsvg_handle_get_intrinsic_size_in_pixels(cache->svgc, &width_px,
+                                               &height_px);
+      symbol->sizex = width_px;
+      symbol->sizey = height_px;
+    } else if (!has_viewbox && has_width && width.unit == RSVG_UNIT_PERCENT &&
+               has_height && height.unit == RSVG_UNIT_PERCENT) {
       RsvgRectangle ink_rect = {0, 0, 0, 0};
       rsvg_handle_get_geometry_for_element(cache->svgc, NULL, &ink_rect, NULL,
                                            NULL);


### PR DESCRIPTION
SVG symbols having width and height attributes with physical units (px, in, cm, mm, pt, pc) will get sized from the viewBox if present. so a symbol like this:

```svg 
<svg xmlns="http://www.w3.org/2000/svg" width="5.5mm" height="5.5mm" viewBox="0 0 15 15">..</svg>
```

will get sized according to the viewBox. But 5.5mm is 20px, so the symbol will end up cropped on the map.

This patch will test if the symbol has intrinsic size and use rsvg_handle_get_intrinsic_size_in_pixels to get the pixel size and size the symbol from that.