### PR TITLE
Avoid casting unique ID to string if the field is numeric in PostGIS Driver

### DIFF
--- a/src/maplayer.c
+++ b/src/maplayer.c
@@ -279,6 +279,43 @@ int msLayerIsOpen(layerObj *layer) {
 }
 
 /*
+** msLayerPropertyIsCharacter()
+**
+** Check if a field in a layer is a Character type
+*/
+static bool msLayerPropertyIsCharacter(layerObj *layer, const char *property) {
+  if (!property) {
+    return false;
+  }
+
+  char md_item_name[256];
+  snprintf(md_item_name, sizeof(md_item_name), "gml_%s_type", property);
+
+  const char *type = msLookupHashTable(&(layer->metadata), md_item_name);
+
+  return (type != NULL && (EQUAL(type, "Character")));
+}
+
+/*
+** msLayerPropertyIsNumeric()
+**
+** Check if a field in a layer is numeric - an Integer, Long, or Real
+*/
+static bool msLayerPropertyIsNumeric(layerObj *layer, const char *property) {
+  if (!property) {
+    return false;
+  }
+
+  char md_item_name[256];
+  snprintf(md_item_name, sizeof(md_item_name), "gml_%s_type", property);
+
+  const char *type = msLookupHashTable(&(layer->metadata), md_item_name);
+
+  return (type != NULL && (EQUAL(type, "Integer") || EQUAL(type, "Long") ||
+                           EQUAL(type, "Real")));
+}
+
+/*
 ** Returns MS_TRUE is a layer supports the common expression/filter syntax (RFC
 *64) and MS_FALSE otherwise.
 */

