### PR TITLE
Add -D_DEFAULT_SOURCE for strlcat/strlcpy provided by glibc >= 2.38.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,10 @@ check_function_exists("strlcpy"  HAVE_STRLCPY)
 check_function_exists("strlen"  HAVE_STRLEN)
 check_function_exists("strncasecmp"  HAVE_STRNCASECMP)
 
+IF((HAVE_STRLCAT OR HAVE_STRLCPY) AND CMAKE_SYSTEM_NAME MATCHES "Linux")
+    add_definitions(-D_DEFAULT_SOURCE)
+ENDIF()
+
 check_symbol_exists(vsnprintf stdio.h HAVE_VSNPRINTF)
 IF(NOT HAVE_VSNPRINTF)
     check_function_exists("vsnprintf"  HAVE_VSNPRINTF)


### PR DESCRIPTION
As reported in [Debian Bug #1067651](https://bugs.debian.org/1067651) MapServer failed to build on Ubuntu noble with glibc 2.39.

`strlcpy` and `strlcat` were introduced in glibc 2.38 but require `-D_DEFAULT_SOURCE` to actually work after being detected by `check_function_exists()`.