### PR TITLE
[Backport branch-8-4] Fix use-after-free error in msDrawRasterLayerLowOpenDataset (#7333)

### DIFF
--- a/msautotest/wxs/wms_raster.map
+++ b/msautotest/wxs/wms_raster.map
@@ -31,7 +31,7 @@ IMAGECOLOR 255 255 255
 SHAPEPATH ./data
 SYMBOLSET etc/symbols.sym
 FONTSET etc/fonts.txt
-
+DEBUG 1
 
 #
 # Start of web interface definition

--- a/src/mapraster.c
+++ b/src/mapraster.c
@@ -651,7 +651,6 @@ void *msDrawRasterLayerLowOpenDataset(mapObj *map, layerObj *layer,
         GDALOpenEx(*p_decrypted_path, GDAL_OF_RASTER | GDAL_OF_SHARED,
                    (const char *const *)papszAllowedDrivers,
                    (const char *const *)connectionoptions, NULL);
-    CSLDestroy(papszAllowedDrivers);
     CSLDestroy(connectionoptions);
 
     // Give a hint about which GDAL driver should be enabled, but only in
@@ -678,6 +677,7 @@ void *msDrawRasterLayerLowOpenDataset(mapObj *map, layerObj *layer,
         }
       }
     }
+    CSLDestroy(papszAllowedDrivers);
     return hDS;
   } else {
     return GDALOpenShared(*p_decrypted_path, GA_ReadOnly);


### PR DESCRIPTION
Manual backport of #7333 (original failed: https://github.com/MapServer/MapServer/pull/7333#issuecomment-3347243898). 

* Fix use-after-free error in msDrawRasterLayerLowOpenDataset

* A test case for crash on printing raster debug info