### PR TITLE
FIXK Alpha channel ignored in STYLE COLOR attribute binding

### DIFF
--- a/src/maputil.c
+++ b/src/maputil.c
@@ -263,7 +263,7 @@ static void bindStyle(layerObj *layer, shapeObj *shape, styleObj *style,
     }
   }
 
-  if (applyOpacity == MS_TRUE && style->opacity < 100 ) {
+  if (applyOpacity == MS_TRUE && style->opacity < 100) {
     int alpha;
     alpha = MS_NINT(style->opacity * 2.55);
     style->color.alpha = alpha;

--- a/src/maputil.c
+++ b/src/maputil.c
@@ -263,8 +263,7 @@ static void bindStyle(layerObj *layer, shapeObj *shape, styleObj *style,
     }
   }
 
-  if (applyOpacity == MS_TRUE &&
-      (style->opacity < 100 || style->color.alpha != 255)) {
+  if (applyOpacity == MS_TRUE && style->opacity < 100 ) {
     int alpha;
     alpha = MS_NINT(style->opacity * 2.55);
     style->color.alpha = alpha;


### PR DESCRIPTION
When binding a STYLE COLOR to an attribute the alpha channel is ignored:

```
STYLE
	COLOR [hex] // bind to a value such as  '#006D2C88'
```

The alpha channel is correctly read and parsed - `style->color.alpha = 136`  but then set to 255 with code below (when `style->opacity` is not set it defaults to 100):

https://github.com/MapServer/MapServer/blob/8f1835ff590d83faa80fa23fc8565c82cae48967/src/maputil.c#L266-L275

This pull request ensures opacity is only set when `style->opacity` has been applied to a style. 

It is unclear which opacity value should take precedence when both an alpha channel is set on `COLOR`, and a style `OPACITY` is also set. It looks like without attribute binding `OPACITY` takes precedence in `mapfile.c`:

https://github.com/MapServer/MapServer/blob/8f1835ff590d83faa80fa23fc8565c82cae48967/src/mapfile.c#L2797-L2805