### PR TITLE
Disable build isolation to not download setuptools dependency.

### DIFF
--- a/src/mapscript/python/CMakeLists.txt
+++ b/src/mapscript/python/CMakeLists.txt
@@ -140,7 +140,7 @@ install(
     endif()
 
     execute_process(
-      COMMAND ${Python_EXECUTABLE} -m pip install \${PYTHON_ROOT} \${PYTHON_PREFIX} .
+      COMMAND ${Python_EXECUTABLE} -m pip install --no-build-isolation \${PYTHON_ROOT} \${PYTHON_PREFIX} .
       WORKING_DIRECTORY ${MAPSCRIPT_WORKING_DIR}
     )
   "


### PR DESCRIPTION
The Debian package build failed with pip 25.3 without this change.

I'm not 100% convinced it belongs upstream, but other packagers are likely to run into the same issue.