### PR TITLE
protoc compiler and library location

### DIFF
--- a/cmake/FindProtobufC.cmake
+++ b/cmake/FindProtobufC.cmake
@@ -55,6 +55,7 @@
 
 set(PROTBUFC_SOURCE_EXTENSION "pb-c.c")
 set(PROTBUFC_HEADER_EXTENSION "pb-c.h")
+
 function(PROTOBUFC_GENERATE_C SOURCES HEADERS)
 	if(NOT ARGN)
 		message(SEND_ERROR "Error: PROTOBUFC_GENERATE_C() called without any proto files")
@@ -90,16 +91,21 @@ find_library(PROTOBUFC_LIBRARY
 mark_as_advanced(PROTOBUFC_LIBRARY)
 
 find_path(PROTOBUFC_INCLUDE_DIR
-							NAMES "google/protobuf-c/protobuf-c.h"
+							NAMES "protobuf-c.h" "google/protobuf-c/protobuf-c.h"
 							PATHS "/usr" "/usr/local" "/opt" ENV PROTOBUFC_ROOTDIR
 							PATH_SUFFIXES "include")
 mark_as_advanced(PROTOBUFC_INCLUDE_DIR)
 
 find_program(PROTOBUFC_COMPILER
-							NAMES "protoc-c"
+							NAMES "protoc" "protoc-c"
 							PATHS "/usr" "/usr/local" "/opt" ENV PROTOBUFC_ROOTDIR
 							PATH_SUFFIXES "bin")
 mark_as_advanced(PROTOBUFC_COMPILER)
+
+
+IF (DEFINED PROTOBUF_PROTOC_EXECUTABLE)
+  SET(PROTOBUFC_COMPILER "${PROTOBUF_PROTOC_EXECUTABLE}")
+ENDIF (DEFINED PROTOBUF_PROTOC_EXECUTABLE)
 
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(ProtobufC DEFAULT_MSG PROTOBUFC_LIBRARY PROTOBUFC_COMPILER PROTOBUFC_INCLUDE_DIR )


### PR DESCRIPTION
I recently added MVT support to the Conda Forge MapServer build and needed to make some enhancements to the CMake configuration to support cross compilation.