### PR TITLE
add PHP 8.3 to test matrix

### DIFF
--- a/.github/workflows/build-mapscript-php.yml
+++ b/.github/workflows/build-mapscript-php.yml
@@ -3,7 +3,7 @@ name: Build and test PHP MapScript
 on:
   push:
     branches:
-      - 'main'
+      - '*'
     except:
       - /^(cherry-pick-)?backport-\d+-to-/
 

--- a/.github/workflows/build-mapscript-php.yml
+++ b/.github/workflows/build-mapscript-php.yml
@@ -20,6 +20,8 @@ jobs:
     strategy:
       matrix:
         php-version: [8.3, 8.2]
+    env:
+      IGNORE_COMPARISON_RESULT_ON_CI: 'true'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build-mapscript-php.yml
+++ b/.github/workflows/build-mapscript-php.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: [8.1, 8.2]
+        php-version: [8.1, 8.2, 8.3]
     env:
       IGNORE_COMPARISON_RESULT_ON_CI: 'true'
 

--- a/.github/workflows/build-mapscript-php.yml
+++ b/.github/workflows/build-mapscript-php.yml
@@ -6,6 +6,11 @@ on:
       - '*'
     except:
       - /^(cherry-pick-)?backport-\d+-to-/
+  pull_request:
+    branches:
+      - '*'
+    except:
+      - /^(cherry-pick-)?backport-\d+-to-/      
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/build-mapscript-php.yml
+++ b/.github/workflows/build-mapscript-php.yml
@@ -19,9 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: [8.1, 8.2, 8.3]
-    env:
-      IGNORE_COMPARISON_RESULT_ON_CI: 'true'
+        php-version: [8.2, 8.3]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build-mapscript-php.yml
+++ b/.github/workflows/build-mapscript-php.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: [8.2, 8.3]
+        php-version: [8.3, 8.2]
 
     steps:
       - name: Checkout code

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -59,12 +59,10 @@ if [ ${PHPVersionMinor} -gt 81 ]; then
     cd php && curl -LO https://phar.phpunit.de/phpunit-11.phar
     echo "PHPUnit version"
     php phpunit-11.phar --version
-    PHPUnitVersion=11
 else
     cd php && curl -LO https://phar.phpunit.de/phpunit-10.phar
     echo "PHPUnit version"
     php phpunit-10.phar --version
-    PHPUnitVersion=10
 fi
 echo "PHP includes"
 php-config --includes

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -51,11 +51,11 @@ python -m pyflakes .
 # run the Python server for the tests
 python -m http.server &> /dev/null &
 
-# get phpunit
+# get PHPUnit
 echo "PHP version"
 php -v
 cd php && curl -LO https://phar.phpunit.de/phpunit-11.phar
-echo "phpunit version"
+echo "PHPUnit version"
 php phpunit-11.phar --version
 echo "PHP includes"
 php-config --includes

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -55,8 +55,8 @@ python -m http.server &> /dev/null &
 echo "PHP version"
 php -v
 PHPVersion=$(php -v|grep --only-matching --perl-regexp "(PHP )\d+\.\\d+\.\\d+");
-PHPVersion=${PHPVersion:4:3};
-if [ ${PHPVersion} > 8.1 ]; then
+PHPVersionMinor=${PHPVersion:4:3};
+if [ ${PHPVersionMinor} > 8.1 ]; then
     cd php && curl -LO https://phar.phpunit.de/phpunit-11.phar
     echo "PHPUnit version"
     php phpunit-11.phar --version

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -54,8 +54,8 @@ python -m http.server &> /dev/null &
 # get PHPUnit
 echo "PHP version"
 php -v
-PHPVersionMinor=$(php --version | head -n 1 | cut -d " " -f 2 | cut -c 1,3);
-if [ ${PHPVersionMinor} > 81 ]; then
+PHPVersionMinor=$(php --version | head -n 1 | cut -d " " -f 2 | cut -c 1,3)
+if [ ${PHPVersionMinor} -gt 81 ]; then
     cd php && curl -LO https://phar.phpunit.de/phpunit-11.phar
     echo "PHPUnit version"
     php phpunit-11.phar --version

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -54,9 +54,19 @@ python -m http.server &> /dev/null &
 # get PHPUnit
 echo "PHP version"
 php -v
