### PR TITLE
msProjectionContextGetFromPool(): set thread_id to current thread

### DIFF
--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -2495,6 +2495,7 @@ projectionContext *msProjectionContextGetFromPool() {
   if (headOfLinkedListOfProjContext) {
     LinkedListOfProjContext *next = headOfLinkedListOfProjContext->next;
     context = headOfLinkedListOfProjContext->context;
+    context->thread_id = msGetThreadId();
     msFree(headOfLinkedListOfProjContext);
     headOfLinkedListOfProjContext = next;
   } else {


### PR DESCRIPTION
Should improve performance issues of https://github.com/MapServer/MapServer/pull/7089