### PR TITLE
CI: Update (temporarily) to ubuntugis-stable

### DIFF
--- a/ci/ubuntu/setup.sh
+++ b/ci/ubuntu/setup.sh
@@ -12,7 +12,7 @@ curl -fsSL https://apt.kitware.com/keys/kitware-archive-latest.asc | sudo tee /e
 echo 'deb [signed-by=/etc/apt/keyrings/kitware-archive-latest.asc] https://apt.kitware.com/ubuntu focal main' | sudo tee /etc/apt/sources.list.d/kitware.list > /dev/null
 
 # Add required repositories
-sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+sudo add-apt-repository -y ppa:ubuntugis/ppa # stable
 sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
 
 sudo apt-get update


### PR DESCRIPTION
Contrary to what I wrote in #7228 - the CI failures were caused by a *downgrade* of GDAL and PROJ. The `ubuntu-20.04` (Focal) packages were removed from `ubuntugis-unstable` which caused the CI to get older builds of GDAL and PROJ from `http://archive.ubuntu.com/ubuntu focal/`. 

CI was failing as GDAL was changed from 3.4.3 to 3.0.4 and PROJ from 8.2.0 to 6.3.1. 

This pull requests (temporarily) switches from `ubuntugis/ubuntugis-unstable` to `ubuntugis/ppa`  (ubuntugis-stable) to get the CI passing again. 