### PR TITLE
SLD Filters missing due to logicial keywords in expressions

### DIFF
--- a/msautotest/wxs/expected/wms_getstyles_expressions24.xml
+++ b/msautotest/wxs/expected/wms_getstyles_expressions24.xml
@@ -1,0 +1,28 @@
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<se:Name>Test24</se:Name>
+<UserStyle>
+<se:FeatureTypeStyle>
+<se:Rule>
+<se:Name>Not Test</se:Name>
+<ogc:Filter><ogc:PropertyIsEqualTo><ogc:PropertyName>Property1</ogc:PropertyName><ogc:Literal>Not Applicable</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Filter>
+<se:PointSymbolizer>
+</se:PointSymbolizer>
+</se:Rule>
+<se:Rule>
+<se:Name>And Test</se:Name>
+<ogc:Filter><ogc:PropertyIsEqualTo><ogc:PropertyName>Property1</ogc:PropertyName><ogc:Literal>With AND value</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Filter>
+<se:PointSymbolizer>
+</se:PointSymbolizer>
+</se:Rule>
+<se:Rule>
+<se:Name>Or Test</se:Name>
+<ogc:Filter><ogc:PropertyIsEqualTo><ogc:PropertyName>Property1</ogc:PropertyName><ogc:Literal>With OR value</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Filter>
+<se:PointSymbolizer>
+</se:PointSymbolizer>
+</se:Rule>
+</se:FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>
+

--- a/msautotest/wxs/expected/wms_getstyles_expressions25.xml
+++ b/msautotest/wxs/expected/wms_getstyles_expressions25.xml
@@ -1,0 +1,28 @@
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.1.0/StyledLayerDescriptor.xsd" xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<NamedLayer>
+<se:Name>Test25</se:Name>
+<UserStyle>
+<se:FeatureTypeStyle>
+<se:Rule>
+<se:Name>Or Test</se:Name>
+<ogc:Filter><ogc:Or><ogc:PropertyIsEqualTo><ogc:PropertyName>Property1</ogc:PropertyName><ogc:Literal>Not value</ogc:Literal></ogc:PropertyIsEqualTo><ogc:PropertyIsEqualTo><ogc:PropertyName>Property1</ogc:PropertyName><ogc:Literal>An Or value</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Or></ogc:Filter>
+<se:PointSymbolizer>
+</se:PointSymbolizer>
+</se:Rule>
+<se:Rule>
+<se:Name>And Test</se:Name>
+<ogc:Filter><ogc:And><ogc:PropertyIsEqualTo><ogc:PropertyName>Property1</ogc:PropertyName><ogc:Literal>An</ogc:Literal></ogc:PropertyIsEqualTo><ogc:PropertyIsEqualTo><ogc:PropertyName>Property1</ogc:PropertyName><ogc:Literal>A Not value</ogc:Literal></ogc:PropertyIsEqualTo></ogc:And></ogc:Filter>
+<se:PointSymbolizer>
+</se:PointSymbolizer>
+</se:Rule>
+<se:Rule>
+<se:Name>Not Test</se:Name>
+<ogc:Filter><ogc:Not><ogc:PropertyIsEqualTo><ogc:PropertyName>Property1</ogc:PropertyName><ogc:Literal>A Not value</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Not></ogc:Filter>
+<se:PointSymbolizer>
+</se:PointSymbolizer>
+</se:Rule>
+</se:FeatureTypeStyle>
+</UserStyle>
+</NamedLayer>
+</StyledLayerDescriptor>
+

--- a/msautotest/wxs/wms_styles_expressions.map
+++ b/msautotest/wxs/wms_styles_expressions.map
@@ -363,4 +363,33 @@ MAP
         END
       END
     END
+
+    LAYER
+      NAME "Test25"
+      TYPE POINT
+      CLASS
+        NAME "Or Test"
+        EXPRESSION (("[Property1]" = "Not value") OR ("[Property1]" = "An Or value"))
+        STYLE
+            COLOR 0 0 255
+            SYMBOL "star"
+        END
+      END
+      CLASS
+        NAME "And Test"
+        EXPRESSION (("[Property1]" = "An And value") AND ("[Property1]" = "A Not value"))
+        STYLE
+            COLOR 0 255 0
+            SYMBOL "star"
+        END
+      END
+      CLASS
+        NAME "Not Test"
+        EXPRESSION (NOT ("[Property1]" = "A Not value"))
+        STYLE
+            COLOR 255 0 0
+            SYMBOL "star"
+        END
+      END
+    END
 END

