### PR TITLE
Define _USE_MATH_DEFINES so that M_PI is available when include math.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1049,6 +1049,9 @@ set(USE_GENERIC_MS_NINT 1)
 add_definitions(-D_XKEYCHECK_H=1)
 endif(WIN32)
 
+# Defines M_PI in particular
+add_definitions(-D_USE_MATH_DEFINES)
+
 
 #INSTALL(FILES mapserver-api.h ${PROJECT_BINARY_DIR}/mapserver-version.h DESTINATION include)
 if(USE_ORACLE_PLUGIN)

--- a/src/mappostgis.cpp
+++ b/src/mappostgis.cpp
@@ -54,9 +54,6 @@
 **
 */
 
-/* required for MSVC */
-#define _USE_MATH_DEFINES
-
 #include <assert.h>
 #include <string.h>
 #include <math.h>


### PR DESCRIPTION
@jmckenna Can you give this a try?