### PR TITLE
Fix MS_MAP_BAD_PATTERN regex and use PROJ_DATA

### DIFF
--- a/etc/mapserver-sample.conf
+++ b/etc/mapserver-sample.conf
@@ -12,7 +12,7 @@ CONFIG
     #
     # MS_MAP_NO_PATH "1"
     MS_MAP_PATTERN "^/opt/mapserver" ## required when referencing mapfiles by path
-    # MS_MAP_BAD_PATTERN "[/\\]{2}|[/\\]?\\.+[/\\]|,"
+    # MS_MAP_BAD_PATTERN "[/\\\\]{2}|[/\\\\]?\\.+[/\\\\]|,"
 
     #
     # Global Log/Debug Setup
@@ -37,7 +37,7 @@ CONFIG
     #
     # Proj Library
     #
-    # PROJ_LIB "/usr/local/share/proj"
+    # PROJ_DATA "/usr/local/share/proj"
 
     #
     # Request Control


### PR DESCRIPTION
See related issue in OSGeoLive - https://github.com/OSGeo/OSGeoLive/pull/419

Likely due to the switching to use [PCRE2 instead of POSIX]( https://github.com/MapServer/MapServer/pull/7073) the regex used in example `mapserver.conf` for `MS_MAP_BAD_PATTERN` is throwing errors: `MS_MAP_BAD_PATTERN "[/\\]{2}|[/\\]?\.{2,}[/\\]|,"`:

![image](https://github.com/user-attachments/assets/c260305a-20fe-49fb-9012-8a7fa9533c4f)

Switched to using the example from  https://github.com/MapServer/MapServer/blob/d54aae0311066e116974ef888b82959bcefb8c24/src/mapservutil.c#L174

`const char *ms_map_bad_pattern_default = "[/\\\\]{2}|[/\\\\]?\\.+[/\\\\]|,";`

In addition the deprecated `PROJ_LIB` is updated to `PROJ_DATA`. See https://proj.org/en/stable/resource_files.html#where-are-proj-resource-files-looked-for