### PR TITLE
WFS: add next link if there might be features left

### DIFF
--- a/msautotest/wxs/expected/wfs_ogr_gpkg_pagination_4326.xml
+++ b/msautotest/wxs/expected/wfs_ogr_gpkg_pagination_4326.xml
@@ -1,0 +1,148 @@
+Content-Type: text/xml; subtype="gml/3.2.1"; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml/3.2"
+   xmlns:wfs="http://www.opengis.net/wfs/2.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=popplace&amp;OUTPUTFORMAT=application%2Fgml%2Bxml%3B%20version%3D3.2 http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+   timeStamp="" numberMatched="4" numberReturned="4"
+   next="http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=GetFeature&amp;TYPENAMES=popplace&amp;BBOX=43.0%2C-65.0%2C45.0%2C-62.0&amp;COUNT=7&amp;STARTINDEX=7">
+      <wfs:boundedBy>
+      	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+      		<gml:lowerCorner>44.020359 -64.732816</gml:lowerCorner>
+      		<gml:upperCorner>44.971547 -62.513078</gml:upperCorner>
+      	</gml:Envelope>
+      </wfs:boundedBy>
+<!-- WARNING: No featureid defined for typename 'popplace'. Output will not validate. -->
+    <wfs:member>
+      <ms:popplace>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>44.911800 -62.513078</gml:lowerCorner>
+        		<gml:upperCorner>44.911800 -62.513078</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id=".1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>44.911800 -62.513078</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>10</ms:POPPLACE_>
+        <ms:POPPLACE_I>1</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CBIKA</ms:UNIQUE_KEY>
+        <ms:NAME>Sheet Harbour</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>011D15</ms:NTS50>
+        <ms:LAT>445500</ms:LAT>
+        <ms:LONG>623200</ms:LONG>
+        <ms:SGC_CODE>1209036</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+      </ms:popplace>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>44.971547 -64.190057</gml:lowerCorner>
+        		<gml:upperCorner>44.971547 -64.190057</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id=".1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>44.971547 -64.190057</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>114</ms:POPPLACE_>
+        <ms:POPPLACE_I>2</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CBPAK</ms:UNIQUE_KEY>
+        <ms:NAME>&quot;Wind&quot;sor</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>021A16</ms:NTS50>
+        <ms:LAT>445900</ms:LAT>
+        <ms:LONG>640800</ms:LONG>
+        <ms:SGC_CODE>1208002</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+      </ms:popplace>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>44.375794 -64.333577</gml:lowerCorner>
+        		<gml:upperCorner>44.375794 -64.333577</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id=".1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>44.375794 -64.333577</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>115</ms:POPPLACE_>
+        <ms:POPPLACE_I>2</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CAWAZ</ms:UNIQUE_KEY>
+        <ms:NAME>Lunenburg</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>021A08</ms:NTS50>
+        <ms:LAT>442300</ms:LAT>
+        <ms:LONG>641900</ms:LONG>
+        <ms:SGC_CODE>1206006</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+      </ms:popplace>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>44.020359 -64.732816</gml:lowerCorner>
+        		<gml:upperCorner>44.020359 -64.732816</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id=".1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>44.020359 -64.732816</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>116</ms:POPPLACE_>
+        <ms:POPPLACE_I>2</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CAUWZ</ms:UNIQUE_KEY>
+        <ms:NAME>Liverpool</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>021A02</ms:NTS50>
+        <ms:LAT>440200</ms:LAT>
+        <ms:LONG>644300</ms:LONG>
+        <ms:SGC_CODE>1204006</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+      </ms:popplace>
+    </wfs:member>
+</wfs:FeatureCollection>
+

