### PR TITLE
Increase default memory for vagrant and remove legacy fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@
 # vi: set ft=ruby :
 
 require 'socket'
+require 'fileutils'
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -13,7 +14,7 @@ EOF
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  vm_ram = ENV['VAGRANT_VM_RAM'] || 2048
+  vm_ram = ENV['VAGRANT_VM_RAM'] || 4098
   vm_cpu = ENV['VAGRANT_VM_CPU'] || 2
 
   config.vm.box = "bento/ubuntu-24.04" # see https://portal.cloud.hashicorp.com/vagrant/discover?query=ubuntu
@@ -37,7 +38,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.synced_folder cache_dir, "/var/cache/apt/archives"
   end
 
-  config.vm.provision "shell", path: "scripts/vagrant/virtualbox-fix.sh"
   config.vm.provision "shell", path: "scripts/vagrant/packages.sh"
   config.vm.provision "shell", path: "scripts/vagrant/postgis.sh"
   config.vm.provision "shell", path: "scripts/vagrant/msautotest.sh"  

--- a/scripts/vagrant/virtualbox-fix.sh
+++ b/scripts/vagrant/virtualbox-fix.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-if [ -e "/usr/lib/VBoxGuestAdditions" ] || [ -L "/usr/lib/VBoxGuestAdditions" ]; then
-    rm -rf /usr/lib/VBoxGuestAdditions
-fi
-
-ln -s /opt/VBoxGuestAdditions-4.3.10/lib/VBoxGuestAdditions /usr/lib/VBoxGuestAdditions


### PR DESCRIPTION
The default 2GB of RAM for vagrant makes builds very slow. It can be overwritten with environment variables, but making the default 4GB makes it run through msautotests much faster. 

The virtualbox-fix.sh no longer seems necessary (or have an effect). VBoxGuestAdditions is now up to version 7.x now (4.3 is referred to in the script). 

Fix added to make it fully automated in https://github.com/MapServer/MapServer/commit/29be7f091310cb7a2f343e15e344dd3e21e352ed
