### PR TITLE
Add HTTP status code for WMS requests, if MS_WMS_ERROR_STATUS_CODE config option/env variable are set to ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 message(STATUS "Requiring C++${CMAKE_CXX_STANDARD} - done")
 
-# Set C99 version
+# Set C version
 # Make CMAKE_C_STANDARD available as cache option overridable by user
-set(CMAKE_C_STANDARD 99
-  CACHE STRING "C standard version to use (default is 99)")
+set(CMAKE_C_STANDARD 11
+  CACHE STRING "C standard version to use (default is 11)")
 message(STATUS "Requiring C${CMAKE_C_STANDARD}")
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)

--- a/msautotest/wxs/expected/wms_invalid_request_with_400_status.txt
+++ b/msautotest/wxs/expected/wms_invalid_request_with_400_status.txt
@@ -1,0 +1,9 @@
+Status: 400 Bad Request
+Content-Type: text/xml; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" standalone="no" ?>
+<ServiceExceptionReport version="1.3.0" xmlns="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd">
+<ServiceException>
+msWMSDispatch(): WMS server error. Incomplete WMS request: VERSION parameter missing
+</ServiceException>
+</ServiceExceptionReport>

--- a/msautotest/wxs/expected/wms_invalid_request_with_500_status.txt
+++ b/msautotest/wxs/expected/wms_invalid_request_with_500_status.txt
@@ -1,0 +1,8 @@
+Status: 500 Internal Server Error
+Content-Type: text/html
+
+<HTML>
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
+msLoadMap(): Unable to access file. (i_do_not_exist.map)
+</BODY></HTML>

--- a/msautotest/wxs/expected/wms_invalid_request_without_500_status.txt
+++ b/msautotest/wxs/expected/wms_invalid_request_without_500_status.txt
@@ -1,0 +1,7 @@
+Content-Type: text/html
+
+<HTML>
+<HEAD><TITLE>MapServer Message</TITLE></HEAD>
+<BODY BGCOLOR="#FFFFFF">
+msLoadMap(): Unable to access file. (i_do_not_exist.map)
+</BODY></HTML>

--- a/msautotest/wxs/wms_simple.map
+++ b/msautotest/wxs/wms_simple.map
@@ -3,6 +3,10 @@
 #
 # REQUIRES: INPUT=GDAL OUTPUT=PNG SUPPORTS=WMS
 #
+# RUN_PARMS: wms_invalid_request_without_500_status.txt [MAPSERV] QUERY_STRING="map=i_do_not_exist.map&SERVICE=WMS" > [RESULT]
+# RUN_PARMS: wms_invalid_request_with_500_status.txt MS_WMS_ERROR_STATUS_CODE=ON [MAPSERV] QUERY_STRING="map=i_do_not_exist.map&SERVICE=WMS" > [RESULT]
+# RUN_PARMS: wms_invalid_request_with_400_status.txt MS_WMS_ERROR_STATUS_CODE=ON [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS" > [RESULT]
+#
 #
 # Capabilities (return latest supported version by default
 #

