### PR TITLE
CI: Update GitHub images to ubuntu-22.04

### DIFF
--- a/.github/workflows/build-mapscript-php.yml
+++ b/.github/workflows/build-mapscript-php.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         php-version: [8.4, 8.3]

--- a/.github/workflows/build-mapscript-python.yml
+++ b/.github/workflows/build-mapscript-python.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [3.9, "3.10", 3.11, 3.12, 3.13]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
             -e WORK_DIR="$PWD" \
             -e WITH_ASAN="${{ matrix.WITH_ASAN }}" \
             -e WITH_COVERAGE="${{ matrix.WITH_COVERAGE }}" \
-            -v $PWD:$PWD ubuntu:20.04 $PWD/.github/workflows/start.sh
+            -v $PWD:$PWD ubuntu:22.04 $PWD/.github/workflows/start.sh
 
       - name: Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B827C12C2D425E227EDCA75089EBE08314DF160
           sudo add-apt-repository -y http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu/
           sudo apt-get update
-          sudo apt-get install --allow-unauthenticated protobuf-c-compiler libprotobuf-c-dev bison flex libfribidi-dev cmake librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal-dev libproj-dev libxml2-dev libexempi-dev lcov lftp postgis libharfbuzz-dev gdal-bin ccache curl postgresql-server-dev-12 postgresql-12-postgis-3 postgresql-12-postgis-3-scripts swig
+          sudo apt-get install --allow-unauthenticated protobuf-c-compiler libprotobuf-c-dev bison flex libfribidi-dev cmake librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal-dev libproj-dev libxml2-dev libexempi-dev lcov lftp postgis libharfbuzz-dev gdal-bin ccache curl postgresql-server-dev-14 postgresql-14-postgis-3 postgresql-14-postgis-3-scripts swig
       - name: Build MapServer
         run: |
           mkdir build

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -19,7 +19,7 @@ permissions:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'MapServer/MapServer'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
 
   cppcheck_2004:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   vm_ram = ENV['VAGRANT_VM_RAM'] || 2048
   vm_cpu = ENV['VAGRANT_VM_CPU'] || 2
 
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "ubuntu/jammy64"
 
   config.vm.hostname = "mapserver-vagrant"
 

--- a/ci/ubuntu/build.sh
+++ b/ci/ubuntu/build.sh
@@ -36,9 +36,9 @@ fi
 # msautotests setup
 
 # setup postgresql
-sudo sed -i  's/md5/trust/' /etc/postgresql/12/main/pg_hba.conf
-sudo sed -i  's/peer/trust/' /etc/postgresql/12/main/pg_hba.conf
-sudo service postgresql restart 12
+sudo sed -i  's/md5/trust/' /etc/postgresql/14/main/pg_hba.conf
+sudo sed -i  's/peer/trust/' /etc/postgresql/14/main/pg_hba.conf
+sudo service postgresql restart 14
 
 cd msautotest
 ./create_postgis_test_data.sh

--- a/ci/ubuntu/setup.sh
+++ b/ci/ubuntu/setup.sh
@@ -22,7 +22,7 @@ sudo apt-get install -y --allow-unauthenticated libonig5
 
 #install recent cmake
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
+sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ jammy main'
 sudo apt-get install -y --allow-unauthenticated cmake
 
 echo "cmake version"

--- a/ci/ubuntu/setup.sh
+++ b/ci/ubuntu/setup.sh
@@ -15,7 +15,7 @@ sudo apt-get install -y --allow-unauthenticated build-essential protobuf-c-compi
             librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev \
             libcairo2-dev libgdal-dev libproj-dev libxml2-dev libexempi-dev lcov lftp postgis libharfbuzz-dev gdal-bin proj-bin ccache curl \
             libpcre2-dev \
-            postgresql-server-dev-12 postgresql-12-postgis-3 postgresql-12-postgis-3-scripts g++ ca-certificates
+            postgresql-server-dev-14 postgresql-14-postgis-3 postgresql-14-postgis-3-scripts g++ ca-certificates
 
 sudo apt-get install -y --allow-unauthenticated libmono-system-drawing4.0-cil mono-mcs
 sudo apt-get install -y --allow-unauthenticated libperl-dev

