### PR TITLE
add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -51,7 +51,6 @@ authors:
 repository-code: https://github.com/MapServer/MapServer
 license: MIT
 doi: 10.5281/zenodo.6994443
-url: https://mapserver.org/
 keywords:
   - web
   - geospatial

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,64 @@
+cff-version: 1.2.0
+title: MapServer
+message: If you use this software, please cite it using the metadata from this file.
+version: 8.4.0
+abstract: MapServer is an Open Source platform for publishing spatial data and interactive mapping applications to the web.
+type: software
+authors:
+  - family-names: McKenna
+    given-names: Jeff
+    affiliation: GatewayGeo
+    orcid: https://orcid.org/0000-0003-3900-1863
+  - given-names: Lime
+    family-names: Steve
+    affiliation: MNIT DNR
+  - given-names: Bonfort
+    family-names: Thomas
+    affiliation: Airbus
+  - given-names: Boué
+    family-names: Jérome
+  - family-names: Butler
+    given-names: Howard
+    affiliation: Hobu Inc
+    orcid: https://orcid.org/0000-0002-5340-1380
+  - family-names: Girvin
+    given-names: Seth
+    affiliation: Geographika
+  - family-names: Kralidis
+    given-names: Tom
+  - family-names: Meissl
+    given-names: Stephan
+    affiliation: EOX
+    orcid: https://orcid.org/0000-0002-1407-8859
+  - family-names: Morissette
+    given-names: Daniel
+    affiliation: Mapgears
+  - family-names: Nacionales
+    given-names: Perry
+    affiliation: University of Minnesota
+  - family-names: Rahkonen
+    given-names: Jukka
+    affiliation: National Land Survey of Finland
+  - family-names: Rouault
+    given-names: Even
+    affiliation: Spatialys
+    orcid: https://orcid.org/0000-0002-5068-0476
+  - family-names: Smith
+    given-names: Mike
+    affiliation: US Army Corps of Engineers
+  - family-names: Szekeres
+    given-names: Tamas 
+repository-code: https://github.com/MapServer/MapServer
+license: MIT
+doi: 10.5281/zenodo.6994443
+url: https://mapserver.org/
+keywords:
+  - web
+  - geospatial
+  - software
+  - ogc
+  - standards
+  - gdal
+  - open source
+  - free software
+  - MIT


### PR DESCRIPTION
- leveraged by Zenodo (for DOIs)
- initially tested through [MOSS](https://github.com/OSGeo/MOSS/blob/main/CITATION.cff), then implemented by [GRASS GIS](https://github.com/OSGeo/grass/blob/main/CITATION.cff) and others
- includes first attempt at including all PSC members

cc @ploewe