### PR TITLE
Fix C5208 warning in mapuvraster.cpp

### DIFF
--- a/src/mapuvraster.cpp
+++ b/src/mapuvraster.cpp
@@ -57,7 +57,7 @@
 #define MSUVRASTER_LAT "lat"
 #define MSUVRASTER_LATINDEX -107
 
-typedef struct {
+struct uvRasterLayerInfo {
 
   /* query cache results */
   int query_results = 0;
@@ -85,7 +85,7 @@ typedef struct {
 
   std::string timestring{};
   std::string timefield{};
-} uvRasterLayerInfo;
+};
 
 static uvRasterLayerInfo *getLayerInfo(layerObj *layer) {
   return static_cast<uvRasterLayerInfo *>(layer->layerinfo);


### PR DESCRIPTION
Fix the following warning in the MSVC builds:

```
mapuvraster.cpp
C:\projects\mapserver\src\mapuvraster.cpp(60,16): warning C5208: unnamed class used in 
typedef name cannot declare members other than non-static data members, member enumerations, 
or member classes [C:\projects\mapserver\build\mapserver.vcxproj]
```
See https://ci.appveyor.com/project/SethG/mapserver/builds/53638277/job/fwn3uj3bolrq72ek#L305

Switch to `struct` to allow initialisers such as `int refcount = 0;`. 