### PR TITLE
Add fail-on-error: false flag for coveralls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,4 @@ jobs:
         with:
           format: lcov
           file: mapserver.info
+          fail-on-error: false


### PR DESCRIPTION
Add `fail-on-error: false` flag as recommended at https://status.coveralls.io/ during current outage:

```
Update - Outage will be extended for at least several more hours.
To avoid further disruption to your CI workflows, we recommend
employing the fail-on-error: false input option available with 
all official coveralls integrations. 
See: https://docs.coveralls.io/integrations#official-integrations.
```
