### PR TITLE
msautotest: avoid failed tests on AppVeyor to break the build

### DIFF
--- a/msautotest/mspython/test_rq.py
+++ b/msautotest/mspython/test_rq.py
@@ -397,6 +397,9 @@ def test_rq_9():
 # Open a classified map and post a point query.
 
 
+@pytest.mark.xfail(
+    "APPVEYOR" in os.environ, reason="fail for unknown reason on AppVeyor builds"
+)
 def test_rq_10():
 
     map = mapscript.mapObj(get_relpath_to_this("../gdal/classtest1.map"))
@@ -452,6 +455,9 @@ def test_rq_10():
 # Issue another point query, on colored text.
 
 
+@pytest.mark.xfail(
+    "APPVEYOR" in os.environ, reason="fail for unknown reason on AppVeyor builds"
+)
 def test_rqtest_12():
 
     map = mapscript.mapObj(get_relpath_to_this("../gdal/classtest1.map"))


### PR DESCRIPTION
For a yet-to-be-determined reasons, test_rq_10() and test_rqtest_12() have started to fail on AppVeyor builds somewhere between June 28th (https://github.com/MapServer/MapServer/commit/8401b7b6f86a8723aa38ce958894df0162b6fb9f) and July 8th 2024
(https://github.com/MapServer/MapServer/commit/20886024151c5befc9c2876765353929abf23b4f) No MapServer source code change seems to be involved.