--- a/msautotest/wxs/wms_styles_expressions.map
+++ b/msautotest/wxs/wms_styles_expressions.map
@@ -153,7 +153,7 @@ MAP
       NAME "Test10"
       TYPE POINT
       CLASS
-        EXPRESSION (([FID] > 1) And ([FID] <= 10))
+        EXPRESSION (([FID] > 1)And([FID] <= 10))
         STYLE
             COLOR 220 0 0
             WIDTH 1
@@ -165,7 +165,7 @@ MAP
       NAME "Test11"
       TYPE POINT
       CLASS
-        EXPRESSION (([FID] = 1) Or ([FID] = 10))
+        EXPRESSION (([FID] = 1)Or([FID] = 10))
         STYLE
             COLOR 220 0 0
             WIDTH 1
@@ -376,6 +376,7 @@ MAP
         END
       END
       CLASS
+        # TODO - this test incorrectly output "An" to the filter rather than "An And value"
         NAME "And Test"
         EXPRESSION (("[Property1]" = "An And value") AND ("[Property1]" = "A Not value"))
         STYLE

--- a/msautotest/wxs/wms_styles_expressions.map
+++ b/msautotest/wxs/wms_styles_expressions.map
@@ -28,6 +28,7 @@
 # RUN_PARMS: wms_getstyles_expressions21.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test21" > [RESULT_DEMIME]
 # RUN_PARMS: wms_getstyles_expressions22.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test22" > [RESULT_DEMIME]
 # RUN_PARMS: wms_getstyles_expressions23.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test23" > [RESULT_DEMIME]
+# RUN_PARMS: wms_getstyles_expressions24.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetStyles&layers=Test24" > [RESULT_DEMIME]
 
 MAP
     NAME WMS_TEST
@@ -329,6 +330,36 @@ MAP
         STYLE
             COLOR 220 0 0
             WIDTH 1
+        END
+      END
+    END
+
+    # test for string expressions containing logic operators
+    LAYER
+      NAME "Test24"
+      TYPE POINT
+      CLASS
+        NAME "Not Test"
+        EXPRESSION ("[Property1]" = "Not Applicable")
+        STYLE
+            COLOR 0 0 255
+            SYMBOL "star"
+        END
+      END
+      CLASS
+        NAME "And Test"
+        EXPRESSION ("[Property1]" = "With AND value")
+        STYLE
+            COLOR 0 255 0
+            SYMBOL "star"
+        END
+      END
+      CLASS
+        NAME "Or Test"
+        EXPRESSION ("[Property1]" = "With OR value")
+        STYLE
+            COLOR 255 0 0
+            SYMBOL "star"
         END
       END
     END

--- a/msautotest/wxs/wms_styles_expressions.map
+++ b/msautotest/wxs/wms_styles_expressions.map
@@ -153,7 +153,7 @@ MAP
       NAME "Test10"
       TYPE POINT
       CLASS
-        EXPRESSION (([FID] > 1)And([FID] <= 10))
+        EXPRESSION (([FID] > 1) And ([FID] <= 10))
         STYLE
             COLOR 220 0 0
             WIDTH 1
@@ -165,7 +165,7 @@ MAP
       NAME "Test11"
       TYPE POINT
       CLASS
-        EXPRESSION (([FID] = 1)Or([FID] = 10))
+        EXPRESSION (([FID] = 1) Or ([FID] = 10))
         STYLE
             COLOR 220 0 0
             WIDTH 1

--- a/src/mapogcsld.cpp
+++ b/src/mapogcsld.cpp
@@ -4815,27 +4815,18 @@ static int msSLDNumberOfLogicalOperators(const char *pszExpression) {
       continue;
     }
 
