### PR TITLE
Use doubles for raster querying instead of float for Int32 support

### DIFF
--- a/msautotest/wxs/expected/wms_getfeatureinfo_int32_raster.json
+++ b/msautotest/wxs/expected/wms_getfeatureinfo_int32_raster.json
@@ -1,0 +1,11 @@
+Content-Disposition: attachment; filename=result.dat
+Content-Type: application/json; subtype=geojson; charset=utf-8
+
+{
+"type": "FeatureCollection",
+"name": "test",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::2157" } },
+"features": [
+{ "type": "Feature", "properties": { "x": "600182.31", "y": "628802.89", "value_0": 114140618, "value_list": "114140618", "red": "255", "green": "255", "blue": "255" }, "geometry": { "type": "Point", "coordinates": [ 600182.310000000055879, 628802.89000000001397 ] } }
+]
+}

--- a/msautotest/wxs/wms_getfeatureinfo_int32_raster.map
+++ b/msautotest/wxs/wms_getfeatureinfo_int32_raster.map
@@ -1,0 +1,54 @@
+#
+# Test WMS GetfeatureInfo with a raster Int32 layer
+#
+# REQUIRES: SUPPORTS=WMS
+# 
+# RUN_PARMS: wms_getfeatureinfo_int32_raster.json [MAPSERV] "QUERY_STRING=map=[MAPFILE]&service=WMS&request=GetFeatureInfo&version=1.3.0&CRS=EPSG:2157&width=200&height=200&layers=test&bbox=600181.89,628797.70,600191.27,628807.09&query_layers=test&i=50&j=50&STYLES=&info_format=geojson" > [RESULT_DEMIME]
+
+MAP
+
+  NAME 'test'
+  EXTENT 600029.81 628680.39 600319.81 628905.39
+  SIZE 600 600
+  IMAGETYPE PNG
+  PROJECTION
+   "init=epsg:2157"
+  END
+
+  WEB
+      METADATA
+          "ows_enable_request" "*"
+          "ows_srs" "EPSG:2157"
+          "ows_title" "WMS Getfeatureinfo"
+          "wms_getfeatureinfo_formatlist" "geojson"
+          "wms_onlineresource" "http://localhost/cgi-bin/mapserv?map=mymap.map"
+      END
+  END
+
+  OUTPUTFORMAT
+      NAME "geojson"
+      DRIVER "OGR/GEOJSON"
+      MIMETYPE "application/json; subtype=geojson; charset=utf-8"
+      FORMATOPTION "FORM=SIMPLE"
+      FORMATOPTION "STORAGE=memory"
+      FORMATOPTION "LCO:NATIVE_MEDIA_TYPE=application/vnd.geo+json"
+      FORMATOPTION "USE_FEATUREID=true"
+  END
+
+
+  LAYER
+    NAME "test"
+    STATUS OFF
+    TYPE RASTER
+    TEMPLATE "blank"
+    DATA "data/int32.tif"
+    PROJECTION
+        "EPSG:2157"
+    END
+    METADATA
+        "gml_include_items" "all"
+        "gml_value_0_type" "Integer"
+    END
+  END
+
+END # of map file

