### PR TITLE
CI: Add config to msautotest folder checks

### DIFF
--- a/scripts/print-test-results.sh
+++ b/scripts/print-test-results.sh
@@ -2,7 +2,7 @@
 
 ret=0
 
-tests=( query misc gdal wxs renderers sld api )
+tests=( api config gdal misc query renderers sld wxs )
 command_exists () {
    type "$1" &> /dev/null ;
 }


### PR DESCRIPTION
This looks like the cause of the CI passing while tests were failing in the `config` folder. I have added this in (and sorted alphabetically), so this should now make the ASAN CI build fail until #7385 is merged. 