--- a/msautotest/wxs/expected/wfs_ogr_gpkg_pagination_4326_2.xml
+++ b/msautotest/wxs/expected/wfs_ogr_gpkg_pagination_4326_2.xml
@@ -1,0 +1,116 @@
+Content-Type: text/xml; subtype="gml/3.2.1"; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml/3.2"
+   xmlns:wfs="http://www.opengis.net/wfs/2.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=popplace&amp;OUTPUTFORMAT=application%2Fgml%2Bxml%3B%20version%3D3.2 http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+   timeStamp="" numberMatched="10" numberReturned="3"
+   previous="http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=GetFeature&amp;TYPENAMES=popplace&amp;BBOX=43.0%2C-65.0%2C45.0%2C-62.0&amp;COUNT=7">
+      <wfs:boundedBy>
+      	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+      		<gml:lowerCorner>44.365195 -64.563218</gml:lowerCorner>
+      		<gml:upperCorner>44.682792 -63.570040</gml:upperCorner>
+      	</gml:Envelope>
+      </wfs:boundedBy>
+<!-- WARNING: No featureid defined for typename 'popplace'. Output will not validate. -->
+    <wfs:member>
+      <ms:popplace>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>44.365195 -64.563218</gml:lowerCorner>
+        		<gml:upperCorner>44.365195 -64.563218</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id=".1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>44.365195 -64.563218</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>268</ms:POPPLACE_>
+        <ms:POPPLACE_I>3</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CAFBR</ms:UNIQUE_KEY>
+        <ms:NAME>Bridgewater</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>021A07</ms:NTS50>
+        <ms:LAT>442300</ms:LAT>
+        <ms:LONG>643100</ms:LONG>
+        <ms:SGC_CODE>1206004</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>3</ms:POP_RANGE>
+      </ms:popplace>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>44.682792 -63.570040</gml:lowerCorner>
+        		<gml:upperCorner>44.682792 -63.570040</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id=".1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>44.682792 -63.570040</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>392</ms:POPPLACE_>
+        <ms:POPPLACE_I>4</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CAIYJ</ms:UNIQUE_KEY>
+        <ms:NAME>Dartmouth</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>011D12</ms:NTS50>
+        <ms:LAT>444000</ms:LAT>
+        <ms:LONG>633400</ms:LONG>
+        <ms:SGC_CODE>1209022</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>5</ms:POP_RANGE>
+      </ms:popplace>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace>
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>44.615583 -63.692011</gml:lowerCorner>
+        		<gml:upperCorner>44.615583 -63.692011</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id=".1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>44.615583 -63.692011</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>463</ms:POPPLACE_>
+        <ms:POPPLACE_I>96</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CAPHL</ms:UNIQUE_KEY>
+        <ms:NAME>Halifax</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>011D12</ms:NTS50>
+        <ms:LAT>443900</ms:LAT>
+        <ms:LONG>633600</ms:LONG>
+        <ms:SGC_CODE>1209021</ms:SGC_CODE>
+        <ms:CAPITAL>2</ms:CAPITAL>
+        <ms:POP_RANGE>6</ms:POP_RANGE>
+      </ms:popplace>
+    </wfs:member>
+</wfs:FeatureCollection>
+

--- a/msautotest/wxs/wfs_ogr_gpkg.map
+++ b/msautotest/wxs/wfs_ogr_gpkg.map
@@ -11,6 +11,13 @@
 #
 # RUN_PARMS: wfs_ogr_gpkg_issue_6325.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=test_6325&BBOX=0.75,0.75,9,9&COUNT=1" > [RESULT_DEVERSION]
 #
+# Pagination with BBOX in other SRS than source
+# Ideally this should return all seven expected result, but some features being skipped where requested BBOX and source BBOX overlaps, and the next 3 expected features does not fall wihing startIndex and count.
+# Expected is 4 results and next link with startIndex 7
+# RUN_PARMS: wfs_ogr_gpkg_pagination_4326.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=popplace&BBOX=43.0,-65.0,45.0,-62.0&COUNT=7&STARTINDEX=0" > [RESULT_DEVERSION]
+# Expect 3 results, one previous link with count 7, no next link
+# RUN_PARMS: wfs_ogr_gpkg_pagination_4326_2.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=popplace&BBOX=43.0,-65.0,45.0,-62.0&COUNT=7&STARTINDEX=7" > [RESULT_DEVERSION]
+#
 # Filter using intersect with point
 # RUN_PARMS: wfs_ogr_gpkg_filter_intersects_point.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=test_6325&FILTER=<Filter><Intersects><PropertyName>msGeometry</PropertyName><gml:Point srsName=%22EPSG:4326%22><gml:coordinates>1.000000,0.000000</gml:coordinates></gml:Point></Intersects></Filter>" > [RESULT]
 #