-cd php && curl -LO https://phar.phpunit.de/phpunit-11.phar
-echo "PHPUnit version"
-php phpunit-11.phar --version
+PHPVersion=$(php -v|grep --only-matching --perl-regexp "(PHP )\d+\.\\d+\.\\d+");
+PHPVersion=${PHPVersion:4:3};
+if [ ${PHPVersion} > 8.1 ]; then
+    cd php && curl -LO https://phar.phpunit.de/phpunit-11.phar
+    echo "PHPUnit version"
+    php phpunit-11.phar --version
+    PHPUnitVersion=11
+else
+    cd php && curl -LO https://phar.phpunit.de/phpunit-10.phar
+    echo "PHPUnit version"
+    php phpunit-10.phar --version
+    PHPUnitVersion=10
+fi
 echo "PHP includes"
 php-config --includes
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -54,10 +54,8 @@ python -m http.server &> /dev/null &
 # get PHPUnit
 echo "PHP version"
 php -v
-PHPVersion=$(php -v|grep --only-matching --perl-regexp "(PHP )\d+\.\\d+\.\\d+");
-PHPVersionMinor=${PHPVersion::0-2};
-echo "here: $PHPVersionMinor"
-if [ ${PHPVersionMinor} > 8.1 ]; then
+PHPVersionMinor=$(php --version | head -n 1 | cut -d " " -f 2 | cut -c 1,3);
+if [ ${PHPVersionMinor} > 81 ]; then
     cd php && curl -LO https://phar.phpunit.de/phpunit-11.phar
     echo "PHPUnit version"
     php phpunit-11.phar --version

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -54,9 +54,9 @@ python -m http.server &> /dev/null &
 # get phpunit
 echo "PHP version"
 php -v
-cd php && curl -LO https://phar.phpunit.de/phpunit-10.phar
+cd php && curl -LO https://phar.phpunit.de/phpunit-11.phar
 echo "phpunit version"
-php phpunit-10.phar --version
+php phpunit-11.phar --version
 echo "PHP includes"
 php-config --includes
 

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -55,7 +55,8 @@ python -m http.server &> /dev/null &
 echo "PHP version"
 php -v
 PHPVersion=$(php -v|grep --only-matching --perl-regexp "(PHP )\d+\.\\d+\.\\d+");
-PHPVersionMinor=${PHPVersion:4:3};
+PHPVersionMinor=${PHPVersion::0-2};
+echo "here: $PHPVersionMinor"
 if [ ${PHPVersionMinor} > 8.1 ]; then
     cd php && curl -LO https://phar.phpunit.de/phpunit-11.phar
     echo "PHPUnit version"

--- a/msautotest/php/run_test.sh
+++ b/msautotest/php/run_test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if test -z $PHP_MAPSCRIPT_SO; then
-   php phpunit-11.phar .
+   php phpunit-$PHPUnitVersion.phar .
    exit $?
 else
-   php -d "extension=$PHP_MAPSCRIPT_SO" phpunit-11.phar .
+   php -d "extension=$PHP_MAPSCRIPT_SO" phpunit-$PHPUnitVersion.phar .
    exit $?
 fi

--- a/msautotest/php/run_test.sh
+++ b/msautotest/php/run_test.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+PHPVersionMinor=$(php --version | head -n 1 | cut -d " " -f 2 | cut -c 1,3)
+if [ ${PHPVersionMinor} -gt 81 ]; then
+    PHPUnitVersion=11
+else
+    PHPUnitVersion=10
+fi
+
 if test -z $PHP_MAPSCRIPT_SO; then
    php phpunit-$PHPUnitVersion.phar .
    exit $?

--- a/msautotest/php/run_test.sh
+++ b/msautotest/php/run_test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if test -z $PHP_MAPSCRIPT_SO; then
-   php phpunit-10.phar .
+   php phpunit-11.phar .
    exit $?
 else
-   php -d "extension=$PHP_MAPSCRIPT_SO" phpunit-10.phar .
+   php -d "extension=$PHP_MAPSCRIPT_SO" phpunit-11.phar .
    exit $?
 fi


### PR DESCRIPTION
- also handles PHPUnit requirements for PHP versions
- the test matrix is now PHP 8.3 (currently `8.3.9`) and PHP 8.2 (currently `8.2.1`)
- this removes the unsupported PHP 8.1 from the test matrix