--- a/ci/ubuntu/setup.sh
+++ b/ci/ubuntu/setup.sh
@@ -7,9 +7,7 @@ dpkg -l | grep postgis || /bin/true
 sudo apt-get remove --purge postgresql* libpq-dev libpq5 cmake || /bin/true
 
 # This currently fails as of https://lists.osgeo.org/pipermail/ubuntu/2023-October/002046.html
-# sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B827C12C2D425E227EDCA75089EBE08314DF160
-sudo add-apt-repository -y http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu/
+sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
 sudo apt-get update
 sudo apt-get install -y --allow-unauthenticated build-essential protobuf-c-compiler libprotobuf-c-dev bison flex libfribidi-dev \
             librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev \

--- a/scripts/vagrant/packages.sh
+++ b/scripts/vagrant/packages.sh
@@ -13,7 +13,7 @@ apt-get -y upgrade
 # install packages we need
 apt-get install -q -y git build-essential pkg-config cmake libgeos-dev rake \
     libpq-dev python3-dev python3-pip python3-venv libproj-dev libxml2-dev postgis php-dev \
-    postgresql-server-dev-12 postgresql-12-postgis-3 postgresql-12-postgis-3-scripts vim bison flex swig \
+    postgresql-server-dev-14 postgresql-14-postgis-3 postgresql-14-postgis-3-scripts vim bison flex swig \
     librsvg2-dev libpng-dev libjpeg-dev libgif-dev \
     libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev \
     libgdal-dev libfribidi-dev libexempi-dev \

--- a/scripts/vagrant/postgis.sh
+++ b/scripts/vagrant/postgis.sh
@@ -2,9 +2,9 @@
 
 cd /vagrant/msautotest
 
-sed -i  's/md5/trust/' /etc/postgresql/12/main/pg_hba.conf
-sed -i  's/peer/trust/' /etc/postgresql/12/main/pg_hba.conf
+sed -i  's/md5/trust/' /etc/postgresql/14/main/pg_hba.conf
+sed -i  's/peer/trust/' /etc/postgresql/14/main/pg_hba.conf
 
-service postgresql restart 12
+service postgresql restart 14
 
 ./create_postgis_test_data.sh

--- a/src/mapcairo.c
+++ b/src/mapcairo.c
@@ -368,7 +368,9 @@ int renderSVGSymbolCairo(imageObj *img, double x, double y, symbolObj *symbol,
     }
   }
 #else
-  rsvg_handle_render_cairo(cache->svgc, r->cr);
+  RsvgRectangle viewport = {0, 0, symbol->sizex,
+                            symbol->sizey};
+  rsvg_handle_render_document(cache->svgc, r->cr, &viewport);
 #endif
 
   cairo_restore(r->cr);
@@ -1127,7 +1129,9 @@ int msRenderRasterizedSVGSymbol(imageObj *img, double x, double y,
       return MS_FAILURE;
     }
 #else
-    rsvg_handle_render_cairo(svg_cache->svgc, cr);
+    RsvgRectangle viewport = {0, 0, width,
+                              height};
+    rsvg_handle_render_document(svg_cache->svgc, cr, &viewport);
 #endif
     pb = cairo_image_surface_get_data(surface);
 


### PR DESCRIPTION
> We will soon start the deprecation process for Ubuntu 20.04. While the image is being deprecated, you may experience longer queue times during peak usage hours. Deprecation will begin on 2025-02-01 and the image will be fully unsupported by 2025-04-01.

From https://github.com/actions/runner-images/issues/11101

This updates all `ubuntu-20.04` images to `ubuntu-22.04`, which will likely require regenerating msautotest images. Opening a pull request to see what breaks. 

See also GDAL PR at https://github.com/OSGeo/gdal/pull/11840/files
