### PR TITLE
Check wms_onlineresource for OpenLayers output

### DIFF
--- a/src/maptemplate.c
+++ b/src/maptemplate.c
@@ -4092,7 +4092,7 @@ static char *processLine(mapservObj *mapserv, const char *instr, FILE *stream,
     char *ol;
 #if defined(USE_WMS_SVR) || defined(USE_WFS_SVR) || defined(USE_WCS_SVR) ||    \
     defined(USE_SOS_SVR) || defined(USE_WMS_LYR) || defined(USE_WFS_LYR)
-    ol = msOWSGetOnlineResource(mapserv->map, "O", "onlineresource",
+    ol = msOWSGetOnlineResource(mapserv->map, "MO", "onlineresource",
                                 mapserv->request);
 #else
     ol = msBuildOnlineResource(mapserv->map, mapserv->request);


### PR DESCRIPTION
When using the [OpenLayers output](https://mapserver.org/cgi/openlayers.html) for a WMS requests (by adding `&FORMAT=application/openlayers`), the "ows_onlineresource" is used as part of the OpenLayers template:

https://github.com/MapServer/MapServer/blob/e6eba841ae2c4fc92061ac11fa01c7595cbb492d/src/maptemplate.c#L102

However, currently only `ows_onlineresource` is checked for in the metadata. This PR also checks for the  `wms_onlineresource` WEB METADATA key. 