### PR TITLE
Fix compiler warnings with gcc 14.2

### DIFF
--- a/src/apps/map2img.c
+++ b/src/apps/map2img.c
@@ -48,6 +48,7 @@ static void hasMoreArgumentsOrExit(const char *option,
                                    int num_required_arguments,
                                    int num_remaining_arguments,
                                    configObj *config, mapObj *map) {
+  (void)map;
   if (num_remaining_arguments < num_required_arguments) {
     if (num_required_arguments == 1)
       fprintf(stderr, "Argument %s requires an additional argument.\n", option);

--- a/src/mapdrawgdal.c
+++ b/src/mapdrawgdal.c
@@ -1631,7 +1631,8 @@ int msGetGDALGeoTransform(GDALDatasetH hDS, mapObj *map, layerObj *layer,
     if (success && layer->debug >= MS_DEBUGLEVEL_VVV) {
       msDebug("Worldfile location: %s.\n", fullPath);
     } else if (layer->debug >= MS_DEBUGLEVEL_VVV) {
-      msDebug("Failed using worldfile location: %s.\n", fullPath);
+      msDebug("Failed using worldfile location: %s.\n",
+              fullPath ? fullPath : "(null)");
     }
 
     msFree(fileExtension);
@@ -1777,7 +1778,7 @@ msDrawRasterLayerGDAL_RawMode(mapObj *map, layerObj *layer, imageObj *image,
   /* -------------------------------------------------------------------- */
   /*      Do we have nodata values?                                       */
   /* -------------------------------------------------------------------- */
-  f_nodatas = (float *)calloc(sizeof(float), band_count);
+  f_nodatas = (float *)calloc(band_count, sizeof(float));
   if (f_nodatas == NULL) {
     msSetError(MS_MEMERR, "%s: %d: Out of memory allocating %u bytes.\n",
                "msDrawRasterLayerGDAL_RawMode()", __FILE__, __LINE__,

--- a/src/mapfile.c
+++ b/src/mapfile.c
@@ -6870,7 +6870,7 @@ mapObj *msLoadMapFromString(char *buffer, char *new_mappath,
   /*
   ** Allocate mapObj structure
   */
-  map = (mapObj *)calloc(sizeof(mapObj), 1);
+  map = (mapObj *)calloc(1, sizeof(mapObj));
   MS_CHECK_ALLOC(map, sizeof(mapObj), NULL);
 
   if (initMap(map) == -1) { /* initialize this map */
@@ -6965,7 +6965,7 @@ mapObj *msLoadMap(const char *filename, const char *new_mappath,
   /*
   ** Allocate mapObj structure
   */
-  map = (mapObj *)calloc(sizeof(mapObj), 1);
+  map = (mapObj *)calloc(1, sizeof(mapObj));
   MS_CHECK_ALLOC(map, sizeof(mapObj), NULL);
 
   if (initMap(map) == -1) { /* initialize this map */

--- a/src/mapio.c
+++ b/src/mapio.c
@@ -128,7 +128,7 @@ static msIOContextGroup *msIO_GetContextGroup()
   /* -------------------------------------------------------------------- */
   /*      Create a new context group for this thread.                     */
   /* -------------------------------------------------------------------- */
-  group = (msIOContextGroup *)calloc(sizeof(msIOContextGroup), 1);
+  group = (msIOContextGroup *)calloc(1, sizeof(msIOContextGroup));
 
   group->stdin_context = default_contexts.stdin_context;
   group->stdout_context = default_contexts.stdout_context;
@@ -666,7 +666,7 @@ void msIO_installStdoutToBuffer()
   context.label = "buffer";
   context.write_channel = MS_TRUE;
   context.readWriteFunc = msIO_bufferWrite;
-  context.cbData = calloc(sizeof(msIOBuffer), 1);
+  context.cbData = calloc(1, sizeof(msIOBuffer));
 
   msIO_installHandlers(&group->stdin_context, &context, &group->stderr_context);
 }
@@ -732,7 +732,7 @@ void msIO_installStdinFromBuffer()
   context.label = "buffer";
   context.write_channel = MS_FALSE;
   context.readWriteFunc = msIO_bufferRead;
-  context.cbData = calloc(sizeof(msIOBuffer), 1);
+  context.cbData = calloc(1, sizeof(msIOBuffer));
 
   msIO_installHandlers(&context, &group->stdout_context,
                        &group->stderr_context);

--- a/src/mapobject.c
+++ b/src/mapobject.c
@@ -49,7 +49,7 @@ mapObj *msNewMapObj() {
   mapObj *map = NULL;
 
   /* create an empty map, no layers etc... */
-  map = (mapObj *)calloc(sizeof(mapObj), 1);
+  map = (mapObj *)calloc(1, sizeof(mapObj));
 
   if (!map) {
     msSetError(MS_MEMERR, NULL, "msCreateMap()");

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -1703,7 +1703,7 @@ int msProjectRectAsPolygon(reprojectionObj *reprojector, rectObj *rect) {
   /* If there is more than two sample points we will also get samples from the
    * diagonal line */
   ringPoints =
-      (pointObj *)calloc(sizeof(pointObj), NUMBER_OF_SAMPLE_POINTS * 5 + 3);
+      (pointObj *)calloc(NUMBER_OF_SAMPLE_POINTS * 5 + 3, sizeof(pointObj));
   ring.point = ringPoints;
   ring.numpoints = 0;
 

--- a/src/maprasterquery.c
+++ b/src/maprasterquery.c
@@ -504,8 +504,8 @@ static int msRasterQueryByRectLow(mapObj *map, layerObj *layer,
   /*      band in the file.  Later we will deal with the various band     */
   /*      selection criteria.                                             */
   /* -------------------------------------------------------------------- */
-  pafRaster = (float *)calloc(sizeof(float),
-                              ((size_t)nWinXSize) * nWinYSize * nBandCount);
+  pafRaster = (float *)calloc(((size_t)nWinXSize) * nWinYSize * nBandCount,
+                              sizeof(float));
   MS_CHECK_ALLOC(pafRaster, sizeof(float) * nWinXSize * nWinYSize * nBandCount,
                  -1);
 

--- a/src/mapscript/swiginc/error.i
+++ b/src/mapscript/swiginc/error.i
@@ -39,7 +39,7 @@
         return msGetErrorObj();
     }
 
-    ~errorObj() {}
+    ~errorObj() { (void)self; }
 
     /// Returns the next error in the stack or NULL if the end has been reached
     errorObj *next() 

--- a/src/mapscript/swiginc/layer.i
+++ b/src/mapscript/swiginc/layer.i
@@ -651,9 +651,9 @@
  
     %newobject executeWFSGetFeature;
     /// Executes a GetFeature request on a WFS layer and returns the name of the temporary GML file created. Returns an empty string on error.
-    char *executeWFSGetFeature(layerObj *layer) 
+    char *executeWFSGetFeature()
     {
-        return (char *) msWFSExecuteGetFeature(layer);
+        return (char *) msWFSExecuteGetFeature(self);
     }
 
     /**

--- a/src/mapserv-config.cpp
+++ b/src/mapserv-config.cpp
@@ -139,7 +139,7 @@ configObj *msLoadConfig(const char *ms_config_file) {
     return NULL;
   }
 
-  config = (configObj *)calloc(sizeof(configObj), 1);
+  config = (configObj *)calloc(1, sizeof(configObj));
   MS_CHECK_ALLOC(config, sizeof(configObj), NULL);
 
   if (initConfig(config) != MS_SUCCESS) {

--- a/src/mapwcs11.cpp
+++ b/src/mapwcs11.cpp
@@ -170,7 +170,7 @@ static char *msWCSGetFormatsList11(mapObj *map, layerObj *layer)
   /*      duplicates.                                                     */
   /* -------------------------------------------------------------------- */
   numformats = 0;
-  formats = (char **)calloc(sizeof(char *), numtokens);
+  formats = (char **)calloc(numtokens, sizeof(char *));
 
   for (i = 0; i < numtokens; i++) {
     int format_i, j;

--- a/src/mapwfs.cpp
+++ b/src/mapwfs.cpp
@@ -3463,9 +3463,9 @@ static int msWFSGetFeature(mapObj *map, wfsParamsObj *paramsObj,
     }
   }
 
-  papszGMLGroups = (char **)calloc(sizeof(char *), map->numlayers);
-  papszGMLIncludeItems = (char **)calloc(sizeof(char *), map->numlayers);
-  papszGMLGeometries = (char **)calloc(sizeof(char *), map->numlayers);
+  papszGMLGroups = (char **)calloc(map->numlayers, sizeof(char *));
+  papszGMLIncludeItems = (char **)calloc(map->numlayers, sizeof(char *));
+  papszGMLGeometries = (char **)calloc(map->numlayers, sizeof(char *));
 
   if (paramsObj->pszTypeName) {
     int k, y, z;


### PR DESCRIPTION
and a change in a MapScript function:
MapScript: layerObj.executeWFSGetFeature(): do not take an extra layerObj* argument, but just use self
