### PR TITLE
CI: Run cppcheck using Docker

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -12,16 +12,14 @@ permissions:
 jobs:
 
   cppcheck_2004:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Requirements
-        run: |
-          sudo apt update
-          sudo apt install -y cppcheck
-
       - name: Run cppcheck test
-        run: ./scripts/cppcheck.sh
+        run: |
+            docker run \
+            -e WORK_DIR="$PWD" \
+            -v $PWD:$PWD ubuntu:20.04 $PWD/scripts/cppcheck.sh

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+apt-get update -y
+apt-get install -y cppcheck
+
 cppcheck --version
 
 LOG_FILE=/tmp/cppcheck_mapserver.txt


### PR DESCRIPTION
- Updates the CI runner to ubuntu-latest
- Moves the actual cppcheck to a script run through Docker with a fixed image of ubuntu:20.04

This reduces the risk of breaking CI due to the vagaries and timelines of GitHub such as the following change:

> We will soon start the deprecation process for Ubuntu 20.04. While the image is being deprecated, you may experience longer queue times during peak usage hours. Deprecation will begin on 2025-02-01 and the image will be fully unsupported by 2025-04-01.

From https://github.com/actions/runner-images/issues/11101