### PR TITLE
msPostGISReadShape(): fix crash if returned geometry is NULL

### DIFF
--- a/src/mappostgis.cpp
+++ b/src/mappostgis.cpp
@@ -2165,7 +2165,7 @@ static int msPostGISReadShape(layerObj *layer, shapeObj *shape) {
   const int wkbstrlen =
       PQgetlength(layerinfo->pgresult, layerinfo->rownum, layer->numitems);
 
-  if (!wkbstr) {
+  if (!wkbstr || wkbstrlen == 0) {
     msSetError(MS_QUERYERR, "WKB returned is null!", "msPostGISReadShape()");
     return MS_FAILURE;
   }


### PR DESCRIPTION
Fixes #7192