### PR TITLE
msautotest: Fix interpretation of test output comparison in mstestlib

### DIFF
--- a/msautotest/pymod/mstestlib.py
+++ b/msautotest/pymod/mstestlib.py
@@ -722,16 +722,6 @@ def _run(map, out_file, command, extra_args):
 
     cmp = compare_result(out_file)
 
-    if cmp != "match":
-        if not keep_pass:
-            os.remove("result/" + out_file)
-        if not quiet:
-            print("     results do not match, but ignored.")
-        else:
-            sys.stdout.write(".")
-            sys.stdout.flush()
-        return True, None
-
     if cmp == "match":
         if not keep_pass:
             os.remove("result/" + out_file)


### PR DESCRIPTION
The recent change 64a706f6f598e8bc912a2c0713cc4228e8805f44 introduced a severe regression on msautotest.

At the moment it would not detect changes in test output in many cases. You can test this by changing any textual expected result file.
For example take `msautotest/config/expected/missing_conf.txt`, rewrite the expected error message, run the test and see how it still succeed.

The issue is how the comparison result is currently interpreted

https://github.com/MapServer/MapServer/blob/4121426f071bc0f090f203569cc31bd3feca92b9/msautotest/pymod/mstestlib.py#L725-L742

With the removal of the extra `ignore_comparison_result` parameter the first if block is always considered. The compare result is either `== "match"` and the test successful or `!= "match"` and the difference ignored and the test also succesful.

Right now there is no way to enter any of the other elif blocks.
