### PR TITLE
WCS 1.0: do not emit twice HTTP headers in case of error on SECTION parameter of GetCapabilities

### DIFF
--- a/msautotest/wxs/expected/wcs10_caps_section_error.txt
+++ b/msautotest/wxs/expected/wcs10_caps_section_error.txt
@@ -1,0 +1,8 @@
+Content-Type: application/vnd.ogc.se_xml; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" ?>
+<ServiceExceptionReport version="1.2.0"
+xmlns="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/wcs/1.0.0/OGC-exception.xsd">
+  <ServiceException code="InvalidParameterValue" locator="section">msWCSGetCapabilities(): WCS server error. Invalid SECTION parameter &quot;error&quot;
+  </ServiceException>
+</ServiceExceptionReport>

--- a/msautotest/wxs/wcs_simple.map
+++ b/msautotest/wxs/wcs_simple.map
@@ -25,6 +25,8 @@
 # RUN_PARMS: wcs_cap.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=1.0.0&REQUEST=GetCapabilities" > [RESULT_DEVERSION] [RESULT_DEMIME]
 # RUN_PARMS: wcs_cap.txt [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=1.0.0&REQUEST=GetCapabilities" > [RESULT_DEVERSION] [RESULT]
 #
+# RUN_PARMS: wcs10_caps_section_error.txt [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=1.0.0&REQUEST=GetCapabilities&SECTION=error" > [RESULT]
+#
 # Capabilities updatesequence (less than)
 # RUN_PARMS: wcs_caps_updatesequence.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=1.0.0&REQUEST=GetCapabilities&updatesequence=1999-10-21T12:22:33Z" > [RESULT_DEMIME]
 #
@@ -50,7 +52,6 @@
 #
 # Capabilities 1.1 selected sections
 # RUN_PARMS: wcs11_caps_section3.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=1.1.1&REQUEST=GetCapabilities&sections=All" > [RESULT_DEMIME]
-#
 #
 # Coverage description
 # RUN_PARMS: wcs_describe.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=1.0.0&REQUEST=DescribeCoverage&COVERAGE=grey" > [RESULT_DEMIME]

--- a/src/mapwcs.cpp
+++ b/src/mapwcs.cpp
@@ -1184,8 +1184,6 @@ static int msWCSGetCapabilities(mapObj *map, wcsParamsObj *params,
       strcasecmp(params->section, "/WCS_Capabilities/Capability") != 0 &&
       strcasecmp(params->section, "/WCS_Capabilities/ContentMetadata") != 0 &&
       strcasecmp(params->section, "/") != 0) {
-    msIO_setHeader("Content-Type", "application/vnd.ogc.se_xml; charset=UTF-8");
-    msIO_sendHeaders();
     msSetError(MS_WCSERR, "Invalid SECTION parameter \"%s\"",
                "msWCSGetCapabilities()", params->section);
     return msWCSException(map, "InvalidParameterValue", "section",


### PR DESCRIPTION
Fixes #7193