### PR TITLE
Fix spelling errors.

### DIFF
--- a/src/mapogcapi.cpp
+++ b/src/mapogcapi.cpp
@@ -1217,7 +1217,7 @@ static int processCollectionItemsRequest(mapObj *map, cgiRequestObj *request,
 
   msProjectionInheritContextFrom(&reprObjs.proj, &(map->projection));
   if (msLoadProjectionString(&reprObjs.proj, outputCrs.c_str()) != 0) {
-    outputError(OGCAPI_SERVER_ERROR, "Cannot instanciate output CRS.");
+    outputError(OGCAPI_SERVER_ERROR, "Cannot instantiate output CRS.");
     return MS_SUCCESS;
   }
 


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build:

 * instanciate -> instantiate