### PR TITLE
CQL2Text: fix double free on 'A AND (B AND C)' filters (master 8.8dev only)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1053,7 +1053,7 @@ add_custom_target(check_cql2text_parser_md5 ALL
                   COMMAND ${CMAKE_COMMAND}
                       "-DIN_FILE=cql2textparser.y"
                       "-DTARGET=generate_cql2text_parser"
-                      "-DEXPECTED_MD5SUM=5772933b81f74a3a9e25b85b94221764"
+                      "-DEXPECTED_MD5SUM=dadf2802080f36becdca009199acfa36"
                       "-DFILENAME_CMAKE=${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
                       -P "${PROJECT_SOURCE_DIR}/src/check_md5sum.cmake"
                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"

--- a/msautotest/api/expected/ogcapi_cql2_text_and_issue_GHSA_v4x2_j2g2_rxwp.json.txt
+++ b/msautotest/api/expected/ogcapi_cql2_text_and_issue_GHSA_v4x2_j2g2_rxwp.json.txt
@@ -1,0 +1,8 @@
+Content-Type: application/geo+json
+Content-Crs: <http://www.opengis.net/def/crs/OGC/1.3/CRS84>
+Link: <http://localhost/cgi-bin/mapserv/OGCAPI_TEST/ogcapi/collections/mn_counties/items?f=json&limit=9&offset=0&filter=1%3D1%20AND%20(1%3D1%20AND%201%3D0)>; rel="self"; title="Items for this collection as GeoJSON"; type="application/geo+json"
+Link: <http://localhost/cgi-bin/mapserv/OGCAPI_TEST/ogcapi/collections/mn_counties/items?f=html&limit=9&offset=0&filter=1%3D1%20AND%20(1%3D1%20AND%201%3D0)>; rel="alternate"; title="Items for this collection as HTML"; type="text/html"
+OGC-NumberMatched: 0
+OGC-NumberReturned: 0
+
+{"features":[],"links":[{"href":"http://localhost/cgi-bin/mapserv/OGCAPI_TEST/ogcapi/collections/mn_counties/items?f=json&limit=9&offset=0&filter=1%3D1%20AND%20(1%3D1%20AND%201%3D0)","rel":"self","title":"Items for this collection as GeoJSON","type":"application/geo+json"},{"href":"http://localhost/cgi-bin/mapserv/OGCAPI_TEST/ogcapi/collections/mn_counties/items?f=html&limit=9&offset=0&filter=1%3D1%20AND%20(1%3D1%20AND%201%3D0)","rel":"alternate","title":"Items for this collection as HTML","type":"text/html"}],"numberMatched":0,"numberReturned":0,"type":"FeatureCollection"}

--- a/msautotest/api/ogcapi.map
+++ b/msautotest/api/ogcapi.map
@@ -86,6 +86,7 @@
 # RUN_PARMS: ogcapi_cql2_text_ge.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" "QUERY_STRING=f=json&filter=CTYONLY_>=117" > [RESULT]
 # RUN_PARMS: ogcapi_cql2_text_not.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" "QUERY_STRING=f=json&filter=NOT Name<>'Rice'" > [RESULT]
 # RUN_PARMS: ogcapi_cql2_text_and_true.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" "QUERY_STRING=f=json&filter=Name='Rice' AND 1=1" > [RESULT]
+# RUN_PARMS: ogcapi_cql2_text_and_issue_GHSA_v4x2_j2g2_rxwp.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" "QUERY_STRING=f=json&filter=1=1 AND (1=1 AND 1=0)" > [RESULT]
 # RUN_PARMS: ogcapi_cql2_text_four_and.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" "QUERY_STRING=f=json&filter=Name='Rice' AND 1=1 AND 1=1 AND 1=1" > [RESULT]
 # RUN_PARMS: ogcapi_cql2_text_and_false.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" "QUERY_STRING=f=json&filter=Name='Rice' AND 1=0" > [RESULT]
 # RUN_PARMS: ogcapi_cql2_text_or_true.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" "QUERY_STRING=f=json&filter=Name='Rice' OR 1=1" > [RESULT]

--- a/src/cql2.cpp
+++ b/src/cql2.cpp
@@ -155,14 +155,14 @@ void cql2_expr_node::RebalanceAndOr() {
 /*                        cql2_create_and_or_or()                        */
 /************************************************************************/
 
-cql2_expr_node *cql2_create_and_or_or(cql2_op op, cql2_expr_node *left,
-                                      cql2_expr_node *right) {
-  auto poNode = new cql2_expr_node(op);
+cql2_expr_node *cql2_create_and_or_or(cql2_op op,
+                                      std::unique_ptr<cql2_expr_node> left,
+                                      std::unique_ptr<cql2_expr_node> right) {
+  auto poNode = std::make_unique<cql2_expr_node>(op);
   poNode->m_field_type = CQL2_BOOLEAN;
 
   if (left->m_node_type == CQL2_NT_OPERATION && left->m_op == op) {
     poNode->m_apoChildren = std::move(left->m_apoChildren);
-    delete left;
 
     // Temporary non-binary formulation
     if (right->m_node_type == CQL2_NT_OPERATION && right->m_op == op) {
@@ -170,23 +170,20 @@ cql2_expr_node *cql2_create_and_or_or(cql2_op op, cql2_expr_node *left,
           poNode->m_apoChildren.end(),
           std::make_move_iterator(right->m_apoChildren.begin()),
           std::make_move_iterator(right->m_apoChildren.end()));
-      delete right;
     } else {
-      poNode->m_apoChildren.push_back(std::unique_ptr<cql2_expr_node>(right));
+      poNode->m_apoChildren.push_back(std::move(right));
     }
   } else if (right->m_node_type == CQL2_NT_OPERATION && right->m_op == op) {
     // Temporary non-binary formulation
     poNode->m_apoChildren = std::move(right->m_apoChildren);
-    delete right;
 
-    poNode->m_apoChildren.push_back(std::unique_ptr<cql2_expr_node>(left));
-    delete left;
+    poNode->m_apoChildren.push_back(std::move(left));
   } else {
-    poNode->m_apoChildren.push_back(std::unique_ptr<cql2_expr_node>(left));
-    poNode->m_apoChildren.push_back(std::unique_ptr<cql2_expr_node>(right));
+    poNode->m_apoChildren.push_back(std::move(left));
+    poNode->m_apoChildren.push_back(std::move(right));
   }
 
-  return poNode;
+  return poNode.release();
 }
 
 /************************************************************************/

--- a/src/cql2text.h
+++ b/src/cql2text.h
@@ -15,6 +15,7 @@
 
 #include "cql2.h"
 
+#include <memory>
 #include <string>
 
 struct cql2text_parse_context {
@@ -34,7 +35,8 @@ int cql2textparse(cql2text_parse_context *context);
 int cql2textlex(cql2_expr_node **ppNode, cql2text_parse_context *context);
 void cql2texterror(cql2text_parse_context *context, const char *msg);
 
-cql2_expr_node *cql2_create_and_or_or(cql2_op op, cql2_expr_node *left,
-                                      cql2_expr_node *right);
+cql2_expr_node *cql2_create_and_or_or(cql2_op op,
+                                      std::unique_ptr<cql2_expr_node> left,
+                                      std::unique_ptr<cql2_expr_node> right);
 
 #endif

--- a/src/cql2textparser.cpp
+++ b/src/cql2textparser.cpp
@@ -1597,7 +1597,7 @@ yyreduce:
 
   case 4: /* boolean_expr: boolean_expr "AND" boolean_expr  */
         {
-            yyval = cql2_create_and_or_or( CQL2_AND, yyvsp[-2], yyvsp[0] );
+            yyval = cql2_create_and_or_or( CQL2_AND, std::unique_ptr<cql2_expr_node>(yyvsp[-2]), std::unique_ptr<cql2_expr_node>(yyvsp[0]) );
             if( yyval->HasReachedMaxDepth() )
             {
                 yyerror (context, "Maximum expression depth reached");
@@ -1609,7 +1609,7 @@ yyreduce:
 
   case 5: /* boolean_expr: boolean_expr "OR" boolean_expr  */
         {
-            yyval = cql2_create_and_or_or( CQL2_OR, yyvsp[-2], yyvsp[0] );
+            yyval = cql2_create_and_or_or( CQL2_OR, std::unique_ptr<cql2_expr_node>(yyvsp[-2]), std::unique_ptr<cql2_expr_node>(yyvsp[0]) );
             if( yyval->HasReachedMaxDepth() )
             {
                 yyerror (context, "Maximum expression depth reached");

--- a/src/cql2textparser.y
+++ b/src/cql2textparser.y
@@ -92,7 +92,7 @@ boolean_expr:
 
     boolean_expr CQL2_TOK_AND boolean_expr
         {
-            $$ = cql2_create_and_or_or( CQL2_AND, $1, $3 );
+            $$ = cql2_create_and_or_or( CQL2_AND, std::unique_ptr<cql2_expr_node>($1), std::unique_ptr<cql2_expr_node>($3) );
             if( $$->HasReachedMaxDepth() )
             {
                 yyerror (context, "Maximum expression depth reached");
@@ -103,7 +103,7 @@ boolean_expr:
 
     | boolean_expr CQL2_TOK_OR boolean_expr
         {
-            $$ = cql2_create_and_or_or( CQL2_OR, $1, $3 );
+            $$ = cql2_create_and_or_or( CQL2_OR, std::unique_ptr<cql2_expr_node>($1), std::unique_ptr<cql2_expr_node>($3) );
             if( $$->HasReachedMaxDepth() )
             {
                 yyerror (context, "Maximum expression depth reached");


### PR DESCRIPTION
Fixes https://github.com/MapServer/MapServer/security/advisories/GHSA-v4x2-j2g2-rxwp