### PR TITLE
CMake and CI adjustments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0...3.23)
+cmake_minimum_required(VERSION 3.0...3.29)
 
 project (MapServer)
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -12,10 +12,13 @@ if [ "${MAPSCRIPT_PYTHON_ONLY:-}" = "true" ]; then
     exit
 fi
 
+# Turn CMake warnings as errors
+EXTRA_CMAKEFLAGS="-Werror=dev"
+
 if [ "${WITH_ASAN:-}" = "true" ]; then
     # -DNDEBUG to avoid issues with cairo cleanup
     make cmakebuild MFLAGS="-j$(nproc)" CMAKE_C_FLAGS="-g -fsanitize=address -DNDEBUG" CMAKE_CXX_FLAGS="-g -fsanitize=address -DNDEBUG" \
-    EXTRA_CMAKEFLAGS="-DCMAKE_BUILD_TYPE=None -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address"
+    EXTRA_CMAKEFLAGS="${EXTRA_CMAKEFLAGS} -DCMAKE_BUILD_TYPE=None -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address"
 else
     make cmakebuild MFLAGS="-j$(nproc)" CMAKE_C_FLAGS="-O2" CMAKE_CXX_FLAGS="-O2" LIBMAPSERVER_EXTRA_FLAGS="-Wall -Werror -Wextra"
     make mspython-wheel

--- a/cmake/FindGDAL.cmake
+++ b/cmake/FindGDAL.cmake
@@ -73,7 +73,7 @@ if(UNIX)
     )
 
     if(GDAL_CONFIG)
-        exec_program(${GDAL_CONFIG} ARGS --libs OUTPUT_VARIABLE GDAL_CONFIG_LIBS)
+        execute_process(COMMAND ${GDAL_CONFIG} --libs OUTPUT_VARIABLE GDAL_CONFIG_LIBS)
         if(GDAL_CONFIG_LIBS)
             string(REGEX MATCHALL "-l[^ ]+" _gdal_dashl ${GDAL_CONFIG_LIBS})
             string(REGEX REPLACE "-l" "" _gdal_lib "${_gdal_dashl}")

--- a/src/mapscript/csharp/run_test.sh
+++ b/src/mapscript/csharp/run_test.sh
@@ -1,12 +1,12 @@
 #!/bin/sh -ex
 cd ${CSHARP_MAPSCRIPT_SO}
 echo .: Testing shpdump.exe :.
-mono shpdump.exe ../../../../tests/point.shp
+LC_ALL=C mono shpdump.exe ../../../../tests/point.shp
 echo .: Testing drawmap.exe :.
-mono drawmap.exe ../../../../tests/test.map ./map.png
+LC_ALL=C mono drawmap.exe ../../../../tests/test.map ./map.png
 echo .: Testing shapeinfo.exe :.
-mono shapeinfo.exe ../../../../tests/point.shp
+LC_ALL=C mono shapeinfo.exe ../../../../tests/point.shp
 echo .: Testing getbytes.exe :.
-mono getbytes.exe ../../../../tests/test.map test_csharp2.png
+LC_ALL=C mono getbytes.exe ../../../../tests/test.map test_csharp2.png
 echo .: Testing RFC24.exe :.
-mono RFC24.exe ../../../../tests/test.map
+LC_ALL=C mono RFC24.exe ../../../../tests/test.map


### PR DESCRIPTION
- FindGDAL.cmake: replace use of deprecated exec_program() by execute_process() (avoid warning with CMake 3.28 or later)
- CMakeLists.txt: raise maximum version in cmake_minimum_required() to 3.29 now that CI tests it
- ci/build.sh: turn CMake warnings as errors
- src/mapscript/csharp/run_test.sh: make sure to run with LC_ALL=C