--- a/src/maprasterquery.c
+++ b/src/maprasterquery.c
@@ -59,7 +59,7 @@ typedef struct {
   double *qc_y;
   double *qc_x_reproj;
   double *qc_y_reproj;
-  float *qc_values;
+  double *qc_values;
   int *qc_class;
   int *qc_red;
   int *qc_green;
@@ -211,7 +211,7 @@ static void msRasterLayerInfoInitialize(layerObj *layer)
 /************************************************************************/
 
 static void msRasterQueryAddPixel(layerObj *layer, pointObj *location,
-                                  pointObj *reprojectedLocation, float *values)
+                                  pointObj *reprojectedLocation, double *values)
 
 {
   rasterLayerInfo *rlinfo = (rasterLayerInfo *)layer->layerinfo;
@@ -238,8 +238,8 @@ static void msRasterQueryAddPixel(layerObj *layer, pointObj *location,
           (double *)msSmallCalloc(sizeof(double), rlinfo->query_alloc_max);
       rlinfo->qc_y_reproj =
           (double *)msSmallCalloc(sizeof(double), rlinfo->query_alloc_max);
-      rlinfo->qc_values = (float *)msSmallCalloc(
-          sizeof(float),
+      rlinfo->qc_values = (double *)msSmallCalloc(
+          sizeof(double),
           ((size_t)rlinfo->query_alloc_max) * rlinfo->band_count);
       rlinfo->qc_red =
           (int *)msSmallCalloc(sizeof(int), rlinfo->query_alloc_max);
@@ -285,7 +285,7 @@ static void msRasterQueryAddPixel(layerObj *layer, pointObj *location,
     if (rlinfo->qc_values != NULL)
       rlinfo->qc_values = msSmallRealloc(
           rlinfo->qc_values,
-          sizeof(float) * rlinfo->query_alloc_max * rlinfo->band_count);
+          sizeof(double) * rlinfo->query_alloc_max * rlinfo->band_count);
     if (rlinfo->qc_class != NULL)
       rlinfo->qc_class = msSmallRealloc(rlinfo->qc_class,
                                         sizeof(int) * rlinfo->query_alloc_max);
@@ -385,7 +385,7 @@ static void msRasterQueryAddPixel(layerObj *layer, pointObj *location,
   /* -------------------------------------------------------------------- */
   if (rlinfo->qc_values != NULL)
     memcpy(rlinfo->qc_values + rlinfo->query_results * rlinfo->band_count,
-           values, sizeof(float) * rlinfo->band_count);
+           values, sizeof(double) * rlinfo->band_count);
 
   /* -------------------------------------------------------------------- */
   /*      Add to the results cache.                                       */
@@ -408,7 +408,7 @@ static int msRasterQueryByRectLow(mapObj *map, layerObj *layer,
   double dfXMin, dfYMin, dfXMax, dfYMax, dfX, dfY, dfAdjustedRange;
   int nWinXOff, nWinYOff, nWinXSize, nWinYSize;
   int nRXSize, nRYSize;
-  float *pafRaster;
+  double *pafRaster;
   int nBandCount, *panBandMap, iPixel, iLine;
   CPLErr eErr;
   rasterLayerInfo *rlinfo;
@@ -504,15 +504,17 @@ static int msRasterQueryByRectLow(mapObj *map, layerObj *layer,
   /*      band in the file.  Later we will deal with the various band     */
   /*      selection criteria.                                             */
   /* -------------------------------------------------------------------- */
-  pafRaster = (float *)calloc(((size_t)nWinXSize) * nWinYSize * nBandCount,
-                              sizeof(float));
-  MS_CHECK_ALLOC(pafRaster, sizeof(float) * nWinXSize * nWinYSize * nBandCount,
-                 -1);
 
-  eErr = GDALDatasetRasterIO(hDS, GF_Read, nWinXOff, nWinYOff, nWinXSize,
-                             nWinYSize, pafRaster, nWinXSize, nWinYSize,
-                             GDT_Float32, nBandCount, panBandMap,
-                             4 * nBandCount, 4 * nBandCount * nWinXSize, 4);
+  size_t nPixels = (size_t)nWinXSize * nWinYSize * nBandCount;
+  pafRaster = (double *)calloc(nPixels, sizeof(double));
+  MS_CHECK_ALLOC(pafRaster, sizeof(double) * nPixels, -1);
+
+  // read raster block as GDT_Float64
+  eErr = GDALDatasetRasterIO(
+      hDS, GF_Read, nWinXOff, nWinYOff, nWinXSize, nWinYSize, pafRaster,
+      nWinXSize, nWinYSize, GDT_Float64, nBandCount, panBandMap,
+      sizeof(double) * nBandCount, sizeof(double) * nBandCount * nWinXSize,
+      sizeof(double));
 
   if (eErr != CE_None) {
     msSetError(MS_IOERR, "GDALDatasetRasterIO() failed: %s",
@@ -1179,12 +1181,13 @@ int msRASTERLayerGetShape(layerObj *layer, shapeObj *shape, resultObj *record) {
           if (iValue != 0)
             strlcat(szWork, ",", bufferSize);
 
-          snprintf(szWork + strlen(szWork), bufferSize - strlen(szWork), "%.8g",
+          snprintf(szWork + strlen(szWork), bufferSize - strlen(szWork),
+                   "%.10g",
                    rlinfo->qc_values[shapeindex * rlinfo->band_count + iValue]);
         }
       } else if (EQUALN(layer->items[i], "value_", 6) && rlinfo->qc_values) {
         int iValue = atoi(layer->items[i] + 6);
-        snprintf(szWork, bufferSize, "%.8g",
+        snprintf(szWork, bufferSize, "%.10g",
                  rlinfo->qc_values[shapeindex * rlinfo->band_count + iValue]);
       } else if (EQUAL(layer->items[i], "class") && rlinfo->qc_class) {
         int p_class = rlinfo->qc_class[shapeindex];


### PR DESCRIPTION
Instead of using Float32 for raster queries, use doubles as this supports Int32 raster pixel values. 

Resolves the GetFeatureInfo query issue in #7341. 