### PR TITLE
msProjectRect(): cache whether source projection is polar when repeatdly projecting from it

### DIFF
--- a/src/mapproject.h
+++ b/src/mapproject.h
@@ -65,6 +65,8 @@ typedef struct {
   PJ *proj;
   projectionContext *proj_ctx;
   geotransformObj gt; /* extra transformation to apply */
+  int is_polar;       /* whether the projection includes the pole. Set to -1 for
+                         unknown */
 #endif
 
 #ifdef SWIG


### PR DESCRIPTION
Helps marginally on the belows scenario of
https://github.com/MapServer/MapServer/issues/7189 where the execution time goes from ~440 ms to ~400 ms

```c++
#include "mapserver.h"
#include <stdio.h>
#include <string>

int main() {
    projectionObj src;
    msInitProjection(&src);
    msLoadProjectionStringEPSG(&src, "EPSG:25833");
    const int epsg_list[] = { 25832,
            3034,
            3035,
            3044,
            3045,
            31468,
            31469,
            3857,
            4258,
            4326,
            4647,
            5650,
            5652,
            5674,
            5675,
            5677,
            5678,
            5679,
            4937,
            7409,
            7423,
            9422,
            4979 };
    double minx=200000;
    double miny=5.886e+06;
    double maxx=465000;
    double maxy=6.075e+06;
    for( int epsg: epsg_list )
    {
        projectionObj dst;
        msInitProjection(&dst);
        msProjectionInheritContextFrom(&dst, &src);
        msLoadProjectionStringEPSG(&dst, (std::string("EPSG:") + std::to_string(epsg)).c_str());
        rectObj ext;
        ext.minx = minx;
        msProjectRect(&src, &dst, &ext);
        msFreeProjection(&dst);
    }
    msFreeProjection(&src);
    return 0;
}
```