### PR TITLE
Add stdbool.h inclusion in mapserver.h

### DIFF
--- a/src/mapserver.h
+++ b/src/mapserver.h
@@ -39,6 +39,7 @@
 #define _GNU_SOURCE /* Required for <string.h> strcasestr() defn */
 #endif
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Fixes build failure on 8.4.0-beta2 on Ubuntu 20.04:
```
In file included from /home/even/mapserver/mapserver-8.4.0-beta2/src/mapoutput.c:31:
/home/even/mapserver/mapserver-8.4.0-beta2/src/mapserver.h:3164:15: error: unknown type name ‘bool’
 3164 | MS_DLL_EXPORT bool msLayerPropertyIsCharacter(layerObj *layer,
```