### PR TITLE
msSLDParseRasterSymbolizer(): fix potential heap buffer overflow

### DIFF
--- a/src/mapogcsld.cpp
+++ b/src/mapogcsld.cpp
@@ -2894,7 +2894,7 @@ int msSLDParseRasterSymbolizer(CPLXMLNode *psRoot, layerObj *psLayer,
         } else if (strcasecmp(psNode->pszValue, "Threshold") == 0) {
           papszThresholds[nThresholds] = psNode->psChild->pszValue;
           nThresholds++;
-          if (nValues == nMaxThreshold) {
+          if (nThresholds == nMaxThreshold) {
             nMaxThreshold += 100;
             papszThresholds = (char **)msSmallRealloc(
                 papszThresholds, sizeof(char *) * nMaxThreshold);


### PR DESCRIPTION
Fixes https://github.com/MapServer/MapServer/security/advisories/GHSA-cv4m-mr84-fgjp

Credits to Trail of Bits and Anthropic for reporting and patch suggestion