### PR TITLE
Update Windows CI and Python Versions

### DIFF
--- a/.github/workflows/build-mapscript-python.yml
+++ b/.github/workflows/build-mapscript-python.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
     env:
       MAPSCRIPT_PYTHON_ONLY: 'true'
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ image: Visual Studio 2019
 
 cache:
   - '%LOCALAPPDATA%\pip\Cache'
-  - '%APPVEYOR_BUILD_FOLDER%\swigwin-4.1.0.zip'
+  - '%APPVEYOR_BUILD_FOLDER%\swigwin-4.2.1.zip'
 
 environment:
 
@@ -20,8 +20,6 @@ environment:
   VS_VERSION: Visual Studio 16 2019
   matrix:
   - platform: x64
-    Python_ROOT_DIR: c:/python38-x64
-  - platform: x64
     Python_ROOT_DIR: c:/python39-x64
   - platform: x64
     Python_ROOT_DIR: c:/python310-x64
@@ -29,6 +27,8 @@ environment:
     Python_ROOT_DIR: c:/python311-x64
   - platform: x64
     Python_ROOT_DIR: c:/python312-x64
+  - platform: x64
+    Python_ROOT_DIR: c:/python313-x64
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,22 +2,22 @@ branches:
   except:
     - /(cherry-pick-)?backport-\d+-to-/
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 cache:
   - '%LOCALAPPDATA%\pip\Cache'
-  - '%APPVEYOR_BUILD_FOLDER%\swigwin-4.3.0-beta1.zip'
+  - '%APPVEYOR_BUILD_FOLDER%\swigwin-4.3.0.zip'
 
 environment:
 
   global:
-    SWIG_VER: swigwin-4.3.0-beta1
+    SWIG_VER: swigwin-4.3.0
     TWINE_USERNAME: mapserver
     TWINE_PASSWORD:
       secure: mHoJHeXdXbBNoDf7MA4ZEg==
 
-  # VS 2019
-  VS_VERSION: Visual Studio 16 2019
+  # VS 2022
+  VS_VERSION: Visual Studio 17 2022
   matrix:
   - platform: x64
     Python_ROOT_DIR: c:/python39-x64
@@ -38,6 +38,7 @@ clone_depth: 5
 
 init:
   - net start MSSQL$SQL2019
