### PR TITLE
Set OpenLayers resolution on CGI output maps

### DIFF
--- a/msautotest/misc/expected/browse.html
+++ b/msautotest/misc/expected/browse.html
@@ -20,6 +20,9 @@
     <div id="map"></div>
     <script src="//mapserver.org/lib/10.5.0/ol-mapserver.js"></script>
     <script>
+        if (!ol.proj.get('EPSG:4326')) {
+            ol.proj.addProjection(new ol.proj.Projection({ code: 'EPSG:4326' }));
+        }
         const mslayer = new ol.layer.Image({
             extent: [-180.000000, -180.000000, 180.000000, 180.000000],
             source: new ol.source.Image({
@@ -34,7 +37,11 @@
         const map = new ol.Map({
             layers: [mslayer],
             target: 'map',
-            view: new ol.View()
+            view: new ol.View({
+                projection: 'EPSG:4326',
+                minResolution: 1.3411e-06,
+                maxResolution: 1.40625
+            })
         });
         map.getView().fit([-180.000000, -180.000000, 180.000000, 180.000000], { size: map.getSize() });
     </script>

--- a/msautotest/misc/expected/browse_all.html
+++ b/msautotest/misc/expected/browse_all.html
@@ -20,6 +20,9 @@
     <div id="map"></div>
     <script src="//mapserver.org/lib/10.5.0/ol-mapserver.js"></script>
     <script>
+        if (!ol.proj.get('EPSG:4326')) {
+            ol.proj.addProjection(new ol.proj.Projection({ code: 'EPSG:4326' }));
+        }
         const mslayer = new ol.layer.Image({
             extent: [-180.000000, -180.000000, 180.000000, 180.000000],
             source: new ol.source.Image({
@@ -34,7 +37,11 @@
         const map = new ol.Map({
             layers: [mslayer],
             target: 'map',
-            view: new ol.View()
+            view: new ol.View({
+                projection: 'EPSG:4326',
+                minResolution: 1.3411e-06,
+                maxResolution: 1.40625
+            })
         });
         map.getView().fit([-180.000000, -180.000000, 180.000000, 180.000000], { size: map.getSize() });
     </script>

--- a/msautotest/misc/expected/browse_invalid.html
+++ b/msautotest/misc/expected/browse_invalid.html
@@ -20,6 +20,9 @@
     <div id="map"></div>
     <script src="//mapserver.org/lib/10.5.0/ol-mapserver.js"></script>
     <script>
+        if (!ol.proj.get('EPSG:4326')) {
+            ol.proj.addProjection(new ol.proj.Projection({ code: 'EPSG:4326' }));
+        }
         const mslayer = new ol.layer.Image({
             extent: [-180.000000, -180.000000, 180.000000, 180.000000],
             source: new ol.source.Image({
@@ -34,7 +37,11 @@
         const map = new ol.Map({
             layers: [mslayer],
             target: 'map',
-            view: new ol.View()
+            view: new ol.View({
+                projection: 'EPSG:4326',
+                minResolution: 1.3411e-06,
+                maxResolution: 1.40625
+            })
         });
         map.getView().fit([-180.000000, -180.000000, 180.000000, 180.000000], { size: map.getSize() });
     </script>

--- a/msautotest/misc/expected/wms.html
+++ b/msautotest/misc/expected/wms.html
@@ -21,7 +21,7 @@
     <script src="//mapserver.org/lib/10.5.0/ol-mapserver.js"></script>
     <script>
         if (!ol.proj.get('EPSG:4326')) {
-            ol.proj.addProjection(new ol.proj.Projection({ code : 'EPSG:4326' }));
+            ol.proj.addProjection(new ol.proj.Projection({ code: 'EPSG:4326' }));
         }
         const mslayer = new ol.layer.Image({
             source: new ol.source.Image({

--- a/msautotest/misc/expected/wms.html
+++ b/msautotest/misc/expected/wms.html
@@ -40,7 +40,11 @@
         const map = new ol.Map({
             layers: [mslayer],
             target: 'map',
-            view: new ol.View()
+            view: new ol.View({
+                projection: 'EPSG:4326',
+                minResolution: 1.3392e-06,
+                maxResolution: 1.40426
+            })
         });
         map.getView().fit([-89.905858, -179.744681, 89.905858, 179.744681], { size: map.getSize() });
     </script>

--- a/msautotest/misc/expected/wms_invalid_parameter2.html
+++ b/msautotest/misc/expected/wms_invalid_parameter2.html
@@ -40,7 +40,11 @@
         const map = new ol.Map({
             layers: [mslayer],
             target: 'map',
-            view: new ol.View()
+            view: new ol.View({
+                projection: 'EPSG:3395',
+                minResolution: 0.149135,
+                maxResolution: 156379
+            })
         });
         map.getView().fit([-20016548.603243, -15472271.997468, 20016548.603243, 18740357.487468], { size: map.getSize() });
     </script>

--- a/msautotest/misc/expected/wms_invalid_parameter2.html
+++ b/msautotest/misc/expected/wms_invalid_parameter2.html
@@ -21,7 +21,7 @@
     <script src="//mapserver.org/lib/10.5.0/ol-mapserver.js"></script>
     <script>
         if (!ol.proj.get('EPSG:3395')) {
-            ol.proj.addProjection(new ol.proj.Projection({ code : 'EPSG:3395' }));
+            ol.proj.addProjection(new ol.proj.Projection({ code: 'EPSG:3395' }));
         }
         const mslayer = new ol.layer.Image({
             source: new ol.source.Image({

--- a/msautotest/misc/expected/wms_projected.html
+++ b/msautotest/misc/expected/wms_projected.html
@@ -21,7 +21,7 @@
     <script src="//mapserver.org/lib/10.5.0/ol-mapserver.js"></script>
     <script>
         if (!ol.proj.get('EPSG:3857')) {
-            ol.proj.addProjection(new ol.proj.Projection({ code : 'EPSG:3857' }));
+            ol.proj.addProjection(new ol.proj.Projection({ code: 'EPSG:3857' }));
         }
         const mslayer = new ol.layer.Image({
             source: new ol.source.Image({

--- a/msautotest/misc/expected/wms_projected.html
+++ b/msautotest/misc/expected/wms_projected.html
@@ -40,7 +40,11 @@
         const map = new ol.Map({
             layers: [mslayer],
             target: 'map',
-            view: new ol.View()
+            view: new ol.View({
+                projection: 'EPSG:3857',
+                minResolution: 0.149165,
+                maxResolution: 156410
+            })
         });
         map.getView().fit([-20016548.603243, -20020527.850213, 20016548.603243, 20020527.850213], { size: map.getSize() });
     </script>

--- a/msautotest/misc/expected/wms_projected_extra.html
+++ b/msautotest/misc/expected/wms_projected_extra.html
@@ -40,7 +40,11 @@
         const map = new ol.Map({
             layers: [mslayer],
             target: 'map',
-            view: new ol.View()
+            view: new ol.View({
+                projection: 'EPSG:3395',
+                minResolution: 0.149135,
+                maxResolution: 156379
+            })
         });
         map.getView().fit([-20016548.603243, -15472271.997468, 20016548.603243, 18740357.487468], { size: map.getSize() });
     </script>

--- a/msautotest/misc/expected/wms_projected_extra.html
+++ b/msautotest/misc/expected/wms_projected_extra.html
@@ -21,7 +21,7 @@
     <script src="//mapserver.org/lib/10.5.0/ol-mapserver.js"></script>
     <script>
         if (!ol.proj.get('EPSG:3395')) {
-            ol.proj.addProjection(new ol.proj.Projection({ code : 'EPSG:3395' }));
+            ol.proj.addProjection(new ol.proj.Projection({ code: 'EPSG:3395' }));
         }
         const mslayer = new ol.layer.Image({
             source: new ol.source.Image({

--- a/src/maptemplate.c
+++ b/src/maptemplate.c
@@ -43,6 +43,7 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <math.h>
 
 static inline void IGUR_sizet(size_t ignored) {
   (void)ignored;
@@ -82,11 +83,19 @@ static const char *const olTemplate =
     "    <script "
     "src=\"[openlayers_js_url]\"></script>\n"
     "    <script>\n"
+    "        if (!ol.proj.get('[openlayers_projection]')) {\n"
+    "            ol.proj.addProjection(new ol.proj.Projection({ code : "
+    "'[openlayers_projection]' }));\n"
+    "        }\n"
     "        [openlayers_layer]\n"
     "        const map = new ol.Map({\n"
     "            layers: [mslayer],\n"
     "            target: 'map',\n"
-    "            view: new ol.View()\n"
+    "            view: new ol.View({\n"
+    "                projection: '[openlayers_projection]',\n"
+    "                minResolution: [ol_minresolution],\n"
+    "                maxResolution: [ol_maxresolution]\n"
+    "            })\n"
     "        });\n"
     "        map.getView().fit([[minx], [miny], [maxx], [maxy]], { size: "
     "map.getSize() });\n"
@@ -108,11 +117,7 @@ static const char *const olLayerMapServerTag =
     "        });";
 
 static const char *const olLayerWMSTag =
-    "if (!ol.proj.get('[openlayers_projection]')) {\n"
-    "            ol.proj.addProjection(new ol.proj.Projection({ code : "
-    "'[openlayers_projection]' }));\n"
-    "        }\n"
-    "        const mslayer = new ol.layer.Image({\n"
+    "const mslayer = new ol.layer.Image({\n"
     "            source: new ol.source.Image({\n"
     "                loader: ol.source.wms.createLoader({\n"
     "                    url: '[mapserv_onlineresource]',\n"
@@ -5013,6 +5018,7 @@ int msReturnOpenLayersPage(mapservObj *mapserv) {
   const char *openlayersCssUrl = olCssUrl;
   char *projection = NULL;
   char *format = NULL;
+  char *epsgCode = NULL;
 
   /* 2 CGI parameters are used in the template. we need to transform them
    * to be sure the case matches during the template processing.*/
@@ -5042,6 +5048,14 @@ int msReturnOpenLayersPage(mapservObj *mapserv) {
         projection = msEncodeHTMLEntities(mapserv->request->ParamValues[i]);
         break;
       }
+    }
+  }
+
+  if (mapserv->Mode == BROWSE) {
+    msOWSGetEPSGProj(&(mapserv->map->projection), NULL, NULL, MS_TRUE,
+                     &epsgCode);
+    if (epsgCode) {
+      projection = epsgCode;
     }
   }
 
@@ -5075,12 +5089,36 @@ int msReturnOpenLayersPage(mapservObj *mapserv) {
   buffer = msReplaceSubstring(buffer, "[openlayers_js_url]", openlayersUrl);
   buffer = msReplaceSubstring(buffer, "[openlayers_css_url]", openlayersCssUrl);
   buffer = msReplaceSubstring(buffer, "[openlayers_layer]", layer);
-  if (projection)
-    buffer = msReplaceSubstring(buffer, "[openlayers_projection]", projection);
-  if (format)
+  if (!projection) {
+    // if no projection can be found then use the default OL projection
+    projection = msStrdup("EPSG:3857");
+  }
+  buffer = msReplaceSubstring(buffer, "[openlayers_projection]", projection);
+  if (format) {
     buffer = msReplaceSubstring(buffer, "[openlayers_format]", format);
-  else
+  } else {
     buffer = msReplaceSubstring(buffer, "[openlayers_format]", "image/png");
+  }
+
+  double extentWidth = mapserv->map->extent.maxx - mapserv->map->extent.minx;
+  double extentHeight = mapserv->map->extent.maxy - mapserv->map->extent.miny;
+  // assume default tile size and zoom-levels
+  int zoomLevels = 20;
+  double maxResolution = MS_MAX(extentWidth, extentHeight) / 256.0;
+
+  if (maxResolution <= 0) {
+    maxResolution = 1; // fallback to avoid any divide by zero
+  }
+
+  double minResolution = maxResolution / pow(2.0, zoomLevels);
+  char olMinRes[64], olMaxRes[64];
+
+  snprintf(olMaxRes, sizeof(olMaxRes), "%g", maxResolution);
+  snprintf(olMinRes, sizeof(olMinRes), "%g", minResolution);
+
+  buffer = msReplaceSubstring(buffer, "[ol_maxresolution]", olMaxRes);
+  buffer = msReplaceSubstring(buffer, "[ol_minresolution]", olMinRes);
+
   msIO_fwrite(buffer, strlen(buffer), 1, stdout);
   free(layer);
   free(buffer);

--- a/src/maptemplate.c
+++ b/src/maptemplate.c
@@ -5018,7 +5018,6 @@ int msReturnOpenLayersPage(mapservObj *mapserv) {
   const char *openlayersCssUrl = olCssUrl;
   char *projection = NULL;
   char *format = NULL;
-  char *epsgCode = NULL;
 
   /* 2 CGI parameters are used in the template. we need to transform them
    * to be sure the case matches during the template processing.*/
@@ -5052,9 +5051,11 @@ int msReturnOpenLayersPage(mapservObj *mapserv) {
   }
 
   if (mapserv->Mode == BROWSE) {
+    char *epsgCode = NULL;
     msOWSGetEPSGProj(&(mapserv->map->projection), NULL, NULL, MS_TRUE,
                      &epsgCode);
     if (epsgCode) {
+      // Transfers ownership of epsgCode to projection
       projection = epsgCode;
     }
   }

--- a/src/maptemplate.c
+++ b/src/maptemplate.c
@@ -84,7 +84,7 @@ static const char *const olTemplate =
     "src=\"[openlayers_js_url]\"></script>\n"
     "    <script>\n"
     "        if (!ol.proj.get('[openlayers_projection]')) {\n"
-    "            ol.proj.addProjection(new ol.proj.Projection({ code : "
+    "            ol.proj.addProjection(new ol.proj.Projection({ code: "
     "'[openlayers_projection]' }));\n"
     "        }\n"
     "        [openlayers_layer]\n"


### PR DESCRIPTION
The OpenLayers viewer template uses a `ol.View()`, which defaults to `EPSG:3857` with the min/max resolution range for Web Mercator. 

Layers with extents in other units (e.g. `EPSG:4326` degrees, or small local extents) hit the default `minResolution`, which prevents zooming further in. This PR:

- Calculates minResolution/maxResolution from the map's extent and sets them on the view, so the resolution range matches the data regardless of projection.
- Moves the addProjection/ol.proj.get registration into the shared template so it applies to BROWSE mode as well as WMS requests. This prevents JS errors for unknown projections. 
- For BROWSE mode, gets the projection from the Mapfile using `msOWSGetEPSGProj()` (as there is no CRS/SRS request param).
- Defaults to EPSG:3857 if no projection can be determined (the current behaviour). 
- Updates the test suite