### PR TITLE
Update the MapServer OpenLayers Viewer to use OpenLayers 10.4

### DIFF
--- a/msautotest/misc/expected/browse.html
+++ b/msautotest/misc/expected/browse.html
@@ -4,21 +4,24 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MapServer Simple Viewer</title>
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/ol@v10.4.0/ol.css">
-    <link rel="shortcut icon" type="image/x-icon" href="//www.mapserver.org/_static/mapserver.ico" />
+    <link rel="stylesheet" href="//mapserver.org/lib/10.4.0/ol-mapserver.css">
+    <link rel="shortcut icon" type="image/x-icon" href="//mapserver.org/_static/mapserver.ico" />
     <style>
         #map {
+            position: absolute;
+            top: 0;
+            left: 0;
             width: 100%;
-            height: 100vh;
+            height: 100%;
         }
     </style>
 </head>
 <body>
     <div id="map"></div>
-    <script src="//cdn.jsdelivr.net/npm/ol@v10.4.0/dist/ol.js"></script>
+    <script src="//mapserver.org/lib/10.4.0/ol-mapserver.js"></script>
     <script>
         const mslayer = new ol.layer.Image({
-            extent: [-180.000000,-180.000000,180.000000,180.000000],
+            extent: [-180.000000, -180.000000, 180.000000, 180.000000],
             source: new ol.source.Image({
                 loader: ol.source.mapserver.createLoader({
                     url: 'http://localhost/?map=msautotest/misc/openlayers.map&',
@@ -33,7 +36,7 @@
             target: 'map',
             view: new ol.View()
         });
-        map.getView().fit([-180.000000,-180.000000,180.000000,180.000000], { size: map.getSize() });
+        map.getView().fit([-180.000000, -180.000000, 180.000000, 180.000000], { size: map.getSize() });
     </script>
 </body>
 </html>

--- a/msautotest/misc/expected/browse.html
+++ b/msautotest/misc/expected/browse.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MapServer Simple Viewer</title>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/ol@v10.4.0/ol.css">
+    <link rel="shortcut icon" type="image/x-icon" href="//www.mapserver.org/_static/mapserver.ico" />
+    <style>
+        #map {
+            width: 100%;
+            height: 100vh;
+        }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+    <script src="//cdn.jsdelivr.net/npm/ol@v10.4.0/dist/ol.js"></script>
+    <script>
+        const mslayer = new ol.layer.Image({
+            extent: [-180.000000,-180.000000,180.000000,180.000000],
+            source: new ol.source.Image({
+                loader: ol.source.mapserver.createLoader({
+                    url: 'http://localhost/?map=msautotest/misc/openlayers.map&',
+                    params: {
+                        'layers': 'world-polys world-lines'
+                    }
+                })
+            })
+        });
+        const map = new ol.Map({
+            layers: [mslayer],
+            target: 'map',
+            view: new ol.View()
+        });
+        map.getView().fit([-180.000000,-180.000000,180.000000,180.000000], { size: map.getSize() });
+    </script>
+</body>
+</html>

--- a/msautotest/misc/expected/wms.html
+++ b/msautotest/misc/expected/wms.html
@@ -4,18 +4,21 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MapServer Simple Viewer</title>
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/ol@v10.4.0/ol.css">
-    <link rel="shortcut icon" type="image/x-icon" href="//www.mapserver.org/_static/mapserver.ico" />
+    <link rel="stylesheet" href="//mapserver.org/lib/10.4.0/ol-mapserver.css">
+    <link rel="shortcut icon" type="image/x-icon" href="//mapserver.org/_static/mapserver.ico" />
     <style>
         #map {
+            position: absolute;
+            top: 0;
+            left: 0;
             width: 100%;
-            height: 100vh;
+            height: 100%;
         }
     </style>
 </head>
 <body>
     <div id="map"></div>
-    <script src="//cdn.jsdelivr.net/npm/ol@v10.4.0/dist/ol.js"></script>
+    <script src="//mapserver.org/lib/10.4.0/ol-mapserver.js"></script>
     <script>
         const mslayer = new ol.layer.Image({
             source: new ol.source.Image({
@@ -36,7 +39,7 @@
             target: 'map',
             view: new ol.View()
         });
-        map.getView().fit([-89.905858,-179.744681,89.905858,179.744681], { size: map.getSize() });
+        map.getView().fit([-89.905858, -179.744681, 89.905858, 179.744681], { size: map.getSize() });
     </script>
 </body>
 </html>

--- a/msautotest/misc/expected/wms.html
+++ b/msautotest/misc/expected/wms.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MapServer Simple Viewer</title>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/ol@v10.4.0/ol.css">
+    <link rel="shortcut icon" type="image/x-icon" href="//www.mapserver.org/_static/mapserver.ico" />
+    <style>
+        #map {
+            width: 100%;
+            height: 100vh;
+        }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+    <script src="//cdn.jsdelivr.net/npm/ol@v10.4.0/dist/ol.js"></script>
+    <script>
+        const mslayer = new ol.layer.Image({
+            source: new ol.source.Image({
+                loader: ol.source.wms.createLoader({
+                    url: 'http://localhost/?map=msautotest/misc/openlayers.map&',
+                    params: {
+                        LAYERS: 'world-polys,world-lines',
+                        VERSION: '1.3.0',
+                        FORMAT: 'image/png'
+                    },
+                    projection: 'EPSG:4326',
+                    ratio: 1
+                })
+            })
+        });
+        const map = new ol.Map({
+            layers: [mslayer],
+            target: 'map',
+            view: new ol.View()
+        });
+        map.getView().fit([-89.905858,-179.744681,89.905858,179.744681], { size: map.getSize() });
+    </script>
+</body>
+</html>

--- a/msautotest/misc/expected/wms_projected.html
+++ b/msautotest/misc/expected/wms_projected.html
@@ -4,18 +4,21 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MapServer Simple Viewer</title>
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/ol@v10.4.0/ol.css">
-    <link rel="shortcut icon" type="image/x-icon" href="//www.mapserver.org/_static/mapserver.ico" />
+    <link rel="stylesheet" href="//mapserver.org/lib/10.4.0/ol-mapserver.css">
+    <link rel="shortcut icon" type="image/x-icon" href="//mapserver.org/_static/mapserver.ico" />
     <style>
         #map {
+            position: absolute;
+            top: 0;
+            left: 0;
             width: 100%;
-            height: 100vh;
+            height: 100%;
         }
     </style>
 </head>
 <body>
     <div id="map"></div>
-    <script src="//cdn.jsdelivr.net/npm/ol@v10.4.0/dist/ol.js"></script>
+    <script src="//mapserver.org/lib/10.4.0/ol-mapserver.js"></script>
     <script>
         const mslayer = new ol.layer.Image({
             source: new ol.source.Image({
@@ -36,7 +39,7 @@
             target: 'map',
             view: new ol.View()
         });
-        map.getView().fit([-20016548.603243,-20020527.850213,20016548.603243,20020527.850213], { size: map.getSize() });
+        map.getView().fit([-20016548.603243, -20020527.850213, 20016548.603243, 20020527.850213], { size: map.getSize() });
     </script>
 </body>
 </html>

--- a/msautotest/misc/expected/wms_projected.html
+++ b/msautotest/misc/expected/wms_projected.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MapServer Simple Viewer</title>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/ol@v10.4.0/ol.css">
+    <link rel="shortcut icon" type="image/x-icon" href="//www.mapserver.org/_static/mapserver.ico" />
+    <style>
+        #map {
+            width: 100%;
+            height: 100vh;
+        }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+    <script src="//cdn.jsdelivr.net/npm/ol@v10.4.0/dist/ol.js"></script>
+    <script>
+        const mslayer = new ol.layer.Image({
+            source: new ol.source.Image({
+                loader: ol.source.wms.createLoader({
+                    url: 'http://localhost/?map=msautotest/misc/openlayers.map&',
+                    params: {
+                        LAYERS: 'world-polys,world-lines',
+                        VERSION: '1.3.0',
+                        FORMAT: 'image/png'
+                    },
+                    projection: 'EPSG:3857',
+                    ratio: 1
+                })
+            })
+        });
+        const map = new ol.Map({
+            layers: [mslayer],
+            target: 'map',
+            view: new ol.View()
+        });
+        map.getView().fit([-20016548.603243,-20020527.850213,20016548.603243,20020527.850213], { size: map.getSize() });
+    </script>
+</body>
+</html>

--- a/msautotest/misc/openlayers.map
+++ b/msautotest/misc/openlayers.map
@@ -13,9 +13,9 @@ MAP
   EXTENT -180 -90 180 90
   SIZE 400 400
 
-  # can test locally with OpenLayers hosted on a CDN
-  CONFIG "MS_OPENLAYERS_JS_URL" "//cdn.jsdelivr.net/npm/ol@v10.4.0/dist/ol.js"
-  CONFIG "MS_OPENLAYERS_CSS_URL" "//cdn.jsdelivr.net/npm/ol@v10.4.0/ol.css"
+  # can also test with OpenLayers hosted on a CDN
+  # CONFIG "MS_OPENLAYERS_JS_URL" "//cdn.jsdelivr.net/npm/ol@v10.4.0/dist/ol.js"
+  # CONFIG "MS_OPENLAYERS_CSS_URL" "//cdn.jsdelivr.net/npm/ol@v10.4.0/ol.css"
 
   WEB
     METADATA

--- a/msautotest/misc/openlayers.map
+++ b/msautotest/misc/openlayers.map
@@ -1,0 +1,61 @@
+# Test OpenLayers HTML template output through CGI and WMS
+
+# RUN_PARMS: browse.html [MAPSERV] QUERY_STRING="map=[MAPFILE]&layers=world-polys world-lines&mode=browse&template=openlayers" > [RESULT_DEMIME]
+# RUN_PARMS: wms.html [MAPSERV] QUERY_STRING="map=[MAPFILE]&REQUEST=GetMap&SERVICE=WMS&VERSION=1.3.0&FORMAT=application/openlayers&STYLES=&TRANSPARENT=false&LAYERS=world-polys,world-lines&WIDTH=956&HEIGHT=705&CRS=EPSG:4326&BBOX=-180,-90,180,90" > [RESULT_DEMIME]
+# RUN_PARMS: wms_projected.html [MAPSERV] QUERY_STRING="map=[MAPFILE]&REQUEST=GetMap&SERVICE=WMS&VERSION=1.3.0&FORMAT=application/openlayers&STYLES=&TRANSPARENT=false&LAYERS=world-polys,world-lines&WIDTH=956&HEIGHT=705&CRS=EPSG:3857&BBOX=-20037508.34,-20048966.1,20037508.34,20048966.1" > [RESULT_DEMIME]
+#
+# REQUIRES: INPUT=SHAPE OUTPUT=PNG SUPPORTS=PROJ SUPPORTS=WMS
+#
+
+MAP
+  NAME 'OpenLayersTest'
+  IMAGETYPE PNG
+  EXTENT -180 -90 180 90
+  SIZE 400 400
+
+  # can test locally with OpenLayers hosted on a CDN
+  CONFIG "MS_OPENLAYERS_JS_URL" "//cdn.jsdelivr.net/npm/ol@v10.4.0/dist/ol.js"
+  CONFIG "MS_OPENLAYERS_CSS_URL" "//cdn.jsdelivr.net/npm/ol@v10.4.0/ol.css"
+
+  WEB
+    METADATA
+        # for testing output locally change the following to point to a MapServer URL and location of this Mapfile
+        "ows_onlineresource" "http://localhost/?map=msautotest/misc/openlayers.map&"
+        # required for both CGI and WMS
+        "wms_enable_request" "GetMap" # required for WMS testing
+        # following required for WMS
+        "wms_srs" "EPSG:4326 EPSG:3857"
+    END
+  END
+
+  PROJECTION
+    "+init=epsg:4326"
+  END
+
+  LAYER
+    NAME "world-polys"
+    TYPE POLYGON
+    STATUS OFF
+    DATA "data/world_testpoly.shp"
+    CLASS
+      STYLE
+        OUTLINECOLOR 255 0 0 
+        COLOR 0 255 0 
+      END
+    END
+  END
+
+  LAYER
+    NAME "world-lines"
+    TYPE LINE
+    STATUS OFF
+    DATA "data/testlines.shp"
+    CLASS
+      STYLE
+        WIDTH 0.5
+        COLOR 0 0 0
+      END
+    END
+  END
+
+END

--- a/src/maptemplate.c
+++ b/src/maptemplate.c
@@ -4997,8 +4997,6 @@ int msReturnOpenLayersPage(mapservObj *mapserv) {
     openlayersUrl = (char *)tmpUrl;
 
   if (mapserv->Mode == BROWSE) {
-    msSetError(MS_WMSERR, "At least one layer name required in LAYERS.",
-               "msWMSLoadGetMapParams()");
     layer = processLine(mapserv, olLayerMapServerTag, NULL, BROWSE);
   } else
     layer = processLine(mapserv, olLayerWMSTag, NULL, BROWSE);

--- a/src/maptemplate.c
+++ b/src/maptemplate.c
@@ -5031,7 +5031,7 @@ int msReturnOpenLayersPage(mapservObj *mapserv) {
     tmpUrl = CPLGetConfigOption("MS_OPENLAYERS_CSS_URL", NULL);
 
   if (tmpUrl)
-    openlayersCssUrl = (char *)tmpUrl;
+    openlayersCssUrl = tmpUrl;
 
   if (mapserv->Mode == BROWSE) {
     layer = processLine(mapserv, olLayerMapServerTag, NULL, BROWSE);

--- a/src/maptemplate.c
+++ b/src/maptemplate.c
@@ -51,8 +51,9 @@ static inline void IGUR_voidp(void *ignored) {
   (void)ignored;
 } /* Ignore GCC Unused Result */
 
-static const char *const olUrl = "//cdn.jsdelivr.net/npm/ol@v10.4.0/dist/ol.js";
-static const char *const olCssUrl = "//cdn.jsdelivr.net/npm/ol@v10.4.0/ol.css";
+static const char *const olUrl = "//mapserver.org/lib/10.4.0/ol-mapserver.js";
+static const char *const olCssUrl =
+    "//mapserver.org/lib/10.4.0/ol-mapserver.css";
 
 static const char *const olTemplate =
     "<!DOCTYPE html>\n"
@@ -65,11 +66,14 @@ static const char *const olTemplate =
     "    <link rel=\"stylesheet\" "
     "href=\"[openlayers_css_url]\">\n"
     "    <link rel=\"shortcut icon\" type=\"image/x-icon\" "
-    "href=\"//www.mapserver.org/_static/mapserver.ico\" />\n"
+    "href=\"//mapserver.org/_static/mapserver.ico\" />\n"
     "    <style>\n"
     "        #map {\n"
+    "            position: absolute;\n"
+    "            top: 0;\n"
+    "            left: 0;\n"
     "            width: 100%;\n"
-    "            height: 100vh;\n"
+    "            height: 100%;\n"
     "        }\n"
     "    </style>\n"
     "</head>\n"
@@ -84,7 +88,7 @@ static const char *const olTemplate =
     "            target: 'map',\n"
     "            view: new ol.View()\n"
     "        });\n"
-    "        map.getView().fit([[minx],[miny],[maxx],[maxy]], { size: "
+    "        map.getView().fit([[minx], [miny], [maxx], [maxy]], { size: "
     "map.getSize() });\n"
     "    </script>\n"
     "</body>\n"
@@ -92,7 +96,7 @@ static const char *const olTemplate =
 
 static const char *const olLayerMapServerTag =
     "const mslayer = new ol.layer.Image({\n"
-    "            extent: [[minx],[miny],[maxx],[maxy]],\n"
+    "            extent: [[minx], [miny], [maxx], [maxy]],\n"
     "            source: new ol.source.Image({\n"
     "                loader: ol.source.mapserver.createLoader({\n"
     "                    url: '[mapserv_onlineresource]',\n"

--- a/src/maptemplate.c
+++ b/src/maptemplate.c
@@ -5023,7 +5023,7 @@ int msReturnOpenLayersPage(mapservObj *mapserv) {
     tmpUrl = CPLGetConfigOption("MS_OPENLAYERS_JS_URL", NULL);
 
   if (tmpUrl)
-    openlayersUrl = (char *)tmpUrl;
+    openlayersUrl = tmpUrl;
 
   /* now do the same for the MS_OPENLAYERS_CSS_URL */
   tmpUrl = msGetConfigOption(mapserv->map, "MS_OPENLAYERS_CSS_URL");

--- a/src/mapwms.cpp
+++ b/src/mapwms.cpp
@@ -4235,6 +4235,14 @@ int msTranslateWMS2Mapserv(const char **names, const char **values,
 static int msWMSGetMap(mapObj *map, int nVersion, char **names, char **values,
                        int numentries, const char *wms_exception_format,
                        owsRequestObj *ows_request) {
+
+  // If we are returning an OpenLayers map there is no need to first generate an
+  // image. We can't call msReturnOpenLayersPage directly here as it requires
+  // the mapservObj
+  if (strcasecmp(map->imagetype, "application/openlayers") == 0) {
+    return MS_SUCCESS;
+  }
+
   imageObj *img;
   int sldrequested = MS_FALSE, sldspatialfilter = MS_FALSE;
   int drawquerymap = MS_FALSE;

--- a/tests/mapserver-sample.conf
+++ b/tests/mapserver-sample.conf
@@ -34,10 +34,11 @@ CONFIG
     # MS_XMLMAPFILE_XSLT
     # MS_MODE
     # MS_OPENLAYERS_JS_URL
+    # MS_OPENLAYERS_CSS_URL
     # MS_TEMPPATH
-    # MS_MAX_OPEN_FILES 
+    # MS_MAX_OPEN_FILES
   END
- 
+
   #
   # Map aliases
   #


### PR DESCRIPTION
The current built-in [OpenLayers Viewer](http://localhost/mapserver_docs/cgi/openlayers.html) uses [OpenLayers 2](https://openlayers.org/two/) - last updated in 2014. This pull request updates the templates used by the inbuilt viewer to use OpenLayers 10.4 - the current latest version. 

To enable this update a new OpenLayers source was added to the OpenLayers project, to enable map layers to be created using the MapServer CGI parameters, as well as the standard WMS interface. See https://github.com/openlayers/openlayers/pull/16591 for details, and the online example (using the Itasca demo) at https://openlayers.org/en/latest/examples/mapserver-cgi.html. Thanks to @ahocevar for the JS code reviews and accepting the pull request. 

A cut-down version of the OL library has been built - see the build steps in [this repo](https://github.com/geographika/ol-mapserver) that will be used as the default JS library used if `MS_OPENLAYERS_JS_URL` is not set. This will be uploaded to mapserver.org in the pull request at https://github.com/MapServer/MapServer-documentation/pull/1005. 

OpenLayers 3+ has its own CSS file, which isn't automatically picked up by the JS file (as it was in OpenLayers2). For this reason a new `MS_OPENLAYERS_CSS_URL` environment variable has been added as part of this pull request, and the MapServer docs will be updated. By default, it will point to `//mapserver.org/lib/10.4.0/ol-mapserver.css`.

Along with changing the HTML generated by MapServer for the templates, the following changes have been made:

- an optimisataion when used for viewing WMS - previously a GetMap image was created by the call, but then the code went on to generate and return the HTML OpenLayers page. The creation of this image is now skipped, which speeds up initial load. 
- a redundant/confusing error message was removed - `At least one layer name required in LAYERS` (it seems to be copied from somewhere else as it had the wrong function name `msWMSLoadGetMapParams`)
- tests added to check the HTML output via CGI and WMS. There were no tests previously.


