### PR TITLE
 Bump C/C++ standard to 17 for ICU 76.

### DIFF
--- a/.github/workflows/start.sh
+++ b/.github/workflows/start.sh
@@ -40,7 +40,7 @@ ci/ubuntu/build.sh
 
 # Validate openapi document
 pip install check-jsonschema --break-system-packages
-wget https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.0/schema.yaml -O openapi_schema.yaml
+wget https://raw.githubusercontent.com/OAI/OpenAPI-Specification/refs/heads/main/_archive_/schemas/v3.0/schema.yaml -O openapi_schema.yaml
 echo "Run check-jsonschema --schemafile openapi_schema.yaml msautotest/api/expected/ogcapi_api.json"
 check-jsonschema --schemafile openapi_schema.yaml msautotest/api/expected/ogcapi_api.json
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ set (MapServer_VERSION_SUFFIX "")
 
 # Set C++ version
 # Make CMAKE_CXX_STANDARD available as cache option overridable by user
-set(CMAKE_CXX_STANDARD 11
-  CACHE STRING "C++ standard version to use (default is 11)")
+set(CMAKE_CXX_STANDARD 17
+  CACHE STRING "C++ standard version to use (default is 17)")
 message(STATUS "Requiring C++${CMAKE_CXX_STANDARD}")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -31,8 +31,8 @@ message(STATUS "Requiring C++${CMAKE_CXX_STANDARD} - done")
 
 # Set C version
 # Make CMAKE_C_STANDARD available as cache option overridable by user
-set(CMAKE_C_STANDARD 11
-  CACHE STRING "C standard version to use (default is 11)")
+set(CMAKE_C_STANDARD 17
+  CACHE STRING "C standard version to use (default is 17)")
 message(STATUS "Requiring C${CMAKE_C_STANDARD}")
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)


### PR DESCRIPTION
As reported in [Debian Bug #1101239](https://bugs.debian.org/1101239), MapServer fails to build with ICU 76 (pulled in via libxml2) which now requires C++17.