--- a/src/mapfile.c
+++ b/src/mapfile.c
@@ -7507,6 +7507,7 @@ void initResultCache(resultCacheObj *resultcache) {
   if (resultcache) {
     resultcache->results = NULL;
     resultcache->numresults = 0;
+    resultcache->hasnext = MS_UNKNOWN;
     resultcache->cachesize = 0;
     resultcache->bounds.minx = resultcache->bounds.miny =
         resultcache->bounds.maxx = resultcache->bounds.maxy = -1;

--- a/src/mapquery.c
+++ b/src/mapquery.c
@@ -1159,6 +1159,7 @@ int msQueryByRect(mapObj *map) {
   int paging;
   int nclasses = 0;
   int *classgroup = NULL;
+  int numresultstotal;
   double minfeaturesize = -1;
   queryCacheObj queryCache;
 
@@ -1355,9 +1356,10 @@ int msQueryByRect(mapObj *map) {
     if (lp->minfeaturesize > 0)
       minfeaturesize = Pix2LayerGeoref(map, lp, lp->minfeaturesize);
 
+    numresultstotal = 0;
     while ((status = msLayerNextShape(lp, &shape)) ==
            MS_SUCCESS) { /* step through the shapes */
-
+      numresultstotal++;
       /* Check if the shape size is ok to be drawn */
       if ((shape.type == MS_SHAPE_LINE || shape.type == MS_SHAPE_POLYGON) &&
           (minfeaturesize > 0)) {
@@ -1447,6 +1449,10 @@ int msQueryByRect(mapObj *map) {
       }
 
     } /* next shape */
+
+    if (paging && lp->maxfeatures > 0 && numresultstotal == lp->maxfeatures &&
+        numresultstotal > lp->resultcache->numresults)
+      lp->resultcache->hasnext = MS_TRUE;
 
     if (classgroup)
       msFree(classgroup);

--- a/src/mapserver.h
+++ b/src/mapserver.h
@@ -1794,6 +1794,7 @@ typedef struct {
     %immutable;
 #endif            /* SWIG */
   int numresults; ///< Length of result set
+  int hasnext;    /// If any there are any more features left
   rectObj bounds; ///< Bounding box of query results
 
 #ifdef SWIG


### PR DESCRIPTION
# Summary 
In some cases, GetFeature responses will contain less features than expected. This PR will add `next`-links in such cases to make all features discoverable through WFS-paging.
# Problem

When requesting GetFeature with pagination and BBOX in another SRS than the layer source, the pagination currently reports less results than expected in certain cases. 

I have added one such case in the autotests, and it is visualised in the image below.
  
<img width="1940" height="751" alt="Screenshot from 2025-08-26 17-26-13" src="https://github.com/user-attachments/assets/a3928f30-919f-4828-8fa3-b6dd46ca050c" />

* The purple polygon `bbox4326` is the requested BBOX in EPSG:4326
* The pink rect is the bounds of the requested BBOX in the source projection, EPSG:3978
* The points is the `popplace`-data, where those in green are within requested BBOX.
* The map projection is in source projection

Since the number of points within requested BBOX is 7, a query with `COUNT=7&STARTINDEX=0` is expected to return all 7 matches. Currently it will only report 4 hits and no `next`-link, indicating that there are no more features.

The filtering done in  `msQueryByRect` will first call `msLayerWhichShapes` with the BBOX in source SRS and if paging is enabled, it will limit the result to `COUNT` or `maxfeatures`-limit. If a feature is filtered out in a later stage, the result count will be less than `maxfeatures`-limit, and MapServer will report that there are no more features left.  

## Solution
This PR does not solve original issue, but will add `next`-link if there may be any more features of interest, making the features discoverable. 

To keep track whether a `next`-link might need to be added, I added a `hasnext`-flag to `resultCacheObj`. This will be marked as true if there may be features of interest in the next page. I.e., if any feature has been filtered out, and the total number of features (including skipped ones) equals to the amount of requested features. 

One downside of this is that the user may in some cases need to page through pages containing 0 features. 

## Other alternatives

I am not sure what would be the best way to solve the original issue.  I'd be happy to hear if anyone has an idea. Some ideas I can think of:

### Skip paging in first/driver filtering

If paging was removed in the `msLayerWhichShapes`-step, and handled after when iterating the features, the problem would be solved. But I guess this would not be optimal for large datasets. 

### Support query by shape

If `msLayerWhichShapes` were to support query by a shape, we could just filter on a shape in source coords, matching the requested BBOX. If I am not wrong, it currently only supports filtering by BBOX. 

### Internal pagination

I looked a bit into doing some internal pagination and storing feature indexes in between pages. But if there are no featureIds, calling `msLayerWhichShapes` multiple times may assign 'random'(?) indexes to features, so seems not that reliable. Could this be done another way? 