--- a/src/maperror.h
+++ b/src/maperror.h
@@ -91,8 +91,12 @@ extern "C" {
 
 #define MESSAGELENGTH 2048
 #define ROUTINELENGTH 64
+#define HTTPSTATUSLENGTH 128
 
 #define MS_ERROR_LANGUAGE "en-US"
+
+#define MS_HTTP_400_BAD_REQUEST "400 Bad Request"
+#define MS_HTTP_500_INTERNAL_SERVER_ERROR "500 Internal Server Error"
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #define MS_DLL_EXPORT __declspec(dllexport)
@@ -119,7 +123,8 @@ typedef struct errorObj {
   int code; ///< MapServer error code such as :data:`MS_IMGERR`
   char
       routine[ROUTINELENGTH]; ///< MapServer function in which the error was set
-  char message[MESSAGELENGTH]; ///< Context-dependent error message
+  char message[MESSAGELENGTH];        ///< Context-dependent error message
+  char http_status[HTTPSTATUSLENGTH]; ////< HTTP status
   int isreported; ///< :data:`MS_TRUE` or :data:`MS_FALSE` flag indicating if
                   ///< the error has been output
   int errorcount; ///< Number of subsequent errors
@@ -161,6 +166,10 @@ MS_DLL_EXPORT void msRedactCredentials(char *str);
 MS_DLL_EXPORT void msSetError(int code, const char *message,
                               const char *routine, ...)
     MS_PRINT_FUNC_FORMAT(2, 4);
+void msSetErrorSetIsWMS(int is_wms);
+void msSetErrorWithStatus(int ms_errcode, const char *http_status,
+                          const char *message, const char *routine, ...)
+    MS_PRINT_FUNC_FORMAT(3, 5);
 MS_DLL_EXPORT void msWriteError(FILE *stream);
 MS_DLL_EXPORT void msWriteErrorXML(FILE *stream);
 MS_DLL_EXPORT char *msGetErrorCodeString(int code);

--- a/src/mapfile.c
+++ b/src/mapfile.c
@@ -6514,7 +6514,8 @@ int msSaveMap(mapObj *map, char *filename) {
 
   stream = fopen(msBuildPath(szPath, map->mappath, filename), "w");
   if (!stream) {
-    msSetError(MS_IOERR, "(%s)", "msSaveMap()", filename);
+    msSetErrorWithStatus(MS_IOERR, MS_HTTP_500_INTERNAL_SERVER_ERROR, "(%s)",
+                         "msSaveMap()", filename);
     return (-1);
   }
 
@@ -6546,7 +6547,8 @@ int msSaveConfig(configObj *config, const char *filename) {
 
   stream = fopen(filename, "w");
   if (!stream) {
-    msSetError(MS_IOERR, "(%s)", "msSaveConfig()", filename);
+    msSetErrorWithStatus(MS_IOERR, MS_HTTP_500_INTERNAL_SERVER_ERROR, "(%s)",
+                         "msSaveConfig()", filename);
     return (-1);
   }
 
@@ -6836,8 +6838,10 @@ static void applyStyleItemToLayer(mapObj *map) {
       const char *filename = layer->styleitem + strlen("sld://");
 
       if (*filename == '\0') {
-        msSetError(MS_IOERR, "Empty SLD filename: \"%s\".",
-                   "applyLayerDefaultSubstitutions()", layer->styleitem);
+        msSetErrorWithStatus(MS_IOERR, MS_HTTP_500_INTERNAL_SERVER_ERROR,
+                             "Empty SLD filename: \"%s\".",
+                             "applyLayerDefaultSubstitutions()",
+                             layer->styleitem);
       } else {
         msSLDApplyFromFile(map, layer, filename);
       }
@@ -6989,8 +6993,9 @@ mapObj *msLoadMap(const char *filename, const char *new_mappath,
 
     msyyin = tmpfile();
     if (msyyin == NULL) {
-      msSetError(MS_IOERR, "tmpfile() failed to create temporary file",
-                 "msLoadMap()");
+      msSetErrorWithStatus(MS_IOERR, MS_HTTP_500_INTERNAL_SERVER_ERROR,
+                           "tmpfile() failed to create temporary file",
+                           "msLoadMap()");
       msReleaseLock(TLOCK_PARSER);
       msFreeMap(map);
       return NULL;
@@ -7006,7 +7011,8 @@ mapObj *msLoadMap(const char *filename, const char *new_mappath,
   } else {
 #endif
     if ((msyyin = fopen(filename, "r")) == NULL) {
-      msSetError(MS_IOERR, "(%s)", "msLoadMap()", filename);
+      msSetErrorWithStatus(MS_IOERR, MS_HTTP_500_INTERNAL_SERVER_ERROR, "(%s)",
+                           "msLoadMap()", filename);
       msReleaseLock(TLOCK_PARSER);
       msFreeMap(map);
       return NULL;
@@ -7386,7 +7392,8 @@ static char **tokenizeMapInternal(char *filename, int *ret_numtokens) {
   }
 
   if ((msyyin = fopen(filename, "r")) == NULL) {
-    msSetError(MS_IOERR, "(%s)", "msTokenizeMap()", filename);
+    msSetErrorWithStatus(MS_IOERR, MS_HTTP_500_INTERNAL_SERVER_ERROR, "(%s)",
+                         "msTokenizeMap()", filename);
     return NULL;
   }
 


### PR DESCRIPTION
Currently when one issues an HTTP request that ends up in error, MapServer doesn't emit a HTTP Status header response. Hence the webserver will default to generate a 200 OK one.

This is an historical behavior used by other WMS server implementations (GeoServer, Degree) due to the WMS specification being unclear on what do do. Given that WMS is in a retirement phase, it would be risky to change that behavior by default.

That said there are WMS clients that would enjoy having a proper HTTP 400 or 500 status code. Hence if the MS_WMS_ERROR_STATUS_CODE environment variable / config option is set to ON (typically in the ENV section of the mapserver configuration file), MapServer will emit those status codes.

This relies on code to call the msSetErrorWithStatus() new function. A pass has been done in mapwms.cpp to call it. And a more moderate one in a few places of mapfile.c and mapservutil.c related to generic mapfile handling.