### PR TITLE
Set GDAL_DRIVER_PATH on Windows for the GIF driver

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,7 +85,9 @@ build_script:
   - cd %BUILD_FOLDER%/build
   # set the MapScript custom environment variable for python 3.8+
   - set MAPSERVER_DLL_PATH=%BUILD_FOLDER%/build/Release;%SDK_BIN%
-  - set PROJ_LIB=%SDK_BIN%/proj9/SHARE
+  - set PROJ_DATA=%SDK_BIN%/proj9/SHARE
+  # ensure the GIF driver is available for tests
+  - set GDAL_DRIVER_PATH=%SDK_BIN%/gdal/plugins
   # check the mapserver exe can run
   - mapserv -v
   - cmake --build . --target pythonmapscript-wheel --config Release

--- a/msautotest/mspython/test_rq.py
+++ b/msautotest/mspython/test_rq.py
@@ -397,10 +397,10 @@ def test_rq_9():
 # Open a classified map and post a point query.
 
 
-@pytest.mark.xfail(
-    "APPVEYOR" in os.environ, reason="fail for unknown reason on AppVeyor builds"
-)
 def test_rq_10():
+    """
+    This test requires the GIF driver to be available in GDAL, by setting GDAL_DRIVER_PATH
+    """
 
     map = mapscript.mapObj(get_relpath_to_this("../gdal/classtest1.map"))
     layer = map.getLayer(0)
@@ -455,10 +455,10 @@ def test_rq_10():
 # Issue another point query, on colored text.
 
 
-@pytest.mark.xfail(
-    "APPVEYOR" in os.environ, reason="fail for unknown reason on AppVeyor builds"
-)
 def test_rqtest_12():
+    """
+    This test requires the GIF driver to be available in GDAL, by setting GDAL_DRIVER_PATH
+    """
 
     map = mapscript.mapObj(get_relpath_to_this("../gdal/classtest1.map"))
     layer = map.getLayer(0)


### PR DESCRIPTION
See discussions in #7103. Tests were failing as the GDAL GIF driver wasn't available by default in the Windows SDK.
Failing tests now re-enabled and passing. 