### PR TITLE
cgiutil: fix handling of malformed percent-encoding

### DIFF
--- a/src/cgiutil.c
+++ b/src/cgiutil.c
@@ -411,23 +411,22 @@ void unescape_url(char *url) {
 
   for (x = 0, y = 0; url[y]; ++x, ++y) {
     if (url[y] == '%') {
-        hi = hexadecimalToDecimal(url[y + 1]);
-        if (hi < 0) {
-          /* %-encoding is malformed, leave as-is */
-          url[x] = '%';
-          continue;
-        }
-        lo = hexadecimalToDecimal(url[y + 2]);
-        if (lo < 0) {
-          /* %-encoding is malformed, leave as-is */
-          url[x] = '%';
-          continue;
-        }
-        url[x] = (char)(hi * 16 + lo);
-        y += 2;
-    }
-    else {
-        url[x] = url[y];
+      hi = hexadecimalToDecimal(url[y + 1]);
+      if (hi < 0) {
+        /* %-encoding is malformed, leave as-is */
+        url[x] = '%';
+        continue;
+      }
+      lo = hexadecimalToDecimal(url[y + 2]);
+      if (lo < 0) {
+        /* %-encoding is malformed, leave as-is */
+        url[x] = '%';
+        continue;
+      }
+      url[x] = (char)(hi * 16 + lo);
+      y += 2;
+    } else {
+      url[x] = url[y];
     }
   }
   url[x] = '\0';

--- a/src/cgiutil.c
+++ b/src/cgiutil.c
@@ -396,7 +396,7 @@ char *fmakeword(FILE *f, char stop, int *cl) {
   }
 }
 
