### PR TITLE
mapuvraster: fix hDS file descriptor leak in msUVRASTERLayerGetExtent

### DIFF
--- a/src/mapuvraster.cpp
+++ b/src/mapuvraster.cpp
@@ -975,8 +975,8 @@ int msUVRASTERLayerGetExtent(layerObj *layer, rectObj *extent)
   const int nYSize = GDALGetRasterYSize(hDS);
   double adfGeoTransform[6] = {0};
   const CPLErr eErr = GDALGetGeoTransform(hDS, adfGeoTransform);
+  GDALClose(hDS);
   if (eErr != CE_None) {
-    GDALClose(hDS);
     return MS_FAILURE;
   }
 


### PR DESCRIPTION
mapuvraster is very leaky in 7.6.x and beyond. 7.4.x series is fine.



