### PR TITLE
Pin Python version for precommit action and update flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,19 +1,35 @@
 [flake8]
-max_line_length = 88
+max-line-length = 88
 ignore =
-    C408 # Unnecessary dict/list/tuple call - rewrite as a literal
-    E203 # whitespace before ':' - doesn't work well with black
-    E225 # missing whitespace around operator - let black worry about that
-    E262 # inline comment should start with '# '
-    E265 # block comment should start with '# '
-    E266 # too many leading '#' for block comment
-    E302 # expected 2 blank lines, found 1
-    E402 # module level import not at top of file
-    E501 # line too long - let black handle that
-    E711 # comparison to None should be
-    E712 # comparison to False/True should be
-    E741 # ambiguous variable name
-    F405 # may be undefined, or defined from star imports
-    W291 # trailing
-    W503 # line break occurred before a binary operator - let black worry about that
-    W504 # line break occurred adter a binary operator - let black worry about that
+    # Unnecessary dict/list/tuple call - rewrite as a literal
+    C408 
+    # whitespace before ':' - doesn't work well with black
+    E203 
+    # missing whitespace around operator - let black worry about that
+    E225 
+    # inline comment should start with '# '
+    E262 
+    # block comment should start with '# '
+    E265 
+    # too many leading '#' for block comment
+    E266 
+    # expected 2 blank lines, found 1
+    E302 
+    # module level import not at top of file
+    E402 
+    # line too long - let black handle that
+    E501 
+    # comparison to None should be
+    E711 
+    # comparison to False/True should be
+    E712 
+    # ambiguous variable name
+    E741 
+    # may be undefined, or defined from star imports
+    F405 
+    # trailing
+    W291 
+    # line break occurred before a binary operator - let black worry about that
+    W503 
+    # line break occurred after a binary operator - let black worry about that
+    W504

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -16,4 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         -   id: isort
             args: ["--profile", "black"]
     -   repo: https://github.com/pycqa/flake8
-        rev: 3.9.2
+        rev: 7.1.1
         hooks:
         -   id: flake8
     -   repo: https://github.com/pre-commit/mirrors-clang-format


### PR DESCRIPTION
On pull request branches, the `pre-commit/action@v3.0.1` is failing. For example [here](https://github.com/geographika/mapserver/actions/runs/11366259720/job/31616233100#step:4:1).

It looks like `actions/setup-python@v5` requires a Python version to be set as it reports the following warnings:

```
Warning: Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file.
Warning: .python-version doesn't exist.
Warning: The `python-version` input is not set.  The version of Python currently in `PATH` will be used.
```

Errors are then reported in the pre-commit action:

```
Run python -m pip install pre-commit
  python -m pip install pre-commit
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    RUST_BACKTRACE: 1
    CARGO_TERM_COLOR: always
    CLICOLOR: 1
error: externally-managed-environment
```

This issue seems to have been reported to https://github.com/pre-commit/action/ several times - most cases are not using `setup-python`, but some have the same error as the Python version isn't specified - see https://github.com/pre-commit/action/issues/210#issuecomment-2378267599

Switching to Python 3.12 caused the flake8 library to report the errors below. I've updated this to use the latest version of flake8 in the `.pre-commit-config.yaml` file.

```
   File "/home/runner/.cache/pre-commit/repoxjhic1i8/py_env-python3.12/lib/python3.12/site-packages/flake8/plugins/manager.py", line 356, in __init__
    self.manager = PluginManager(
                   ^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repoxjhic1i8/py_env-python3.12/lib/python3.12/site-packages/flake8/plugins/manager.py", line 238, in __init__
    self._load_entrypoint_plugins()
  File "/home/runner/.cache/pre-commit/repoxjhic1i8/py_env-python3.12/lib/python3.12/site-packages/flake8/plugins/manager.py", line 254, in _load_entrypoint_plugins
    eps = importlib_metadata.entry_points().get(self.namespace, ())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'EntryPoints' object has no attribute 'get'
```

Updating flake8 then causes the following error: `ValueError: Error code '#' supplied to 'ignore' option does not match '^[A-Z]{1,3}[0-9]{0,3}$'`
This is due to changes in the `.flak8` config file format. The GDAL [.flake8](https://github.com/OSGeo/gdal/blob/master/.flake8 ) file has been updated, so I've updated to the same format: - see https://github.com/OSGeo/gdal/pull/9936

It looks like caching means the pre-commit action is still passing on `mapserver/mapserver`. 
https://github.com/MapServer/MapServer/actions/runs/11366426395/job/31616775459#step:4:61

```
Cache restored successfully
Cache restored from key: pre-commit-3||dc9c2f1a20b8119bfdb71faa95055d8f2a83bb6aacf921d26e10f90765317698
```