### PR TITLE
CI: Update build-mapscript-python to use Docker

### DIFF
--- a/.github/workflows/build-mapscript-python.yml
+++ b/.github/workflows/build-mapscript-python.yml
@@ -16,24 +16,19 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
-    env:
-      MAPSCRIPT_PYTHON_ONLY: 'true'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: ./ci/ubuntu/setup.sh
-
-      - name: Build
-        run: ./ci/ubuntu/build.sh
+      - name: Set up Python and Install Dependencies
+        run: |
+            docker run \
+            -e WORK_DIR="$PWD" \
+            -e PYTHON_VERSION="${{ matrix.python-version }}" \
+            -e MAPSCRIPT_PYTHON_ONLY="true" \
+            -v $PWD:$PWD ubuntu:20.04 $PWD/scripts/build-mapscript-python.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/ci/ubuntu/setup.sh
+++ b/ci/ubuntu/setup.sh
@@ -6,25 +6,28 @@ dpkg -l | grep postgresql || /bin/true
 dpkg -l | grep postgis || /bin/true
 sudo apt-get remove --purge postgresql* libpq-dev libpq5 cmake || /bin/true
 
-# This currently fails as of https://lists.osgeo.org/pipermail/ubuntu/2023-October/002046.html
-# sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B827C12C2D425E227EDCA75089EBE08314DF160
-sudo add-apt-repository -y http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu/
+# Fix missing Kitware key issue
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | sudo tee /etc/apt/keyrings/kitware-archive-latest.asc > /dev/null
+echo 'deb [signed-by=/etc/apt/keyrings/kitware-archive-latest.asc] https://apt.kitware.com/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/kitware.list > /dev/null
+
+# Add required repositories
+sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
+
 sudo apt-get update
+
 sudo apt-get install -y --allow-unauthenticated build-essential protobuf-c-compiler libprotobuf-c-dev bison flex libfribidi-dev \
             librsvg2-dev colordiff libpq-dev libpng-dev libjpeg-dev libgif-dev libgeos-dev libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev \
             libcairo2-dev libgdal-dev libproj-dev libxml2-dev libexempi-dev lcov lftp postgis libharfbuzz-dev gdal-bin proj-bin ccache curl \
             libpcre2-dev \
-            postgresql-server-dev-12 postgresql-12-postgis-3 postgresql-12-postgis-3-scripts g++ ca-certificates
+            postgresql-server-dev-12 postgresql-12-postgis-3 postgresql-12-postgis-3-scripts g++ ca-certificates \
+            libmono-system-drawing4.0-cil mono-mcs \
+            libperl-dev \
+            openjdk-8-jdk \
+            libonig5
 
-sudo apt-get install -y --allow-unauthenticated libmono-system-drawing4.0-cil mono-mcs
-sudo apt-get install -y --allow-unauthenticated libperl-dev
-sudo apt-get install -y --allow-unauthenticated openjdk-8-jdk
-sudo apt-get install -y --allow-unauthenticated libonig5
-
-#install recent cmake
-wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
-sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
+# install recent CMake from Kitware
 sudo apt-get install -y --allow-unauthenticated cmake
 
 echo "cmake version"

--- a/scripts/build-mapscript-python.sh
+++ b/scripts/build-mapscript-python.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -eu  # Exit on error and treat unset variables as errors
+
+cd "$WORK_DIR"
+
+# Ensure the Python version is provided
+if [ -z "${PYTHON_VERSION:-}" ]; then
+    echo "Error: Python version not specified. Make sure to pass it as an environment variable."
+    exit 1
+fi
+
+DEBIAN_FRONTEND=noninteractive 
+
+apt-get update -y
+
+# https://github.com/pyenv/pyenv/wiki#suggested-build-environment
+
+# general dependencies
+apt-get install -y sudo software-properties-common wget
+
+# pyenv dependencies
+apt-get install -y \
+    build-essential libssl-dev zlib1g-dev \
+    libbz2-dev libreadline-dev libsqlite3-dev curl git \
+    libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
+
+# install pyenv
+curl https://pyenv.run | bash
+# https://github.com/pyenv/pyenv?tab=readme-ov-file#b-set-up-your-shell-environment-for-pyenv
+
+# set up pyenv environment
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+
+# initialize pyenv (for non-interactive shell)
+eval "$(pyenv init --path)"
+eval "$(pyenv init -)"
+
+# verify installation
+pyenv --version
+
+# export CRYPTOGRAPHY_DONT_BUILD_RUST=1 # to avoid issue when building Cryptography python module
+pyenv install -s "$PYTHON_VERSION"
+
+# set the global Python version
+pyenv global $PYTHON_VERSION
+
+# install build dependencies
+ci/ubuntu/setup.sh
+
+cd "$WORK_DIR"
+
+# build the project
+ci/ubuntu/build.sh
+
+echo "Done!"


### PR DESCRIPTION
As with #7224 run the build-mapscript-python workflow using Docker. Also switch the main build to use `ubuntu-latest` (as there are modifications to the shared `setup.sh` script). 

Quite a few hurdles to overcome to get this working, and unsure why moving to a shell script caused some parts of `setup.sh` to stop working. `pyenv` is also tricky to configure (and the approach seems to have changed a few times over the years). 

A couple of notes for reference. The following error ` docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "/home/runner/work/mapserver/mapserver/scripts/build-mapscript-python.sh": permission denied: unknown.` was becuase the new shell script required execute permissions to be set with:

```
git update-index --chmod=+x ./scripts/build-mapscript-python.sh
```

To run locally on a Windows machine:

```
cd D:\GitHub\MapServer
docker run -e WORK_DIR="/mapserver" -e PYTHON_VERSION="3.10" -e MAPSCRIPT_PYTHON_ONLY="true" -v D:\GitHub\mapserver:/mapserver ubuntu:20.04 /mapserver/scripts/build-mapscript-python.sh
```

Note some clean-up needs to be done to avoid the following error - `D:\GitHub\mapserver\swig-git-master` needs to be removed prior to each run or get:  `# fatal: destination path 'swig-git-master' already exists and is not an empty directory.`


