### PR TITLE
[msautotest] fix CONFIG test errors (for WITH_COVERAGE)

### DIFF
--- a/msautotest/config/index.conf
+++ b/msautotest/config/index.conf
@@ -1,7 +1,7 @@
 CONFIG
   ENV
     MS_MAP_PATTERN "."
-    MS_INDEX_TEMPLATE_DIRECTORY "/mapserver/share/ogcapi/templates/html-index-plain/"
+    MS_INDEX_TEMPLATE_DIRECTORY "../../share/ogcapi/templates/html-index-plain/"
   END
   MAPS
     INDEX "index.map"


### PR DESCRIPTION
(note: the errors are deep in the runner logs, but the total build still gives a green checkmark at the end, so it was easy to miss these errors - however my local tests break on these errors)
- this current pull request removes 2 `results don't match` test errors for CONFIG (for `WITH_COVERAGE` run)
- however, 10 errors still remain for the CONFIG tests, for `WITH_ASAN`
  - build log: [asan-build-log.txt](https://github.com/user-attachments/files/23478813/asan-build-log.txt) (search for the text "results don't match")
  - for example, the `config/index.map` test generates the following stack error, when I run the tests locally:
  
````
=================================================================
==36744==ERROR: AddressSanitizer: stack-use-after-scope on address 0x70caa8900020 at pc 0x70cab821f96f bp 0x7ffcf1eb86e0 sp 0x7ffcf1eb7e88
READ of size 12 at 0x70caa8900020 thread T0
    #0 0x70cab821f96e in strlen ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391
    #1 0x70cab2e84613 in pcre2_regexec (/lib/x86_64-linux-gnu/libpcre2-posix.so.3+0x1613) (BuildId: 82e51d62e96715f491183a56806553d062ba132c)
    #2 0x70cab7298236 in ms_regexec /src/src/mapregex.c:93
    #3 0x70cab72a3e28 in msEvalRegex /src/src/mapfile.c:149
    #4 0x70cab72e3c3d in msLoadMap /src/src/mapfile.c:7034
    #5 0x70cab6fae932 in msCGILoadMap /src/src/mapservutil.c:271
    #6 0x654190509ce3 in main /src/src/apps/mapserv.c:278
    #7 0x70cab63031c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #8 0x70cab630328a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #9 0x654190508974 in _start (/src/build/mapserv+0x3974) (BuildId: 6f13b92201bf317acafea77e6371beb751e6d60f)

Address 0x70caa8900020 is located in stack of thread T0 at offset 32 in frame
    #0 0x70cab6fadeb6 in msCGILoadMap /src/src/mapservutil.c:169

  This frame has 1 object(s):
    [32, 1056) 'pathBuf' (line 225) <== Memory access at offset 32 is inside this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-scope ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391 in strlen
Shadow bytes around the buggy address:
  0x70caa88ffd80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x70caa88ffe00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x70caa88ffe80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x70caa88fff00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x70caa88fff80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x70caa8900000: f1 f1 f1 f1[f8]f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x70caa8900080: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x70caa8900100: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x70caa8900180: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x70caa8900200: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x70caa8900280: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==36744==ABORTING
````

- config/index_kitchensink.map generates this stack error:
```
=================================================================
==36749==ERROR: AddressSanitizer: stack-use-after-scope on address 0x744a45900020 at pc 0x744a5525e96f bp 0x7ffd50fc6e30 sp 0x7ffd50fc65d8
READ of size 24 at 0x744a45900020 thread T0
    #0 0x744a5525e96e in strlen ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391
    #1 0x744a4fec3613 in pcre2_regexec (/lib/x86_64-linux-gnu/libpcre2-posix.so.3+0x1613) (BuildId: 82e51d62e96715f491183a56806553d062ba132c)
    #2 0x744a542d7236 in ms_regexec /src/src/mapregex.c:93
    #3 0x744a542e2e28 in msEvalRegex /src/src/mapfile.c:149
    #4 0x744a54322c3d in msLoadMap /src/src/mapfile.c:7034
    #5 0x744a53fed932 in msCGILoadMap /src/src/mapservutil.c:271
    #6 0x55756f92ace3 in main /src/src/apps/mapserv.c:278
    #7 0x744a533421c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #8 0x744a5334228a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 274eec488d230825a136fa9c4d85370fed7a0a5e)
    #9 0x55756f929974 in _start (/src/build/mapserv+0x3974) (BuildId: 6f13b92201bf317acafea77e6371beb751e6d60f)

Address 0x744a45900020 is located in stack of thread T0 at offset 32 in frame
    #0 0x744a53feceb6 in msCGILoadMap /src/src/mapservutil.c:169

  This frame has 1 object(s):
    [32, 1056) 'pathBuf' (line 225) <== Memory access at offset 32 is inside this variable
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-use-after-scope ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:391 in strlen
Shadow bytes around the buggy address:
  0x744a458ffd80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x744a458ffe00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x744a458ffe80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x744a458fff00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x744a458fff80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x744a45900000: f1 f1 f1 f1[f8]f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x744a45900080: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x744a45900100: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x744a45900180: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x744a45900200: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
  0x744a45900280: f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8 f8
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==36749==ABORTING
```

@rouault @geographika can you take a look?  It seems that we need to clear up memory for this `pathBuf` variable??