-    if (strncasecmp(papszArgs[i], "AND", 3) == 0) {
+    if ((strncasecmp(papszArgs[i], "AND", 3) == 0) ||
+        (strcasestr(papszArgs[i], "AND("))) {
       nAndCount += 1;
     }
 
-    if (strcasestr(papszArgs[i], "AND(")) {
-      nAndCount += 1;
-    }
-
-    if (strncasecmp(papszArgs[i], "OR", 2) == 0) {
+    if ((strncasecmp(papszArgs[i], "OR", 3) == 0) ||
+        (strcasestr(papszArgs[i], "OR("))) {
       nOrCount += 1;
     }
 
-    if (strcasestr(papszArgs[i], "OR(")) {
-      nOrCount += 1;
-    }
-
-    if (strncasecmp(papszArgs[i], "NOT", 3) == 0) {
-      nNotCount += 1;
-    }
-
-    if (strcasestr(papszArgs[i], "NOT(")) {
+    if ((strncasecmp(papszArgs[i], "NOT", 3) == 0) ||
+        (strcasestr(papszArgs[i], "NOT("))) {
       nNotCount += 1;
     }
 

--- a/src/mapogcsld.cpp
+++ b/src/mapogcsld.cpp
@@ -4800,42 +4800,51 @@ static int msSLDNumberOfLogicalOperators(const char *pszExpression) {
   if (!pszExpression)
     return 0;
 
+  int nAndCount = 0;
+  int nNotCount = 0;
+  int nOrCount = 0;
+
+  int nArgs = 0;
+  char **papszArgs;
+  papszArgs = msStringTokenize(pszExpression, " ", &nArgs, MS_TRUE);
+
   /* -------------------------------------------------------------------- */
   /*      tests here are minimal to be able to parse simple expression    */
   /*      like A AND B, A OR B, NOT A.                                    */
   /* -------------------------------------------------------------------- */
-  pszAnd = strcasestr(pszExpression, " AND ");
-  pszOr = strcasestr(pszExpression, " OR ");
-  pszNot = strcasestr(pszExpression, "NOT ");
 
-  if (!pszAnd && !pszOr) {
-    pszAnd = strcasestr(pszExpression, "AND(");
-    pszOr = strcasestr(pszExpression, "OR(");
+  for (int i = 0; i < nArgs; i++) {
+    if (strlen(papszArgs[i]) == 0) {
+      free(papszArgs[i]);
+      continue;
+    }
+
+    if (strncasecmp(papszArgs[i], "AND", 3) == 0) {
+      nAndCount += 1;
+    }
+
+    if (strncasecmp(papszArgs[i], "OR", 3) == 0) {
+      nOrCount += 1;
+    }
+
+    if (strncasecmp(papszArgs[i], "NOT", 3) == 0) {
+      nNotCount += 1;
+    }
+
+    free(papszArgs[i]);
   }
+  free(papszArgs);
 
-  if (!pszNot) {
-    pszNot = strcasestr(pszExpression, "NOT(");
-  }
-
-  if (!pszAnd && !pszOr && !pszNot)
+  if (nAndCount == 0 && nNotCount == 0 && nOrCount == 0) {
     return 0;
-
-  /* done not matter how many exactly if there are 2 or more */
-  if ((pszAnd && pszOr) || (pszAnd && pszNot) || (pszOr && pszNot))
-    return 2;
-
-  if (pszAnd) {
-    pszSecondAnd = strcasestr(pszAnd + 3, " AND ");
-    pszSecondOr = strcasestr(pszAnd + 3, " OR ");
-  } else if (pszOr) {
-    pszSecondAnd = strcasestr(pszOr + 2, " AND ");
-    pszSecondOr = strcasestr(pszOr + 2, " OR ");
   }
 
-  if (!pszSecondAnd && !pszSecondOr)
+  int sum = nAndCount + nNotCount + nOrCount;
+  if (sum == 1) {
     return 1;
-  else
+  } else {
     return 2;
+  }
 }
 
 static char *msSLDGetAttributeNameOrValue(const char *pszExpression,

--- a/src/mapogcsld.cpp
+++ b/src/mapogcsld.cpp
@@ -4793,6 +4793,11 @@ static char *msSLDGetLeftExpressionOfOperator(const char *pszExpression) {
 }
 
 static int msSLDNumberOfLogicalOperators(const char *pszExpression) {
+  /* -------------------------------------------------------------------- */
+  /*      tests here are minimal to be able to parse simple expression    */
+  /*      like A AND B, A OR B, NOT A.                                    */
+  /*      TODO - add proper expression parsing                            */
+  /* -------------------------------------------------------------------- */
   if (!pszExpression)
     return 0;
 
@@ -4804,11 +4809,6 @@ static int msSLDNumberOfLogicalOperators(const char *pszExpression) {
   char **papszArgs;
   papszArgs = msStringTokenize(pszExpression, " ", &nArgs, MS_TRUE);
 
-  /* -------------------------------------------------------------------- */
-  /*      tests here are minimal to be able to parse simple expression    */
-  /*      like A AND B, A OR B, NOT A.                                    */
-  /* -------------------------------------------------------------------- */
-
   for (int i = 0; i < nArgs; i++) {
     if (strlen(papszArgs[i]) == 0) {
       free(papszArgs[i]);
@@ -4819,11 +4819,23 @@ static int msSLDNumberOfLogicalOperators(const char *pszExpression) {
       nAndCount += 1;
     }
 
+    if (strcasestr(pszExpression, "AND(")) {
+      nAndCount += 1;
+    }
+
     if (strncasecmp(papszArgs[i], "OR", 2) == 0) {
       nOrCount += 1;
     }
 
+    if (strcasestr(pszExpression, "OR(")) {
+      nOrCount += 1;
+    }
+
     if (strncasecmp(papszArgs[i], "NOT", 3) == 0) {
+      nNotCount += 1;
+    }
+
+    if (strcasestr(pszExpression, "NOT(")) {
       nNotCount += 1;
     }
 

--- a/src/mapogcsld.cpp
+++ b/src/mapogcsld.cpp
@@ -4819,7 +4819,7 @@ static int msSLDNumberOfLogicalOperators(const char *pszExpression) {
       nAndCount += 1;
     }
 
-    if (strcasestr(pszExpression, "AND(")) {
+    if (strcasestr(papszArgs[i], "AND(")) {
       nAndCount += 1;
     }
 
@@ -4827,7 +4827,7 @@ static int msSLDNumberOfLogicalOperators(const char *pszExpression) {
       nOrCount += 1;
     }
 
-    if (strcasestr(pszExpression, "OR(")) {
+    if (strcasestr(papszArgs[i], "OR(")) {
       nOrCount += 1;
     }
 
@@ -4835,7 +4835,7 @@ static int msSLDNumberOfLogicalOperators(const char *pszExpression) {
       nNotCount += 1;
     }
 
-    if (strcasestr(pszExpression, "NOT(")) {
+    if (strcasestr(papszArgs[i], "NOT(")) {
       nNotCount += 1;
     }
 

--- a/src/mapogcsld.cpp
+++ b/src/mapogcsld.cpp
@@ -4793,10 +4793,6 @@ static char *msSLDGetLeftExpressionOfOperator(const char *pszExpression) {
 }
 
 static int msSLDNumberOfLogicalOperators(const char *pszExpression) {
-  const char *pszAnd = NULL;
-  const char *pszOr = NULL;
-  const char *pszNot = NULL;
-  const char *pszSecondAnd = NULL, *pszSecondOr = NULL;
   if (!pszExpression)
     return 0;
 

--- a/src/mapogcsld.cpp
+++ b/src/mapogcsld.cpp
@@ -4819,7 +4819,7 @@ static int msSLDNumberOfLogicalOperators(const char *pszExpression) {
       nAndCount += 1;
     }
 
-    if (strncasecmp(papszArgs[i], "OR", 3) == 0) {
+    if (strncasecmp(papszArgs[i], "OR", 2) == 0) {
       nOrCount += 1;
     }
 


### PR DESCRIPTION
When using WMS GetStyles requests to generate SLD I noticed some filters were missing. On debugging it became apparent that any string containing a logical operator was failing to generate a filter:

```
EXPRESSION ("[Property1]" = "Not Applicable")
```

Was missing the expected filter:

```xml
<ogc:Filter><ogc:PropertyIsEqualTo><ogc:PropertyName>Property1</ogc:PropertyName><ogc:Literal>Not Applicable</ogc:Literal></ogc:PropertyIsEqualTo></ogc:Filter>
```

`msSLDNumberOfLogicalOperators` had a simple search for `AND`, `NOT`, and `OR` that was finding these words in strings causing errors. This fix attempts to tokenize the string, leaving quoted strings intact to avoid this. It is by no means perfect, and I also had to change previous test cases to have spaces around keywords e.g. `(([FID] > 1)And([FID] <= 10))` so that they pass. 

MapServer seems to be missing a parsing engine for expressions (or at least I can't find anything in the codebase). Without this any SLD expression building is going to be flaky. See also #5894. 


