### PR TITLE
msautotest: fix get_gdal_version() to support GDAL version nickname

### DIFF
--- a/msautotest/pymod/mstestlib.py
+++ b/msautotest/pymod/mstestlib.py
@@ -495,6 +495,10 @@ def get_gdal_version():
         pos = gdal_version.find(",")
         if pos >= 0:
             return gdal_version[0:pos]
+        # e.g. "GDAL 3.11.3 Eganville"
+        pos = gdal_version.find(" ")
+        if pos >= 0:
+            return gdal_version[0:pos]
     return None
 
 


### PR DESCRIPTION
Fixes
```
Cannot validate XML because SCHEMAS_OPENGIS_NET not found. Run "python ../pymod/xmlvalidate.py -download_ogc_schemas" from msautotest/wxs
Traceback (most recent call last):
  File "/home/runner/work/mapserver/mapserver/msautotest/wxs/./run_test.py", line 43, in <module>
    mstestlib.get_pytests(os.path.dirname(os.path.abspath(__file__))),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/mapserver/mapserver/msautotest/wxs/../pymod/mstestlib.py", line 536, in get_pytests
    if not has_requires(version_info, gdal_version, requires_list):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/mapserver/mapserver/msautotest/wxs/../pymod/mstestlib.py", line 111, in has_requires
    if compare_version(gdal_version, item[len("GDAL>=") :]) < 0:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/mapserver/mapserver/msautotest/wxs/../pymod/mstestlib.py", line 84, in compare_version
    a_x, a_y, a_z = int(a[0]), int(a[1]), int(a[2])
                                          ^^^^^^^^^
ValueError: invalid literal for int() with base 10: '3 "Eganville"'
```