### PR TITLE
Fix Python MapScript installation.

### DIFF
--- a/src/mapscript/python/CMakeLists.txt
+++ b/src/mapscript/python/CMakeLists.txt
@@ -122,7 +122,7 @@ install(
     endif()
 
     execute_process(
-      COMMAND ${Python_EXECUTABLE} -m pip install \${PYTHON_ROOT} \${PYTHON_PREFIX}
+      COMMAND ${Python_EXECUTABLE} -m pip install \${PYTHON_ROOT} \${PYTHON_PREFIX} .
       WORKING_DIRECTORY ${OUTPUT_FOLDER}
     )
   "


### PR DESCRIPTION
The Debian package build for 8.2.0~beta1 failed to build because the Python MapScript files are not installed in `DESTDIR` as expected.

pip fails to install the Python MapScript files:
```
Install the project...
/usr/bin/cmake -P cmake_install.cmake
-- Install configuration: "RelWithDebInfo"
ERROR: You must give at least one requirement to install (see "pip help install")
```

This is fixed by specifying the current directory as the working directory is already set to the output directory.