+  # we can skip testing Python versions apart from for releases by updating the version below
   - ps: |
         if ($env:APPVEYOR_REPO_TAG -ne $TRUE) {
             if ("c:/python37-x64" -contains $env:Python_ROOT_DIR -eq $TRUE) {
@@ -53,12 +54,8 @@ build_script:
   - set "BUILD_FOLDER=%APPVEYOR_BUILD_FOLDER:\=/%"
   - if "%platform%" == "x64" SET VS_FULL=%VS_VERSION%
   - if "%platform%" == "x64" SET VS_ARCH=x64
-  - if "%platform%" == "x86" SET VS_FULL=%VS_VERSION%
-  - if "%platform%" == "x86" SET VS_ARCH=Win32 
-  - if "%platform%" == "x86" SET SDK=release-1928
-  - if "%platform%" == "x64" SET SDK=release-1928-x64
-  - if "%platform%" == "x64" call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
-  - if "%platform%" == "x86" call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars32.bat"
+  - if "%platform%" == "x64" SET SDK=release-1930-x64
+  - if "%platform%" == "x64" call "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build/vcvars64.bat"
   - echo "%VS_FULL%"
   - if not exist %SWIG_VER%.zip appveyor DownloadFile https://github.com/geographika/python-mapscript/raw/main/%SWIG_VER%.zip
   - set SDK_ZIP=%SDK%-dev.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,14 +19,14 @@ environment:
   # VS 2022
   VS_VERSION: Visual Studio 17 2022
   matrix:
-  - platform: x64
-    Python_ROOT_DIR: c:/python39-x64
-  - platform: x64
-    Python_ROOT_DIR: c:/python310-x64
-  - platform: x64
-    Python_ROOT_DIR: c:/python311-x64
-  - platform: x64
-    Python_ROOT_DIR: c:/python312-x64
+  #- platform: x64
+  #  Python_ROOT_DIR: c:/python39-x64
+  #- platform: x64
+  #  Python_ROOT_DIR: c:/python310-x64
+  #- platform: x64
+  #  Python_ROOT_DIR: c:/python311-x64
+  #- platform: x64
+  #  Python_ROOT_DIR: c:/python312-x64
   - platform: x64
     Python_ROOT_DIR: c:/python313-x64
 
@@ -95,6 +95,14 @@ before_test:
   - "./mssql/create_mssql_db.bat"
   - "%Python_ROOT_DIR%/python -m pip install -U -r requirements.txt"
   - "%Python_ROOT_DIR%/python -m pip install --no-index --find-links=file://%BUILD_FOLDER%/build/src/mapscript/python/Release/dist mapscript"
+  # there is a mismatch between sqlite3 in Python 3.13 and the SDK - ensure the SDK DLL is used by copying into _mapscript.pyd folder
+  - ps: |
+        if ($env:Python_ROOT_DIR -eq "c:/python313-x64") {
+            $sourcePath = Join-Path $env:SDK_BIN "sqlite3.dll"
+            $targetPath = Join-Path $env:BUILD_FOLDER "build/src/mapscript/python/Release/mapscriptvenv/Lib/site-packages/mapscript"
+            Copy-Item -Path $sourcePath -Destination $targetPath -Force
+            Write-Host "sqlite3.dll successfully copied to $targetPath"
+        }
 
 test_script:
   - cd %BUILD_FOLDER%/msautotest/mssql

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ init:
 build_script:
   - ps: Write-Host "Build tags - $env:APPVEYOR_REPO_TAG $env:APPVEYOR_REPO_TAG_NAME"
   - rename C:\Python310 Python310_Ignore
-  - rename C:\Python311 Python311_Ignore  
+  - rename C:\Python311 Python311_Ignore
   - set "BUILD_FOLDER=%APPVEYOR_BUILD_FOLDER:\=/%"
   - if "%platform%" == "x64" SET VS_FULL=%VS_VERSION%
   - if "%platform%" == "x64" SET VS_ARCH=x64
@@ -72,6 +72,14 @@ build_script:
   - set SDK_BIN=%BUILD_FOLDER%/sdk/%SDK%/bin
   - set SWIG_EXECUTABLE=%BUILD_FOLDER%/sdk/%SWIG_VER%/swig.exe
   - set REGEX_DIR=%BUILD_FOLDER%/sdk/support/regex-0.12
+  # there is a mismatch between sqlite3 in Python 3.13 and the SDK - ensure the SDK DLL is used by copying into _mapscript.pyd folder
+  - ps: |
+        if ($env:Python_ROOT_DIR -eq "c:/python313-x64") {
+            $sourcePath = Join-Path $env:SDK_BIN "sqlite3.dll"
+            $targetPath = "c:/python313-x64/DLLs"
+            Copy-Item -Path $sourcePath -Destination $targetPath -Force
+            Write-Host "sqlite3.dll successfully copied to $targetPath"
+        }
   - cd %BUILD_FOLDER%
   - mkdir build
   - cd build
@@ -95,14 +103,6 @@ before_test:
   - "./mssql/create_mssql_db.bat"
   - "%Python_ROOT_DIR%/python -m pip install -U -r requirements.txt"
   - "%Python_ROOT_DIR%/python -m pip install --no-index --find-links=file://%BUILD_FOLDER%/build/src/mapscript/python/Release/dist mapscript"
-  # there is a mismatch between sqlite3 in Python 3.13 and the SDK - ensure the SDK DLL is used by copying into _mapscript.pyd folder
-  - ps: |
-        if ($env:Python_ROOT_DIR -eq "c:/python313-x64") {
-            $sourcePath = Join-Path $env:SDK_BIN "sqlite3.dll"
-            $targetPath = Join-Path $env:BUILD_FOLDER "build/src/mapscript/python/Release/mapscriptvenv/Lib/site-packages/mapscript"
-            Copy-Item -Path $sourcePath -Destination $targetPath -Force
-            Write-Host "sqlite3.dll successfully copied to $targetPath"
-        }
 
 test_script:
   - cd %BUILD_FOLDER%/msautotest/mssql

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,14 +19,14 @@ environment:
   # VS 2022
   VS_VERSION: Visual Studio 17 2022
   matrix:
-  #- platform: x64
-  #  Python_ROOT_DIR: c:/python39-x64
-  #- platform: x64
-  #  Python_ROOT_DIR: c:/python310-x64
-  #- platform: x64
-  #  Python_ROOT_DIR: c:/python311-x64
-  #- platform: x64
-  #  Python_ROOT_DIR: c:/python312-x64
+  - platform: x64
+    Python_ROOT_DIR: c:/python39-x64
+  - platform: x64
+    Python_ROOT_DIR: c:/python310-x64
+  - platform: x64
+    Python_ROOT_DIR: c:/python311-x64
+  - platform: x64
+    Python_ROOT_DIR: c:/python312-x64
   - platform: x64
     Python_ROOT_DIR: c:/python313-x64
 
@@ -72,7 +72,7 @@ build_script:
   - set SDK_BIN=%BUILD_FOLDER%/sdk/%SDK%/bin
   - set SWIG_EXECUTABLE=%BUILD_FOLDER%/sdk/%SWIG_VER%/swig.exe
   - set REGEX_DIR=%BUILD_FOLDER%/sdk/support/regex-0.12
-  # there is a mismatch between sqlite3 in Python 3.13 and the SDK - ensure the SDK DLL is used by copying into _mapscript.pyd folder
+  # there is a mismatch between sqlite3 in Python 3.13 and the SDK - ensure the SDK DLL is used by overwriting the DLL in the Python installation
   - ps: |
         if ($env:Python_ROOT_DIR -eq "c:/python313-x64") {
             $sourcePath = Join-Path $env:SDK_BIN "sqlite3.dll"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,12 @@ image: Visual Studio 2019
 
 cache:
   - '%LOCALAPPDATA%\pip\Cache'
-  - '%APPVEYOR_BUILD_FOLDER%\swigwin-4.2.1.zip'
+  - '%APPVEYOR_BUILD_FOLDER%\swigwin-4.3.0-beta1.zip'
 
 environment:
 
   global:
-    SWIG_VER: swigwin-4.2.1
+    SWIG_VER: swigwin-4.3.0-beta1
     TWINE_USERNAME: mapserver
     TWINE_PASSWORD:
       secure: mHoJHeXdXbBNoDf7MA4ZEg==

--- a/src/mapscript/python/README.rst
+++ b/src/mapscript/python/README.rst
@@ -38,11 +38,11 @@ Advantages of ready-made wheels on PyPI include:
 Wheels are built based on the `Appveyor build environments <https://github.com/MapServer/MapServer/blob/main/appveyor.yml>`_. 
 These are as follows at the time of writing:
 
-+ Python 3.8 x64
 + Python 3.9 x64
 + Python 3.10 x64
 + Python 3.11 x64
 + Python 3.12 x64
++ Python 3.13 x64
 
 The mapscript wheels have been compiled using Visual Studio 2022 version 17 (``MSVC++ 17.9 _MSC_VER == 1939``). 
 Linux Wheels may also be available in the future using the `manylinux <https://github.com/pypa/manylinux>`_ project. 


### PR DESCRIPTION
As of 2024-10-07 Python 3.8 is no longer supported. The new 3.13 Python was released on 2024-10-07. 
This pull request removes 3.8 and adds 3.13. The cache folder for SWIG was also updated to match the version in use. 
See https://www.python.org/downloads/ for details. 

Other changes:

- Image updated to Visual Studio 2022
- SWIG updated to 4.3
- SDK updated to https://www.gisinternals.com/query.html?content=filelist&file=release-1930-x64-dev.zip

There is a sqlite3.dll incompatibility between Python 3.13 (version `3.45.3`) and the SDK (version `3.47.1`). The CI copies the DLL into the Python installation. Options to resolve this long-term are in the discussions below. 


