### PR TITLE
Tileindex: Fix vector tileindex infinite recursion

### DIFF
--- a/src/mapogr.cpp
+++ b/src/mapogr.cpp
@@ -2490,9 +2490,6 @@ static int msOGRFileWhichShapes(layerObj *layer, rectObj rect,
       msFree(select);
       return MS_FAILURE;
     }
-
-    // Update itemindexes / layer->iteminfo
-    msOGRLayerInitItemInfo(layer);
   } else {
 
     // case of 1) GetLayer + SetFilter
@@ -4008,6 +4005,10 @@ int msOGRLayerWhichShapes(layerObj *layer, rectObj rect, int /*isQuery*/) {
   }
 
   status = msOGRFileWhichShapes(layer, rect, psInfo);
+
+  // Update itemindexes / layer->iteminfo
+  if (status == MS_SUCCESS)
+    msOGRLayerInitItemInfo(layer);
 
   if (status != MS_SUCCESS || layer->tileindex == NULL)
     return status;


### PR DESCRIPTION
In certain cases MS would end up in a endless recursion, with the following stack:

`msOGRFileReadTile` - fetch next tile 
 -- `msOgrFileWhichShapes` - bbox filter 
 ----  `msOgrInitItems` - reload items
------- `msOGRFileReadTile` - fetch tile...

To avoid this, I moved `msOgrInitItems` out of the function. 

In my case, it was triggered by a WFS GetFeature request to a tileindex layer, where the data was GPKG and the tileindex itself was a shapefile.

I made an attempt at recreating the issue from the existing [auto test](https://github.com/MapServer/MapServer/blob/main/msautotest/wxs/wfs_ogr_tileindex_of_shp.map) but did not get that far at the moment. I suspect it would enter the relevant code if a `sortBy`-clause was added to the WFS request in the test. But it threw (unrelated) errors when I added it, so might need some more investigation.  