### PR TITLE
fix proj epsgaxis= stripping to also work for +epsgaxis=

### DIFF
--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -762,7 +762,7 @@ int msProcessProjection(projectionObj *p) {
       // PROJ doesn't like extraneous parameters that it doesn't recognize
       // when initializing a CRS from a +init=epsg:xxxx string
       // Cf https://github.com/OSGeo/PROJ/issues/4203
-      if (strncmp(p->args[i], "epsgaxis=", strlen("epsgaxis=")) != 0) {
+      if (strstr(p->args[i], "epsgaxis=") == NULL) {
         args[numargs] = p->args[i];
         ++numargs;
       }


### PR DESCRIPTION
`+epsgaxis` is [added with a plus here](https://github.com/MapServer/MapServer/blob/main/src/mapfile.c#L1366) and that was not stripped

follow up on #7121
fixes #6973