### PR TITLE
Remove call to libxml2 xmlMemoryDump

### DIFF
--- a/src/mapowscommon.c
+++ b/src/mapowscommon.c
@@ -869,7 +869,6 @@ int msOWSSchemaValidation(const char *xml_schema, const char *xml) {
 
   /* If XML Schema hasn't been rightly loaded */
   if (schema == NULL) {
-    xmlMemoryDump();
     xmlCleanupParser();
     return ret;
   }


### PR DESCRIPTION
CI builds are currently failing with the following:

```
 /home/runner/work/mapserver/mapserver/src/mapowscommon.c: In function 'msOWSSchemaValidation':
/home/runner/work/mapserver/mapserver/src/mapowscommon.c:872:5: error: 'xmlMemoryDump' is deprecated [-Werror=deprecated-declarations]
  872 |     xmlMemoryDump();
      |     ^~~~~~~~~~~~~
In file included from /usr/include/libxml2/libxml/tree.h:28,
                 from /usr/include/libxml2/libxml/parser.h:16,
                 from /usr/include/libxml2/libxml/tree.h:17,
                 from /home/runner/work/mapserver/mapserver/src/mapows.h:43,
                 from /home/runner/work/mapserver/mapserver/src/mapowscommon.c:35:
/usr/include/libxml2/libxml/xmlmemory.h:161:9: note: declared here
  161 |         xmlMemoryDump   (void);
      |         ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
```
It looks like this function should no longer be called based on the comment in https://github.com/GNOME/libxml2/commit/886bf4e63bb920a19a747d6cf55090562dd0f348

> This was used to check for memory leaks but could potentially create a
.memdump file. These days, there are better ways to check for memory
leaks.

It was also removed from all the libxml examples in https://github.com/GNOME/libxml2/commit/fc119e329069fae2ac7c25bc36ccb8847bac04ad

> xmlMemoryDump is an obsolete way to test for memory leaks.

The same commit message includes:

> xmlCleanupParser is dangerous and shouldn't be called in most cases.
Being part of the examples led many people to use it incorrectly.

`xmlCleanupParser` can be found in 20 locations in the MapServer codebase and so can be handled in a separate pull request if it should be removed. 