-int x2i(char c) {
+static int hexadecimalToDecimal(char c) {
   if (c >= '0' && c <= '9')
     return c - '0';
   if (c >= 'A' && c <= 'F')
@@ -411,13 +411,13 @@ void unescape_url(char *url) {
 
   for (x = 0, y = 0; url[y]; ++x, ++y) {
     if (url[y] == '%') {
-        hi = x2i(url[y + 1]);
+        hi = hexadecimalToDecimal(url[y + 1]);
         if (hi < 0) {
           /* %-encoding is malformed, leave as-is */
           url[x] = '%';
           continue;
         }
-        lo = x2i(url[y + 2]);
+        lo = hexadecimalToDecimal(url[y + 2]);
         if (lo < 0) {
           /* %-encoding is malformed, leave as-is */
           url[x] = '%';

--- a/src/cgiutil.c
+++ b/src/cgiutil.c
@@ -396,22 +396,38 @@ char *fmakeword(FILE *f, char stop, int *cl) {
   }
 }
 
-char x2c(char *what) {
-  register char digit;
-
-  digit = (what[0] >= 'A' ? ((what[0] & 0xdf) - 'A') + 10 : (what[0] - '0'));
-  digit *= 16;
-  digit += (what[1] >= 'A' ? ((what[1] & 0xdf) - 'A') + 10 : (what[1] - '0'));
-  return (digit);
+int x2i(char c) {
+  if (c >= '0' && c <= '9')
+    return c - '0';
+  if (c >= 'A' && c <= 'F')
+    return c - 'A' + 10;
+  if (c >= 'a' && c <= 'f')
+    return c - 'a' + 10;
+  return -1;
 }
 
 void unescape_url(char *url) {
-  register int x, y;
+  register int x, y, hi, lo;
 
   for (x = 0, y = 0; url[y]; ++x, ++y) {
-    if ((url[x] = url[y]) == '%') {
-      url[x] = x2c(&url[y + 1]);
-      y += 2;
+    if (url[y] == '%') {
+        hi = x2i(url[y + 1]);
+        if (hi < 0) {
+          /* %-encoding is malformed, leave as-is */
+          url[x] = '%';
+          continue;
+        }
+        lo = x2i(url[y + 2]);
+        if (lo < 0) {
+          /* %-encoding is malformed, leave as-is */
+          url[x] = '%';
+          continue;
+        }
+        url[x] = (char)(hi * 16 + lo);
+        y += 2;
+    }
+    else {
+        url[x] = url[y];
     }
   }
   url[x] = '\0';

--- a/src/cgiutil.c
+++ b/src/cgiutil.c
@@ -396,7 +396,7 @@ char *fmakeword(FILE *f, char stop, int *cl) {
   }
 }
 
-static int hexadecimalToDecimal(char c) {
+static int hex_to_integer(char c) {
   if (c >= '0' && c <= '9')
     return c - '0';
   if (c >= 'A' && c <= 'F')
@@ -411,13 +411,13 @@ void unescape_url(char *url) {
 
   for (x = 0, y = 0; url[y]; ++x, ++y) {
     if (url[y] == '%') {
-      hi = hexadecimalToDecimal(url[y + 1]);
+      hi = hex_to_integer(url[y + 1]);
       if (hi < 0) {
         /* %-encoding is malformed, leave as-is */
         url[x] = '%';
         continue;
       }
-      lo = hexadecimalToDecimal(url[y + 2]);
+      lo = hex_to_integer(url[y + 2]);
       if (lo < 0) {
         /* %-encoding is malformed, leave as-is */
         url[x] = '%';

--- a/src/cgiutil.h
+++ b/src/cgiutil.h
@@ -93,7 +93,6 @@ MS_DLL_EXPORT void getword(char *, char *, char);
 MS_DLL_EXPORT char *makeword_skip(char *, char, char);
 MS_DLL_EXPORT char *makeword(char *, char);
 MS_DLL_EXPORT char *fmakeword(FILE *, char, int *);
-MS_DLL_EXPORT int x2i(char);
 MS_DLL_EXPORT void unescape_url(char *);
 MS_DLL_EXPORT void plustospace(char *);
 MS_DLL_EXPORT int rind(char *, char);

--- a/src/cgiutil.h
+++ b/src/cgiutil.h
@@ -93,7 +93,7 @@ MS_DLL_EXPORT void getword(char *, char *, char);
 MS_DLL_EXPORT char *makeword_skip(char *, char, char);
 MS_DLL_EXPORT char *makeword(char *, char);
 MS_DLL_EXPORT char *fmakeword(FILE *, char, int *);
-MS_DLL_EXPORT char x2c(char *);
+MS_DLL_EXPORT int x2i(char);
 MS_DLL_EXPORT void unescape_url(char *);
 MS_DLL_EXPORT void plustospace(char *);
 MS_DLL_EXPORT int rind(char *, char);


### PR DESCRIPTION
unescape_url() implicitly assumed that two hex digits follow the percent sign without any checks.
This lead to an out-of-bounds read on malformed percent-encoded URLs, such as "/?foo=bar%", and undefined behavior if non-hex digits were supplied.

Fix this by verifying that two hex digits follow the percent sign and only unescape it in this case. In the malformed case, leave the percent-sign and the following digits as-is.

Minimal example of the OOB read:
```
MapServer/tests/ $ valgrind ../build/mapserv -conf mapserver-sample.conf "QUERY_STRING=map=test.map&mode=map&foo=bar%"
==770135== Memcheck, a memory error detector
==770135== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==770135== Using Valgrind-3.25.1 and LibVEX; rerun with -h for copyright info
==770135== Command: ../build/mapserv -conf mapserver-sample.conf QUERY_STRING=map=/tmp/test.map&mode=map&foo=bar%
==770135== 
==770135== Invalid read of size 1
==770135==    at 0x4AE61E3: x2c (in /home/stefan/Documents/repos/mapserver/MapServer/build/libmapserver.so.8.7-dev)
==770135==    by 0x4AE6277: unescape_url (in /home/stefan/Documents/repos/mapserver/MapServer/build/libmapserver.so.8.7-dev)
==770135==    by 0x4AE5B54: loadParams (in /home/stefan/Documents/repos/mapserver/MapServer/build/libmapserver.so.8.7-dev)
==770135==    by 0x4002AA0: main (in /home/stefan/Documents/repos/mapserver/MapServer/build/mapserv)
==770135==  Address 0xce380f9 is 0 bytes after a block of size 9 alloc'd
==770135==    at 0x48508A8: malloc (vg_replace_malloc.c:446)
==770135==    by 0x4CCC3D6: msSmallMalloc (in /home/stefan/Documents/repos/mapserver/MapServer/build/libmapserver.so.8.7-dev)
==770135==    by 0x4AE5FB9: makeword (in /home/stefan/Documents/repos/mapserver/MapServer/build/libmapserver.so.8.7-dev)
==770135==    by 0x4AE5B11: loadParams (in /home/stefan/Documents/repos/mapserver/MapServer/build/libmapserver.so.8.7-dev)
==770135==    by 0x4002AA0: main (in /home/stefan/Documents/repos/mapserver/MapServer/build/mapserv)
[...]
```