### PR TITLE
msautotest Python GDAL get version fix

### DIFF
--- a/msautotest/pymod/mstestlib.py
+++ b/msautotest/pymod/mstestlib.py
@@ -492,9 +492,6 @@ def get_gdal_version():
         pos = gdal_version.find("dev")
         if pos >= 0:
             return gdal_version[0:pos]
-        pos = gdal_version.find(",")
-        if pos >= 0:
-            return gdal_version[0:pos]
         # e.g. "GDAL 3.11.3 Eganville"
         pos = gdal_version.find(" ")
         if pos >= 0:

--- a/msautotest/pymod/mstestlib.py
+++ b/msautotest/pymod/mstestlib.py
@@ -486,14 +486,18 @@ def get_gdal_version():
     except Exception:
         gdal_version = os.popen("gdalinfo --version").read()
 
-    # Parse something like "GDAL x.y.zdev, released..." to extract "x.y.z"
+    # Parse GDAL version formats to extract "x.y.z" e.g.
+    # 'GDAL x.y.zdev'
+    # 'GDAL 3.11.3 "Eganville", released 2025/07/12'
+    # 'GDAL 3.11.3 Eganville'
+    # 'GDAL 3.x.y, released'
     if gdal_version.startswith("GDAL "):
         gdal_version = gdal_version[len("GDAL ") :]
-        pos = gdal_version.find("dev")
-        if pos >= 0:
-            return gdal_version[0:pos]
-        # e.g. "GDAL 3.11.3 Eganville"
-        pos = gdal_version.find(" ")
+        dev_pos = gdal_version.find("dev")
+        comma_pos = gdal_version.find(",")
+        space_pos = gdal_version.find(" ")
+        positions = [p for p in (dev_pos, comma_pos, space_pos) if p != -1]
+        pos = min(positions) if positions else -1
         if pos >= 0:
             return gdal_version[0:pos]
     return None


### PR DESCRIPTION
Following on from https://github.com/MapServer/MapServer/pull/7317 I ran into a similar issue when using Vagrant.
The GDAL version string was `3.11.3 "Eganville", released 2025/07/12`, and due to the comma raised the following error:

```python
run_test.py:43: in <module>
    mstestlib.get_pytests(os.path.dirname(os.path.abspath(__file__))),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../pymod/mstestlib.py:540: in get_pytests
    if not has_requires(version_info, gdal_version, requires_list):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../pymod/mstestlib.py:111: in has_requires
    if compare_version(gdal_version, item[len("GDAL>=") :]) < 0:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../pymod/mstestlib.py:84: in compare_version
    a_x, a_y, a_z = int(a[0]), int(a[1]), int(a[2])
                                          ^^^^^^^^^
E   ValueError: invalid literal for int() with base 10: '3 "Eganville"'
```

This PR simply removes the comma-check - as we only need to check for a space. 
cc @rouault 