### PR TITLE
Fix memory allocation for bool

### DIFF
--- a/src/mapdrawgdal.c
+++ b/src/mapdrawgdal.c
@@ -1497,7 +1497,7 @@ static int LoadGDALImages(GDALDatasetH hDS, int band_numbers[4], int band_count,
     pabyBuffer = pabyWholeBuffer + iColorIndex * nPixelCount;
 
     if (iColorIndex == 0 && bGotNoData)
-      *ppbIsNoDataBuffer = (bool *)calloc(nPixelCount, 1);
+      *ppbIsNoDataBuffer = (bool *)calloc(nPixelCount, sizeof(bool));
 
     for (i = 0; i < nPixelCount; i++) {
       float fScaledValue;


### PR DESCRIPTION
Had an issue where MapServer crashed on Windows (but not linux) when rendering raster with NODATA and `PROCESSING "SCALE=AUTO"` set in the mapfile. 

It crashed when I tested using `map2img` from the conda build ` 8.6.0 py314h835350a_2` and a local windows build. 

It seems like the  `bool` type is 4 bytes in some Windows builds, so I updated the calloc call to ensure proper memory size is allocated.  