### PR TITLE
Fix mapcairo build on OpenBSD by reusing the APPLE codepath for fontconfig lookup

### DIFF
--- a/cmake/FindCairo.cmake
+++ b/cmake/FindCairo.cmake
@@ -38,14 +38,11 @@ FIND_PATH(CAIRO_INCLUDE_DIR
     PATH_SUFFIXES cairo
 )
 
-IF(APPLE)
-   #On Mountain Lion we need this for the XQuartz supplied version of cairo
-    PKG_CHECK_MODULES(PC_FONTCONFIG fontconfig) # FIXME: After we require CMake 2.8.2 we can pass QUIET to this call.
-    FIND_PATH(FC_INCLUDE_DIR
-       NAMES fontconfig/fontconfig.h
-       HINTS ${PC_FONTCONFIG_INCLUDEDIR}
-    )
-ENDIF(APPLE)
+PKG_CHECK_MODULES(PC_FONTCONFIG fontconfig) # FIXME: After we require CMake 2.8.2 we can pass QUIET to this call.
+FIND_PATH(FC_INCLUDE_DIR
+   NAMES fontconfig/fontconfig.h
+   HINTS ${PC_FONTCONFIG_INCLUDEDIR}
+)
 
 FIND_LIBRARY(CAIRO_LIBRARY
     NAMES cairo


### PR DESCRIPTION
on OpenBSD, fontconfig isnt installed in the same prefix as cairo.

I have a long-standing patch against FindCairo.cmake: https://github.com/openbsd/ports/blob/master/geo/mapserver/patches/patch-cmake_FindCairo_cmake

it fixes this particular build issue:
```
FAILED: CMakeFiles/mapserver.dir/src/mapcairo.c.o 
/usr/obj/ports/mapserver-8.4.1/bin/cc -DMAPSERVER_BUILD -DMAPSERVER_CONFIG_FILE=\"/etc/mapserver.conf\" -DPROJ_VERSION_MAJOR=9 -Dmapserver_EXPORTS -I/usr/obj/ports/mapserver-8.4.1/build-amd64 -I/usr/obj/ports/mapserver-8.4.1/mapserver-8.4.1/src/renderers/agg/include -I/usr/obj/ports/mapserver-8.4.1/mapserver-8.4.1/src/mapscript/v8 -I/usr/obj/ports/mapserver-8.4.1/mapserver-8.4.1/src/flatgeobuf/include -I/usr/X11R6/include/freetype2 -I/usr/obj/ports/mapserver-8.4.1/build-amd64/renderers/mvt -I/usr/local/include/fribidi -I/usr/local/include/harfbuzz -I/usr/local/include/cairo -I/usr/local/include/postgresql -I/usr/local/include/postgresql/server -I/usr/local/include/libxml2 -isystem /usr/local/include -O2 -pipe -Wall -Werror=format-security -DNDEBUG -std=c17 -fPIC -Wall -Wextra -Werror=format-security -MD -MT CMakeFiles/mapserver.dir/src/mapcairo.c.o -MF CMakeFiles/mapserver.dir/src/mapcairo.c.o.d -o CMakeFiles/mapserver.dir/src/mapcairo.c.o -c /usr/obj/ports/mapserver-8.4.1/mapserver-8.4.1/src/mapcairo.c
In file included from /usr/obj/ports/mapserver-8.4.1/mapserver-8.4.1/src/mapcairo.c:64:
/usr/local/include/cairo/cairo-ft.h:50:10: fatal error: 'fontconfig/fontconfig.h' file not found
   50 | #include <fontconfig/fontconfig.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
ninja: build stopped: subcommand failed.
```
on openbsd, fontconfig is installed in `/usr/X11R6/include`:
```
$pkg-config --cflags fontconfig                                                                                                                                               
-I/usr/X11R6/include -I/usr/X11R6/include/freetype2
```
reusing the APPLE codepath fixes it