### PR TITLE
Fix workaround for Proj versions 9.0.0 to 9.4.0

### DIFF
--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1900,13 +1900,13 @@ int msProjectRect(projectionObj *in, projectionObj *out, rectObj *rect) {
    */
   else {
     int apply_over = MS_TRUE;
-#if PROJ_VERSION_MAJOR >= 6 && PROJ_VERSION_MAJOR < 9
+#if PROJ_VERSION_MAJOR >= 6 && PROJ_VERSION_MAJOR < 9 || (PROJ_VERSION_MAJOR == 9 && PROJ_VERSION_MINOR <= 4 && PROJ_VERSION_PATCH < 1)
     // Workaround PROJ [6,9[ bug (fixed per
     // https://github.com/OSGeo/PROJ/pull/3055) that prevents datum shifts from
     // being applied when +over is added to +init=epsg:XXXX This is far from
     // being bullet proof but it should work for most common use cases
     if (in && in->proj) {
-      if (in->numargs == 1 && EQUAL(in->args[0], "init=epsg:4326") &&
+      if (((in->numargs == 1 && EQUAL(in->args[0], "init=epsg:4326")) || (in->numargs == 2 &&  EQUAL(in->args[0], "init=epsg:4326") && EQUAL(in->args[1], "+epsgaxis=ne"))) &&
           rect->minx >= -180 && rect->maxx <= 180) {
         apply_over = MS_FALSE;
       } else if (in->numargs == 1 && EQUAL(in->args[0], "init=epsg:3857") &&

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1900,13 +1900,17 @@ int msProjectRect(projectionObj *in, projectionObj *out, rectObj *rect) {
    */
   else {
     int apply_over = MS_TRUE;
-#if PROJ_VERSION_MAJOR >= 6 && PROJ_VERSION_MAJOR < 9 || (PROJ_VERSION_MAJOR == 9 && PROJ_VERSION_MINOR <= 4 && PROJ_VERSION_PATCH < 1)
+#if PROJ_VERSION_MAJOR >= 6 && PROJ_VERSION_MAJOR < 9 ||                       \
+    (PROJ_VERSION_MAJOR == 9 && PROJ_VERSION_MINOR <= 4 &&                     \
+     PROJ_VERSION_PATCH < 1)
     // Workaround PROJ [6,9[ bug (fixed per
     // https://github.com/OSGeo/PROJ/pull/3055) that prevents datum shifts from
     // being applied when +over is added to +init=epsg:XXXX This is far from
     // being bullet proof but it should work for most common use cases
     if (in && in->proj) {
-      if (((in->numargs == 1 && EQUAL(in->args[0], "init=epsg:4326")) || (in->numargs == 2 &&  EQUAL(in->args[0], "init=epsg:4326") && EQUAL(in->args[1], "+epsgaxis=ne"))) &&
+      if (((in->numargs == 1 && EQUAL(in->args[0], "init=epsg:4326")) ||
+           (in->numargs == 2 && EQUAL(in->args[0], "init=epsg:4326") &&
+            EQUAL(in->args[1], "+epsgaxis=ne"))) &&
           rect->minx >= -180 && rect->maxx <= 180) {
         apply_over = MS_FALSE;
       } else if (in->numargs == 1 && EQUAL(in->args[0], "init=epsg:3857") &&


### PR DESCRIPTION
Hello,

This is a fix for a workaround for a bug in Proj versions between version 9.0.0 and 9.4.0 (inclusive), which is described in this issue:

#7019 

The source of this problem was a workaround in mapserver for a bug in proj prior to version 9.4.1. The workaround checks for proj major versions between 6 and 9, and then applies a fix. However, versions 9.0.0 through 9.4.0 suffer from the original proj bug, and do not have the workaround applied.


I'm fairly confident of my change on line 1903, but on line 1909 I had not much idea what I was doing. I only tested requests in EPSG:4326 and EPSG:3857 which the workaround targets, I did not test with expanded projection strings. 

I am happy to write some tests + test data for this change if required!