### PR TITLE
Emit explicit error message when proj.db cannot be found

### DIFF
--- a/msautotest/wxs/expected/wms_custom_projection_not_specified.xml
+++ b/msautotest/wxs/expected/wms_custom_projection_not_specified.xml
@@ -2,6 +2,6 @@
 <ServiceExceptionReport version="1.3.0" xmlns="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://schemas.opengis.net/wms/1.3.0/exceptions_1_3_0.xsd">
 <ServiceException code="InvalidSRS">
 msWMSLoadGetMapParams(): WMS server error. Invalid CRS given : CRS must be valid for all requested layers.
-msProcessProjection(): Projection library error. proj error &quot;Invalid value for an argument&quot; for &quot;init=esri:54009&quot;
+msProcessProjection(): Projection library error. PROJ error &quot;Invalid value for an argument&quot; when instantiating &quot;init=esri:54009&quot;
 </ServiceException>
 </ServiceExceptionReport>


### PR DESCRIPTION
Fixes #7202

```
$ PROJ_DATA=invalid mapserv -conf ../etc/mapserv.conf QUERY_STRING="map=wms_layer_groups.map&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities"
Content-Type: text/html

<HTML>
<HEAD><TITLE>MapServer Message</TITLE></HEAD>
<BODY BGCOLOR="#FFFFFF">
msProcessProjection(): Projection library error. PROJ error &quot;Cannot find proj.db&quot; when instantiating &quot;init=epsg:4326&quot;
```