### PR TITLE
Automatically Densify simple polygons when creating centerlines

### DIFF
--- a/src/mapgeos.c
+++ b/src/mapgeos.c
@@ -1284,7 +1284,13 @@ shapeObj *msGEOSCenterline(shapeObj *shape) {
     return NULL;
   }
 
-  shape2 = msGEOSVoronoiDiagram(shape, 0.0, MS_TRUE);
+  if (shape->numlines > 0 && shape->line[0].numpoints <= 6) {
+    // automatically densify simple polygons
+    shape2 = msDensify(shape, 3);
+    shape2 = msGEOSVoronoiDiagram(shape2, 0.0, MS_TRUE);
+  } else {
+    shape2 = msGEOSVoronoiDiagram(shape, 0.0, MS_TRUE);
+  }
   if (!shape2) {
     msSetError(MS_GEOSERR, "Voronoi diagram generation failed.",
                "msGEOSCenterline()");

--- a/src/mapgeos.c
+++ b/src/mapgeos.c
@@ -1286,8 +1286,12 @@ shapeObj *msGEOSCenterline(shapeObj *shape) {
 
   if (shape->numlines > 0 && shape->line[0].numpoints <= 6) {
     // automatically densify simple polygons
-    shape2 = msDensify(shape, 3);
-    shape2 = msGEOSVoronoiDiagram(shape2, 0.0, MS_TRUE);
+    shapeObj *densifiedShape = msDensify(shape, 3);
+    if (densifiedShape) {
+        shape2 = msGEOSVoronoiDiagram(densifiedShape, 0.0, MS_TRUE);
+        msFreeShape(densifiedShape);
+        free(densifiedShape);
+    }
   } else {
     shape2 = msGEOSVoronoiDiagram(shape, 0.0, MS_TRUE);
   }


### PR DESCRIPTION
Automatically densify simple polygons before creating msGEOSVoronoiDiagram. 
Possible fix for #7058. 

The number of points and the value of 3 for msDensify are based on a test dataset. I'm not sure of general applicability. 
