### PR TITLE
Update OpenLayers version and support non-built-in projections

### DIFF
--- a/msautotest/misc/expected/browse.html
+++ b/msautotest/misc/expected/browse.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MapServer Simple Viewer</title>
-    <link rel="stylesheet" href="//mapserver.org/lib/10.4.0/ol-mapserver.css">
+    <link rel="stylesheet" href="//mapserver.org/lib/10.5.0/ol-mapserver.css">
     <link rel="shortcut icon" type="image/x-icon" href="//mapserver.org/_static/mapserver.ico" />
     <style>
         #map {
@@ -18,7 +18,7 @@
 </head>
 <body>
     <div id="map"></div>
-    <script src="//mapserver.org/lib/10.4.0/ol-mapserver.js"></script>
+    <script src="//mapserver.org/lib/10.5.0/ol-mapserver.js"></script>
     <script>
         const mslayer = new ol.layer.Image({
             extent: [-180.000000, -180.000000, 180.000000, 180.000000],

--- a/msautotest/misc/expected/wms_projected.html
+++ b/msautotest/misc/expected/wms_projected.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MapServer Simple Viewer</title>
-    <link rel="stylesheet" href="//mapserver.org/lib/10.4.0/ol-mapserver.css">
+    <link rel="stylesheet" href="//mapserver.org/lib/10.5.0/ol-mapserver.css">
     <link rel="shortcut icon" type="image/x-icon" href="//mapserver.org/_static/mapserver.ico" />
     <style>
         #map {
@@ -18,8 +18,11 @@
 </head>
 <body>
     <div id="map"></div>
-    <script src="//mapserver.org/lib/10.4.0/ol-mapserver.js"></script>
+    <script src="//mapserver.org/lib/10.5.0/ol-mapserver.js"></script>
     <script>
+        if (!ol.proj.get('EPSG:3857')) {
+            ol.proj.addProjection(new ol.proj.Projection({ code : 'EPSG:3857' }));
+        }
         const mslayer = new ol.layer.Image({
             source: new ol.source.Image({
                 loader: ol.source.wms.createLoader({

--- a/msautotest/misc/expected/wms_projected_extra.html
+++ b/msautotest/misc/expected/wms_projected_extra.html
@@ -20,8 +20,8 @@
     <div id="map"></div>
     <script src="//mapserver.org/lib/10.5.0/ol-mapserver.js"></script>
     <script>
-        if (!ol.proj.get('EPSG:4326')) {
-            ol.proj.addProjection(new ol.proj.Projection({ code : 'EPSG:4326' }));
+        if (!ol.proj.get('EPSG:3395')) {
+            ol.proj.addProjection(new ol.proj.Projection({ code : 'EPSG:3395' }));
         }
         const mslayer = new ol.layer.Image({
             source: new ol.source.Image({
@@ -32,7 +32,7 @@
                         VERSION: '1.3.0',
                         FORMAT: 'image/png'
                     },
-                    projection: 'EPSG:4326',
+                    projection: 'EPSG:3395',
                     ratio: 1
                 })
             })
@@ -42,7 +42,7 @@
             target: 'map',
             view: new ol.View()
         });
-        map.getView().fit([-89.905858, -179.744681, 89.905858, 179.744681], { size: map.getSize() });
+        map.getView().fit([-20016548.603243, -15472271.997468, 20016548.603243, 18740357.487468], { size: map.getSize() });
     </script>
 </body>
 </html>

--- a/msautotest/misc/openlayers.map
+++ b/msautotest/misc/openlayers.map
@@ -3,7 +3,8 @@
 # RUN_PARMS: browse.html [MAPSERV] QUERY_STRING="map=[MAPFILE]&layers=world-polys world-lines&mode=browse&template=openlayers" > [RESULT_DEMIME]
 # RUN_PARMS: wms.html [MAPSERV] QUERY_STRING="map=[MAPFILE]&REQUEST=GetMap&SERVICE=WMS&VERSION=1.3.0&FORMAT=application/openlayers&STYLES=&TRANSPARENT=false&LAYERS=world-polys,world-lines&WIDTH=956&HEIGHT=705&CRS=EPSG:4326&BBOX=-180,-90,180,90" > [RESULT_DEMIME]
 # RUN_PARMS: wms_projected.html [MAPSERV] QUERY_STRING="map=[MAPFILE]&REQUEST=GetMap&SERVICE=WMS&VERSION=1.3.0&FORMAT=application/openlayers&STYLES=&TRANSPARENT=false&LAYERS=world-polys,world-lines&WIDTH=956&HEIGHT=705&CRS=EPSG:3857&BBOX=-20037508.34,-20048966.1,20037508.34,20048966.1" > [RESULT_DEMIME]
-#
+# RUN_PARMS: wms_projected_extra.html [MAPSERV] QUERY_STRING="map=[MAPFILE]&REQUEST=GetMap&SERVICE=WMS&VERSION=1.3.0&FORMAT=application/openlayers&STYLES=&TRANSPARENT=false&LAYERS=world-polys,world-lines&WIDTH=956&HEIGHT=705&CRS=EPSG:3395&BBOX=-20037508.34,-15496570.74,20037508.34,18764656.23" > [RESULT_DEMIME]
+
 # REQUIRES: INPUT=SHAPE OUTPUT=PNG SUPPORTS=PROJ SUPPORTS=WMS
 #
 
@@ -14,8 +15,8 @@ MAP
   SIZE 400 400
 
   # can also test with OpenLayers hosted on a CDN
-  # CONFIG "MS_OPENLAYERS_JS_URL" "//cdn.jsdelivr.net/npm/ol@v10.4.0/dist/ol.js"
-  # CONFIG "MS_OPENLAYERS_CSS_URL" "//cdn.jsdelivr.net/npm/ol@v10.4.0/ol.css"
+  # CONFIG "MS_OPENLAYERS_JS_URL" "//cdn.jsdelivr.net/npm/ol@v10.5.0/dist/ol.js"
+  # CONFIG "MS_OPENLAYERS_CSS_URL" "//cdn.jsdelivr.net/npm/ol@v10.5.0/ol.css"
 
   WEB
     METADATA
@@ -24,7 +25,7 @@ MAP
         # required for both CGI and WMS
         "wms_enable_request" "GetMap" # required for WMS testing
         # following required for WMS
-        "wms_srs" "EPSG:4326 EPSG:3857"
+        "wms_srs" "EPSG:4326 EPSG:3857 EPSG:3395"
     END
   END
 

--- a/src/maptemplate.c
+++ b/src/maptemplate.c
@@ -51,9 +51,9 @@ static inline void IGUR_voidp(void *ignored) {
   (void)ignored;
 } /* Ignore GCC Unused Result */
 
-static const char *const olUrl = "//mapserver.org/lib/10.4.0/ol-mapserver.js";
+static const char *const olUrl = "//mapserver.org/lib/10.5.0/ol-mapserver.js";
 static const char *const olCssUrl =
-    "//mapserver.org/lib/10.4.0/ol-mapserver.css";
+    "//mapserver.org/lib/10.5.0/ol-mapserver.css";
 
 static const char *const olTemplate =
     "<!DOCTYPE html>\n"
@@ -108,7 +108,11 @@ static const char *const olLayerMapServerTag =
     "        });";
 
 static const char *const olLayerWMSTag =
-    "const mslayer = new ol.layer.Image({\n"
+    "if (!ol.proj.get('[openlayers_projection]')) {\n"
+    "            ol.proj.addProjection(new ol.proj.Projection({ code : "
+    "'[openlayers_projection]' }));\n"
+    "        }\n"
+    "        const mslayer = new ol.layer.Image({\n"
     "            source: new ol.source.Image({\n"
     "                loader: ol.source.wms.createLoader({\n"
     "                    url: '[mapserv_onlineresource]',\n"


### PR DESCRIPTION
The OpenLayers template added in #7218 works fine when a request is made using one of the built-in OpenLayers projections - EPSG:4326 or EPSG:3857, however for other projections when using WMS requests and `&FORMAT=application/openlayers` OpenLayers throws an error:

```js
TypeError: Cannot read properties of null (reading 'getAxisOrientation')
# at following line as projection is null
const axisOrientation = projection.getAxisOrientation();
```

This PR adds an additional JS check to prevent this error, by ensuring the code is registered with OpenLayers. As the map only shows layers from MapServer the actual projections don't need to have any further details (which would get very complicated and require proj4js to be included and fulll PROJ definitions to be sent back).

The check is as follows:

```js
if (!ol.proj.get('EPSG:2157')) {
 ol.proj.addProjection(new ol.proj.Projection({ code : 'EPSG:2157' }));
}
```

If the projection is already supported by OpenLayers no changes are made. 

The PR also includes a test, and bumps up the inbuilt OL version to a custom build based on v10.5.0 of OpenLayers, with additional `ol.proj` objects added (see https://github.com/geographika/ol-mapserver/commit/ee4119297019297eaa8cb1bd8d30808b5d78263e). PR to the docs repo to follow. 