### PR TITLE
OGCAPI Features: restore support for 'oga_compliance_mode' metadata item (8.8 only)

### DIFF
--- a/msautotest/api/expected/ogcapi_api_unknown_parameter.json.txt
+++ b/msautotest/api/expected/ogcapi_api_unknown_parameter.json.txt
@@ -1,0 +1,4 @@
+Content-Type: application/json
+Status: 400
+
+{"code":"InvalidParameterValue","description":"Unknown query parameter: unknown"}

--- a/msautotest/api/expected/ogcapi_collection_unknown_parameter.json.txt
+++ b/msautotest/api/expected/ogcapi_collection_unknown_parameter.json.txt
@@ -1,0 +1,4 @@
+Content-Type: application/json
+Status: 400
+
+{"code":"InvalidParameterValue","description":"Unknown query parameter: unknown"}

--- a/msautotest/api/expected/ogcapi_collections_items_unknown_parameter.json.txt
+++ b/msautotest/api/expected/ogcapi_collections_items_unknown_parameter.json.txt
@@ -1,0 +1,4 @@
+Content-Type: application/json
+Status: 400
+
+{"code":"InvalidParameterValue","description":"Unknown query parameter: unknown"}

--- a/msautotest/api/expected/ogcapi_collections_unknown_parameter.json.txt
+++ b/msautotest/api/expected/ogcapi_collections_unknown_parameter.json.txt
@@ -1,0 +1,4 @@
+Content-Type: application/json
+Status: 400
+
+{"code":"InvalidParameterValue","description":"Unknown query parameter: unknown"}

--- a/msautotest/api/expected/ogcapi_conformance_unknown_parameter.json.txt
+++ b/msautotest/api/expected/ogcapi_conformance_unknown_parameter.json.txt
@@ -1,0 +1,4 @@
+Content-Type: application/json
+Status: 400
+
+{"code":"InvalidParameterValue","description":"Unknown query parameter: unknown"}

--- a/msautotest/api/expected/ogcapi_extraparams_collections_items_unknown_parameter.json.txt
+++ b/msautotest/api/expected/ogcapi_extraparams_collections_items_unknown_parameter.json.txt
@@ -1,0 +1,4 @@
+Content-Type: application/json
+Status: 400
+
+{"code":"InvalidParameterValue","description":"Unknown query parameter: unknown"}

--- a/msautotest/api/expected/ogcapi_landing_page_unknown_parameter.json.txt
+++ b/msautotest/api/expected/ogcapi_landing_page_unknown_parameter.json.txt
@@ -1,0 +1,4 @@
+Content-Type: application/json
+Status: 400
+
+{"code":"InvalidParameterValue","description":"Unknown query parameter: unknown"}

--- a/msautotest/api/ogcapi.map
+++ b/msautotest/api/ogcapi.map
@@ -28,6 +28,13 @@
 # RUN_PARMS: ogcapi_invalid_api_signature1.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/invalid" "QUERY_STRING=f=json" > [RESULT_DEVERSION]
 # RUN_PARMS: ogcapi_invalid_api_signature2.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/invalid/" "QUERY_STRING=f=json" > [RESULT_DEVERSION]
 
+# RUN_PARMS: ogcapi_landing_page_unknown_parameter.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi" "QUERY_STRING=f=json&unknown=parameter" > [RESULT]
+# RUN_PARMS: ogcapi_api_unknown_parameter.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/api" "QUERY_STRING=f=json&unknown=parameter" > [RESULT]
+# RUN_PARMS: ogcapi_conformance_unknown_parameter.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/conformance" "QUERY_STRING=f=json&unknown=parameter" > [RESULT]
+# RUN_PARMS: ogcapi_collections_unknown_parameter.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections" "QUERY_STRING=f=json&unknown=parameter" > [RESULT]
+# RUN_PARMS: ogcapi_collection_unknown_parameter.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties" "QUERY_STRING=f=json&unknown=parameter" > [RESULT]
+# RUN_PARMS: ogcapi_collections_items_unknown_parameter.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" "QUERY_STRING=f=json&unknown=parameter" > [RESULT]
+
 MAP
   EXTENT 190012.242200 4816648.737800 762254.477900 5472427.737000
   SIZE 800 800

--- a/msautotest/api/ogcapi_extraparams.map
+++ b/msautotest/api/ogcapi_extraparams.map
@@ -18,6 +18,8 @@
 # test with limit parameter and empty token
 # RUN_PARMS: ogcapi_extraparams_collection_items_limit.json [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_population_centers/items" "QUERY_STRING=f=json&limit=2" > [RESULT_DEMIME]
 
+# RUN_PARMS: ogcapi_extraparams_collections_items_unknown_parameter.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_population_centers/items" "QUERY_STRING=f=json&unknown=parameter" > [RESULT]
+
 
 MAP
   EXTENT 190012.242200 4816648.737800 762254.477900 5472427.737000


### PR DESCRIPTION
and make it default to true.

That parameter was removed per PR #7360 which added support for a extra_params configuration item.

This PR adds the param names from the extra_params as allowed parameters to validate the query parameters. This is a pre-requisite for the to-come support of "Queryables as Query Parameters" of OGC API Features - Part 3 : https://docs.ogc.org/is/19-079r2/19-079r2.html#queryables-query-parameters