### PR TITLE
Pin SWIG version used for CI

### DIFF
--- a/.github/workflows/build-mapscript-python.yml
+++ b/.github/workflows/build-mapscript-python.yml
@@ -22,6 +22,7 @@ jobs:
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
     env:
       MAPSCRIPT_PYTHON_ONLY: 'true'
+      SWIG_GIT_TAG: 'v4.2.1' # master
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,12 @@ jobs:
           - name: Regular, with coverage
             WITH_ASAN: "false"
             WITH_COVERAGE: "true"
+            SWIG_GIT_TAG: "v4.2.1"
 
           - name: Address_sanitizer
             WITH_ASAN: "true"
             WITH_COVERAGE: "false"
+            SWIG_GIT_TAG: "v4.2.1"
 
     name: ${{ matrix.name }}
 
@@ -37,6 +39,7 @@ jobs:
             -e WORK_DIR="$PWD" \
             -e WITH_ASAN="${{ matrix.WITH_ASAN }}" \
             -e WITH_COVERAGE="${{ matrix.WITH_COVERAGE }}" \
+            -e SWIG_GIT_TAG="${{ matrix.SWIG_GIT_TAG }}" \
             -v $PWD:$PWD ubuntu:20.04 $PWD/.github/workflows/start.sh
 
       - name: Coveralls

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -30,8 +30,8 @@ echo "cmake version"
 cmake --version
 
 # upgrade to recent SWIG
-git clone https://github.com/swig/swig.git swig-git-master
-cd swig-git-master
+git clone --branch "${SWIG_GIT_TAG:-master}" --depth 1 https://github.com/swig/swig.git swig-git
+cd swig-git
 wget https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.39/pcre2-10.39.tar.gz
 ./Tools/pcre-build.sh
 ./autogen.sh


### PR DESCRIPTION
The master branch of SWIG is breaking Python MapScript - #7081. 
I've not found a backwards (or indeed forwards!) fix for this yet, so I think it may be simplest to pin SWIG to the last working version / released version, rather than using the master branch which could break the CI at any time. 

cc @rouault 