### PR TITLE
Switch XML mapfile parsing to safe default libxml2 options

### DIFF
--- a/src/mapxml.c
+++ b/src/mapxml.c
@@ -55,7 +55,7 @@ int msTransformXmlMapfile(const char *stylesheet, const char *xmlMapfile,
     goto done;
   }
 
-  doc = xmlReadFile(xmlMapfile, NULL, XML_PARSE_NOENT | XML_PARSE_DTDLOAD);
+  doc = xmlReadFile(xmlMapfile, NULL, 0);
   if (doc == NULL) {
     msSetError(MS_MISCERR, "Failed to load xml mapfile",
                "msTransformXmlMapfile()");


### PR DESCRIPTION
Disable XML entity expansion and external DTD loading in XML mapfile parsing (see https://mapserver.org/mapfile/xml_mapfile.html). See https://lists.osgeo.org/pipermail/mapserver-users/2026-June/083830.html for further details. 

The following options will then no longer be supported. None of these are used by the default XSL file at https://github.com/MapServer/MapServer/blob/main/src/xmlmapfile/mapfile.xsl. 

```
<!DOCTYPE map [
  <!ENTITY common SYSTEM "common.xml">
]>
<!DOCTYPE Layer [
  <!ATTLIST Layer type CDATA "raster">
]>
<Layer/>

```