### PR TITLE
No longer depend on GDAL's cpl_port.h MIN/MAX/ABS macros

### DIFF
--- a/src/idw.c
+++ b/src/idw.c
@@ -69,7 +69,7 @@ void msIdwProcessing(layerObj *layer,
   if (interpParamsProcessing) {
     interpParams->radius = atof(interpParamsProcessing);
   } else {
-    interpParams->radius = MAX(layer->map->width, layer->map->height);
+    interpParams->radius = MS_MAX(layer->map->width, layer->map->height);
   }
 
   interpParamsProcessing =

--- a/src/mapcontour.c
+++ b/src/mapcontour.c
@@ -345,19 +345,21 @@ static int msContourLayerReadRaster(layerObj *layer, rectObj rect) {
      * there is no point in interpolating the data for contours in this case.
      */
 
-    virtual_grid_step_x = (int)floor(map_cellsize_x / ABS(adfGeoTransform[1]));
+    virtual_grid_step_x =
+        (int)floor(map_cellsize_x / MS_ABS(adfGeoTransform[1]));
     if (virtual_grid_step_x < 1)
       virtual_grid_step_x =
           1; /* Do not interpolate data if grid sampling step < 1 */
 
-    virtual_grid_step_y = (int)floor(map_cellsize_y / ABS(adfGeoTransform[5]));
+    virtual_grid_step_y =
+        (int)floor(map_cellsize_y / MS_ABS(adfGeoTransform[5]));
     if (virtual_grid_step_y < 1)
       virtual_grid_step_y =
           1; /* Do not interpolate data if grid sampling step < 1 */
 
     /* target cellsize is a multiple of raw data cellsize based on grid step*/
-    dst_cellsize_x = ABS(adfGeoTransform[1]) * virtual_grid_step_x;
-    dst_cellsize_y = ABS(adfGeoTransform[5]) * virtual_grid_step_y;
+    dst_cellsize_x = MS_ABS(adfGeoTransform[1]) * virtual_grid_step_x;
+    dst_cellsize_y = MS_ABS(adfGeoTransform[5]) * virtual_grid_step_y;
 
     /* Compute overlap between source and target views */
 

--- a/src/mapdrawgdal.c
+++ b/src/mapdrawgdal.c
@@ -601,7 +601,7 @@ int msDrawRasterLayerGDAL(mapObj *map, layerObj *layer, imageObj *image,
 
       const int j =
           bScaleColors
-              ? MAX(0, MIN(255, (int)((i - dfScaleMin) * dfScaleRatio)))
+              ? MS_MAX(0, MS_MIN(255, (int)((i - dfScaleMin) * dfScaleRatio)))
               : i;
 
       pixel.red = sEntry.c1;
@@ -685,7 +685,7 @@ int msDrawRasterLayerGDAL(mapObj *map, layerObj *layer, imageObj *image,
       GDALGetColorEntryAsRGB(hColorMap, i, &sEntry);
       const int j =
           bScaleColors
-              ? MAX(0, MIN(255, (int)((i - dfScaleMin) * dfScaleRatio)))
+              ? MS_MAX(0, MS_MIN(255, (int)((i - dfScaleMin) * dfScaleRatio)))
               : i;
 
       if (sEntry.c4 != 0 &&

--- a/src/mapogr.cpp
+++ b/src/mapogr.cpp
@@ -33,6 +33,8 @@
 #include "mapproject.h"
 #include "mapthread.h"
 #include "mapows.h"
+
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -2223,10 +2225,10 @@ static int msOGRFileWhichShapes(layerObj *layer, rectObj rect,
      * no _efficient_ way to do that with OGR.
      * ------------------------------------------------------------------ */
     if (psInfo->rect_is_defined) {
-      rect.minx = MAX(psInfo->rect.minx, rect.minx);
-      rect.miny = MAX(psInfo->rect.miny, rect.miny);
-      rect.maxx = MIN(psInfo->rect.maxx, rect.maxx);
-      rect.maxy = MIN(psInfo->rect.maxy, rect.maxy);
+      rect.minx = std::max(psInfo->rect.minx, rect.minx);
+      rect.miny = std::max(psInfo->rect.miny, rect.miny);
+      rect.maxx = std::min(psInfo->rect.maxx, rect.maxx);
+      rect.maxy = std::min(psInfo->rect.maxy, rect.maxy);
       bIsValidRect = true;
     }
     psInfo->rect = rect;

--- a/src/mapquery.cpp
+++ b/src/mapquery.cpp
@@ -2135,14 +2135,18 @@ int msQueryByPoint(mapObj *map) {
 
             searchSymbols.push_back(std::move(searchSymbol));
 
-            rect.minx = MIN(rect.minx,
-                            center_x + MIN(MIN(P1_X, P2_X), MIN(P3_X, P4_X)));
-            rect.miny = MIN(rect.miny,
-                            center_y + MIN(MIN(P1_Y, P2_Y), MIN(P3_Y, P4_Y)));
-            rect.maxx = MAX(rect.maxx,
-                            center_x + MAX(MAX(P1_X, P2_X), MAX(P3_X, P4_X)));
-            rect.maxy = MAX(rect.maxy,
-                            center_y + MAX(MAX(P1_Y, P2_Y), MAX(P3_Y, P4_Y)));
+            rect.minx =
+                std::min(rect.minx, center_x + std::min(std::min(P1_X, P2_X),
+                                                        std::min(P3_X, P4_X)));
+            rect.miny =
+                std::min(rect.miny, center_y + std::min(std::min(P1_Y, P2_Y),
+                                                        std::min(P3_Y, P4_Y)));
+            rect.maxx =
+                std::max(rect.maxx, center_x + std::max(std::max(P1_X, P2_X),
+                                                        std::max(P3_X, P4_X)));
+            rect.maxy =
+                std::max(rect.maxy, center_y + std::max(std::max(P1_Y, P2_Y),
+                                                        std::max(P3_Y, P4_Y)));
           }
         }
       };

--- a/src/mapserver.h
+++ b/src/mapserver.h
@@ -73,6 +73,12 @@
 #define MS_UNLIKELY(x) (x)
 #endif
 
+/** Macro to compute the minimum of 2 values */
+#define MS_MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+/** Macro to compute the maximum of 2 values */
+#define MS_MAX(a, b) (((a) > (b)) ? (a) : (b))
+
 /* definition of  ms_int32/ms_uint32 */
 #include <limits.h>
 #ifndef _WIN32

--- a/src/mapstring.cpp
+++ b/src/mapstring.cpp
@@ -2515,7 +2515,7 @@ int msStringBufferAppend(msStringBuffer *sb, const char *pszAppendedString) {
   if (sb->length + nAppendLen >= sb->alloc_size) {
     size_t newAllocSize1 = sb->alloc_size + sb->alloc_size / 3;
     size_t newAllocSize2 = sb->length + nAppendLen + 1;
-    size_t newAllocSize = MAX(newAllocSize1, newAllocSize2);
+    size_t newAllocSize = std::max(newAllocSize1, newAllocSize2);
     void *newStr = realloc(sb->str, newAllocSize);
     if (newStr == NULL) {
       msSetError(MS_MEMERR, "Not enough memory", "msStringBufferAppend()");

--- a/src/mapwcs20.cpp
+++ b/src/mapwcs20.cpp
@@ -39,6 +39,7 @@
 #include "mapows.h"
 #include "mapwcs.h"
 #include "mapgdal.h"
+#include <cmath>
 #include <float.h>
 #include "gdal.h"
 #include "cpl_port.h"
@@ -4641,14 +4642,16 @@ this request. Check wcs/ows_enable_request settings.",
           subsetInImageProj.maxy =
               MS_MIN(subsetInImageProj.maxy, layer->extent.maxy);
           {
-            double total = ABS(layer->extent.maxx - layer->extent.minx);
-            double part = ABS(subsetInImageProj.maxx - subsetInImageProj.minx);
+            double total = std::abs(layer->extent.maxx - layer->extent.minx);
+            double part =
+                std::abs(subsetInImageProj.maxx - subsetInImageProj.minx);
             widthFromComputationInImageCRS =
                 MS_NINT((part * map->width) / total);
           }
           {
-            double total = ABS(layer->extent.maxy - layer->extent.miny);
-            double part = ABS(subsetInImageProj.maxy - subsetInImageProj.miny);
+            double total = std::abs(layer->extent.maxy - layer->extent.miny);
+            double part =
+                std::abs(subsetInImageProj.maxy - subsetInImageProj.miny);
             heightFromComputationInImageCRS =
                 MS_NINT((part * map->height) / total);
           }
@@ -4721,10 +4724,10 @@ this request. Check wcs/ows_enable_request settings.",
   } else {
     if (widthFromComputationInImageCRS != 0) {
       params->width = widthFromComputationInImageCRS;
-    } else if (ABS(bbox.maxx - bbox.minx) !=
-               ABS(map->extent.maxx - map->extent.minx)) {
-      double total = ABS(map->extent.maxx - map->extent.minx),
-             part = ABS(bbox.maxx - bbox.minx);
+    } else if (std::abs(bbox.maxx - bbox.minx) !=
+               std::abs(map->extent.maxx - map->extent.minx)) {
+      double total = std::abs(map->extent.maxx - map->extent.minx),
+             part = std::abs(bbox.maxx - bbox.minx);
       params->width = MS_NINT((part * map->width) / total);
     } else {
       params->width = map->width;
@@ -4746,10 +4749,10 @@ this request. Check wcs/ows_enable_request settings.",
   } else {
     if (heightFromComputationInImageCRS != 0) {
       params->height = heightFromComputationInImageCRS;
-    } else if (ABS(bbox.maxy - bbox.miny) !=
-               ABS(map->extent.maxy - map->extent.miny)) {
-      double total = ABS(map->extent.maxy - map->extent.miny),
-             part = ABS(bbox.maxy - bbox.miny);
+    } else if (std::abs(bbox.maxy - bbox.miny) !=
+               std::abs(map->extent.maxy - map->extent.miny)) {
+      double total = std::abs(map->extent.maxy - map->extent.miny),
+             part = std::abs(bbox.maxy - bbox.miny);
       params->height = MS_NINT((part * map->height) / total);
     } else {
       params->height = map->height;


### PR DESCRIPTION
They have been renamed in GDAL 3.13dev to avoid poluting the namespace. Use MS_ prefixed macros instead of std::min/max/abs from C++