### PR TITLE
Add guard for invalid projection strings

### DIFF
--- a/msautotest/mspython/test_projections.py
+++ b/msautotest/mspython/test_projections.py
@@ -106,6 +106,11 @@ PROJECTION_CASES = [
         "IAU:2015:30100",
         marks=pytest.mark.xfail(reason="IAU:2015 is handled as IAU_2015"),
     ),
+    pytest.param(
+        "urn:ogc:def:crs:+",
+        None,
+        marks=pytest.mark.xfail(reason="Invalid projection string"),
+    ),
 ]
 
 

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -730,7 +730,7 @@ static int _msProcessAutoProjection(projectionObj *p) {
 int msProcessProjection(projectionObj *p) {
   assert(p->proj == NULL);
 
-  if (p->numargs < 1 || p->args[0] == NULL) {
+  if (p->numargs < 1) {
     msSetError(
         MS_PROJERR,
         "No projection arguments provided or projection string is invalid.",

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -730,6 +730,14 @@ static int _msProcessAutoProjection(projectionObj *p) {
 int msProcessProjection(projectionObj *p) {
   assert(p->proj == NULL);
 
+  if (p->numargs < 1 || p->args[0] == NULL) {
+    msSetError(
+        MS_PROJERR,
+        "No projection arguments provided or projection string is invalid.",
+        "msProcessProjection()");
+    return -1;
+  }
+
   p->generation_number++;
 
   if (strcasecmp(p->args[0], "GEOGRAPHIC") == 0) {


### PR DESCRIPTION
Follow-up to #7457 to add a test and guard for invalid projection strings in a Mapfile.

Fixes: Reference Info: 500975699 mapserver:mapfuzzer: Null-dereference READ in msProcessProjection https://oss-fuzz.com/testcase-detail/6167937613627392