--- a/src/maplayer.c
+++ b/src/maplayer.c
@@ -283,7 +283,7 @@ int msLayerIsOpen(layerObj *layer) {
 **
 ** Check if a field in a layer is a Character type
 */
-static bool msLayerPropertyIsCharacter(layerObj *layer, const char *property) {
+bool msLayerPropertyIsCharacter(layerObj *layer, const char *property) {
   if (!property) {
     return false;
   }
@@ -301,7 +301,7 @@ static bool msLayerPropertyIsCharacter(layerObj *layer, const char *property) {
 **
 ** Check if a field in a layer is numeric - an Integer, Long, or Real
 */
-static bool msLayerPropertyIsNumeric(layerObj *layer, const char *property) {
+bool msLayerPropertyIsNumeric(layerObj *layer, const char *property) {
   if (!property) {
     return false;
   }

--- a/src/mapogr.cpp
+++ b/src/mapogr.cpp
@@ -1964,14 +1964,10 @@ static char *msOGRGetToken(layerObj *layer, tokenListNodeObjPtr *node) {
     nOutSize = strlen(stresc) + +30;
     out = (char *)msSmallMalloc(nOutSize);
 
-    char md_item_name[256];
-    snprintf(md_item_name, sizeof(md_item_name), "gml_%s_type",
-             n->tokenval.bindval.item);
-    const char *type = msLookupHashTable(&(layer->metadata), md_item_name);
+    bool bIsNumeric = msLayerPropertyIsNumeric(layer, n->tokenval.bindval.item);
     // Do not cast if the variable is of the appropriate type as it can
     // prevent using database indexes, such as for SQlite
-    if (type != NULL && (EQUAL(type, "Integer") || EQUAL(type, "Long") ||
-                         EQUAL(type, "Real"))) {
+    if (bIsNumeric) {
       snprintf(out, nOutSize, "%s", stresc);
     } else {
       const char *SQLtype = "float(16)";
@@ -1989,14 +1985,10 @@ static char *msOGRGetToken(layerObj *layer, tokenListNodeObjPtr *node) {
     nOutSize = strlen(stresc) + 20;
     out = (char *)msSmallMalloc(nOutSize);
 
-    char md_item_name[256];
-    snprintf(md_item_name, sizeof(md_item_name), "gml_%s_type",
-             n->tokenval.bindval.item);
-    const char *type = msLookupHashTable(&(layer->metadata), md_item_name);
+    bool bIsNumeric = msLayerPropertyIsNumeric(layer, n->tokenval.bindval.item);
     // Do not cast if the variable is of the appropriate type as it can
     // prevent using database indexes, such as for SQlite
-    if (type != NULL && (EQUAL(type, "Integer") || EQUAL(type, "Long") ||
-                         EQUAL(type, "Real"))) {
+    if (bIsNumeric) {
       snprintf(out, nOutSize, "%s", stresc);
     } else {
       snprintf(out, nOutSize, "CAST(%s AS integer)", stresc);
@@ -2009,13 +2001,11 @@ static char *msOGRGetToken(layerObj *layer, tokenListNodeObjPtr *node) {
     nOutSize = strlen(stresc) + 30;
     out = (char *)msSmallMalloc(nOutSize);
 
-    char md_item_name[256];
-    snprintf(md_item_name, sizeof(md_item_name), "gml_%s_type",
-             n->tokenval.bindval.item);
-    const char *type = msLookupHashTable(&(layer->metadata), md_item_name);
+    bool bIsCharacter =
+        msLayerPropertyIsCharacter(layer, n->tokenval.bindval.item);
     // Do not cast if the variable is of the appropriate type as it can
     // prevent using database indexes, such as for SQlite
-    if (type != NULL && EQUAL(type, "Character")) {
+    if (bIsCharacter) {
       snprintf(out, nOutSize, "%s", stresc);
     } else {
       snprintf(out, nOutSize, "CAST(%s AS text)", stresc);
@@ -3506,12 +3496,10 @@ msOGRTranslatePartialInternal(layerObj *layer, const msExprNode *expr,
         return "(" + osTmp1 + " IS NULL )";
       }
       if (expr->m_aoChildren[1]->m_nToken == MS_TOKEN_LITERAL_STRING) {
-        char md_item_name[256];
-        snprintf(md_item_name, sizeof(md_item_name), "gml_%s_type",
-                 expr->m_aoChildren[0]->m_osVal.c_str());
-        const char *type = msLookupHashTable(&(layer->metadata), md_item_name);
+        bool bIsCharacter = msLayerPropertyIsCharacter(
+            layer, expr->m_aoChildren[0]->m_osVal.c_str());
         // Cast if needed (or unsure)
-        if (type == NULL || !EQUAL(type, "Character")) {
+        if (bIsCharacter) {
           osTmp1 = "CAST(" + osTmp1 + " AS CHARACTER(4096))";
         }
       }

--- a/src/mapogr.cpp
+++ b/src/mapogr.cpp
@@ -3499,7 +3499,7 @@ msOGRTranslatePartialInternal(layerObj *layer, const msExprNode *expr,
         bool bIsCharacter = msLayerPropertyIsCharacter(
             layer, expr->m_aoChildren[0]->m_osVal.c_str());
         // Cast if needed (or unsure)
-        if (bIsCharacter) {
+        if (!bIsCharacter) {
           osTmp1 = "CAST(" + osTmp1 + " AS CHARACTER(4096))";
         }
       }

--- a/src/mappostgis.cpp
+++ b/src/mappostgis.cpp
@@ -1580,6 +1580,25 @@ static int msPostGISBase64Decode(unsigned char *dest, const char *src,
 #endif
 
 /*
+** isPropertyNumeric()
+**
+** Check if a field is numeric
+*/
+static bool isPropertyNumeric(layerObj *layer, const char *property) {
+
+  if (!property)
+    return false;
+
+  char md_item_name[256];
+  snprintf(md_item_name, sizeof(md_item_name), "gml_%s_type", property);
+
+  const char *type = msLookupHashTable(&(layer->metadata), md_item_name);
+
+  return (type != nullptr && (EQUAL(type, "Integer") || EQUAL(type, "Long") ||
+                              EQUAL(type, "Real")));
+}
+
+/*
 ** msPostGISBuildSQLBox()
 **
 ** Returns malloc'ed char* that must be freed by caller.
@@ -2055,10 +2074,18 @@ static std::string msPostGISBuildSQLWhere(layerObj *layer, const rectObj *rect,
     if (insert_and) {
       strWhere += " AND ";
     }
-    strWhere += '"';
-    strWhere += layerinfo->uid;
-    strWhere += "\" = ";
-    strWhere += std::to_string(*uid);
+
+    bool is_numeric = isPropertyNumeric(layer, layerinfo->uid.c_str());
+    if (is_numeric) {
+      strWhere += layerinfo->uid;
+      strWhere += " = ";
+      strWhere += *uid;
+    } else {
+      strWhere += '"';
+      strWhere += layerinfo->uid;
+      strWhere += "\" = ";
+      strWhere += std::to_string(*uid);
+    }
   }
 
   if (layer->sortBy.nProperties > 0) {
@@ -3696,6 +3723,10 @@ static int msPostGISLayerTranslateFilter(layerObj *layer, expressionObj *filter,
   if (filter->type == MS_STRING && filter->string &&
       filteritem) { /* item/value pair - add escaping */
 
+    // check if field is numeric and avoid converting to string
+    // as this prevents indexes being used
+    bool is_numeric = isPropertyNumeric(layer, filteritem);
+
     char *stresc = msLayerEscapePropertyName(layer, filteritem);
     if (filter->flags & MS_EXP_INSENSITIVE) {
       native_string += "upper(";
@@ -3703,16 +3734,23 @@ static int msPostGISLayerTranslateFilter(layerObj *layer, expressionObj *filter,
       native_string += "::text) = upper(";
     } else {
       native_string += stresc;
-      native_string += "::text = ";
+      if (!is_numeric) {
+        native_string += "::text";
+      }
+      native_string += " = ";
     }
     msFree(stresc);
 
     /* don't have a type for the righthand literal so assume it's a string and
      * we quote */
     stresc = msPostGISEscapeSQLParam(layer, filter->string);
-    native_string += '\'';
-    native_string += stresc;
-    native_string += '\'';
+    if (!is_numeric) {
+      native_string += '\'';
+      native_string += stresc;
+      native_string += '\'';
+    } else {
+      native_string += stresc;
+    }
     msFree(stresc);
 
     if (filter->flags & MS_EXP_INSENSITIVE)

--- a/src/mappostgis.cpp
+++ b/src/mappostgis.cpp
@@ -1580,25 +1580,6 @@ static int msPostGISBase64Decode(unsigned char *dest, const char *src,
 #endif
 
 /*
-** isPropertyNumeric()
-**
-** Check if a field is numeric
-*/
-static bool isPropertyNumeric(layerObj *layer, const char *property) {
-
-  if (!property)
-    return false;
-
-  char md_item_name[256];
-  snprintf(md_item_name, sizeof(md_item_name), "gml_%s_type", property);
-
-  const char *type = msLookupHashTable(&(layer->metadata), md_item_name);
-
-  return (type != nullptr && (EQUAL(type, "Integer") || EQUAL(type, "Long") ||
-                              EQUAL(type, "Real")));
-}
-
-/*
 ** msPostGISBuildSQLBox()
 **
 ** Returns malloc'ed char* that must be freed by caller.
@@ -2075,7 +2056,7 @@ static std::string msPostGISBuildSQLWhere(layerObj *layer, const rectObj *rect,
       strWhere += " AND ";
     }
 
-    bool is_numeric = isPropertyNumeric(layer, layerinfo->uid.c_str());
+    bool is_numeric = msLayerPropertyIsNumeric(layer, layerinfo->uid.c_str());
     if (is_numeric) {
       strWhere += layerinfo->uid;
       strWhere += " = ";
@@ -3725,7 +3706,7 @@ static int msPostGISLayerTranslateFilter(layerObj *layer, expressionObj *filter,
 
     // check if field is numeric and avoid converting to string
     // as this prevents indexes being used
-    bool is_numeric = isPropertyNumeric(layer, filteritem);
+    bool is_numeric = msLayerPropertyIsNumeric(layer, filteritem);
 
     char *stresc = msLayerEscapePropertyName(layer, filteritem);
     if (filter->flags & MS_EXP_INSENSITIVE) {

--- a/src/mapserver.h
+++ b/src/mapserver.h
@@ -3161,6 +3161,10 @@ MS_DLL_EXPORT int msLayerApplyScaletokens(layerObj *layer, double scale);
 MS_DLL_EXPORT int msLayerRestoreFromScaletokens(layerObj *layer);
 MS_DLL_EXPORT int msClusterLayerOpen(layerObj *layer); /* in mapcluster.c */
 MS_DLL_EXPORT int msLayerIsOpen(layerObj *layer);
+MS_DLL_EXPORT bool msLayerPropertyIsCharacter(layerObj *layer,
+                                              const char *property);
+MS_DLL_EXPORT bool msLayerPropertyIsNumeric(layerObj *layer,
+                                            const char *property);
 MS_DLL_EXPORT void msLayerClose(layerObj *layer);
 MS_DLL_EXPORT void msLayerFreeExpressions(layerObj *layer);
 MS_DLL_EXPORT int msLayerWhichShapes(layerObj *layer, rectObj rect,


### PR DESCRIPTION
Following on from #7197 - another performance improvement related to the PostGIS driver.

The PostGIS driver currently adds a WHERE clause to the SQL to get a single feature from the database, but converts both the field and value to strings - `WHERE "id"::text = '5'`. This means no index is used to find the feature. Thanks to @jandic for finding this issue. 

This pull request avoids casting the field to a string, which in our use case reduced query times from 2730ms to 144 ms - 19 times faster (the table has ~2 million records). 

OGC Feature API queries such as `mymap/ogcapi/collections/MyLayer/items/1?f=json` are affected as are any `MS_STRING` filter expression used for a PostGIS layer. 

Note a similar issue was fixed in `mapogr.cpp` with https://github.com/MapServer/MapServer/commit/22dc081f1060ca40e0b209e7bb3e9aa0ca8b5ac3 (by @rouault) - and a similar approach was taken in this pull request:

```
// Do not cast if the variable is of the appropriate type as it can
// prevent using database indexes, such as for SQlite
```

The pull request relies on the `"gml_%s_type"` being set for the Id field for the layer (or any field used in a query), which can be added manually, or by setting `"gml_types" "auto"`. 

Not all database drivers are affected, for example MSSQL uses `[id] = '2'` but as the field is not converted the index is still used even though the id is a string and the fields is an integer. 


