### PR TITLE
Stop swallowing all errors to show index page

### DIFF
--- a/msautotest/config/expected/index_wms.html
+++ b/msautotest/config/expected/index_wms.html
@@ -27,7 +27,7 @@
         <tr>
             <td>1</td>
             <td>CGI</td>
-            <td><a href="http://localhost:8085/cgi-bin/mapserv.exe/WMS/?template=openlayers&mode=browse&layers=all">OpenLayers Viewer</a></td>
+            <td><a href="./?template=openlayers&mode=browse&layers=all">OpenLayers Viewer</a></td>
             <td>WMSMAP</td>
         </tr>
         <tr>

--- a/msautotest/config/expected/index_wms.html
+++ b/msautotest/config/expected/index_wms.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>MapServer Landing Page</title>
+    <meta charset="utf-8" />
+</head>
+  <body>
+<h1>MapServer Mapfile Landing Page</h1>
+<ul>
+    <li><b>Title:</b> MapServer WMS Demo Map</li>
+    <li><b>Layer Count:</b> 1</li>
+    <li><b>Map Name:</b> WMSMAP</li>
+</ul>
+<p>
+    Below are all the services available for this Mapfile.
+</p>
+<table>
+    <thead>
+        <tr>
+            <th>#</th>
+            <th>Type</th>
+            <th>Service</th>
+            <th>Title</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>CGI</td>
+            <td><a href="http://localhost:8085/cgi-bin/mapserv.exe/WMS/?template=openlayers&mode=browse&layers=all">OpenLayers Viewer</a></td>
+            <td>WMSMAP</td>
+        </tr>
+        <tr>
+            <td>2</td>
+            <td>WMS</td>
+            <td><a href="./?version=1.0.0&request=GetCapabilities&service=WMS">WMS GetCapabilities URL (version 1.0.0)</a></td>
+            <td>MapServer WMS Demo Map</td>
+        </tr>
+        <tr>
+            <td>3</td>
+            <td>WMS</td>
+            <td><a href="./?version=1.1.0&request=GetCapabilities&service=WMS">WMS GetCapabilities URL (version 1.1.0)</a></td>
+            <td>MapServer WMS Demo Map</td>
+        </tr>
+        <tr>
+            <td>4</td>
+            <td>WMS</td>
+            <td><a href="./?version=1.1.1&request=GetCapabilities&service=WMS">WMS GetCapabilities URL (version 1.1.1)</a></td>
+            <td>MapServer WMS Demo Map</td>
+        </tr>
+        <tr>
+            <td>5</td>
+            <td>WMS</td>
+            <td><a href="./?version=1.3.0&request=GetCapabilities&service=WMS">WMS GetCapabilities URL (version 1.3.0)</a></td>
+            <td>MapServer WMS Demo Map</td>
+        </tr>
+        </tbody>
+</table>
+</body>
+</html>

--- a/msautotest/config/expected/index_wms_error.txt
+++ b/msautotest/config/expected/index_wms_error.txt
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding="UTF-8" standalone="no" ?>
+<ServiceExceptionReport version="1.3.0" xmlns="http://www.opengis.net/ogc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/ogc http://ogc.dmsolutions.ca/wms/1.3.0/exceptions_1_3_0.xsd">
+<ServiceException code="LayerNotDefined">
+msWMSLoadGetMapParams(): WMS server error. Invalid layer(s) given in the LAYERS parameter. A layer might be disabled for this request. Check wms/ows_enable_request settings.
+</ServiceException>
+</ServiceExceptionReport>

--- a/msautotest/config/index_wms.map
+++ b/msautotest/config/index_wms.map
@@ -1,5 +1,14 @@
 # RUN_PARMS: index_wms.json [MAPSERV] -conf index.conf "PATH_INFO=/WMS_MAP/" QUERY_STRING="f=json" > [RESULT_DEMIME]
 
+# a request with a querystring that returns empty requests errors will default to returning the index JSON
+# RUN_PARMS: index_wms.json [MAPSERV] -conf index.conf "PATH_INFO=/WMS_MAP/" QUERY_STRING="param1=val1&param2=val2&f=json" > [RESULT_DEMIME]
+
+# reutrn index page (in HTML) when previously Web application error. Traditional BROWSE mode requires a TEMPLATE in the WEB section, but none was provided would be returned
+# RUN_PARMS: index_wms.html [MAPSERV] -conf index.conf "PATH_INFO=/WMS_MAP/" QUERY_STRING="?version=1.3.0&request=GetCapabilities&service=" > [RESULT_DEMIME]
+
+# any requests that throw a different error should return the error
+# RUN_PARAMS: index_wms_error.txt [MAPSERV] -conf index.conf "PATH_INFO=/WMS_MAP/" QUERY_STRING="?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&BBOX=-90,0,90,180&CRS=EPSG:4326&WIDTH=372&HEIGHT=372&LAYERS=missing&STYLES=&FORMAT=image/png" >  [RESULT_DEMIME]
+
 MAP
     NAME "WMSMAP"
     IMAGETYPE "png"
@@ -14,8 +23,6 @@ MAP
             "wms_srs" "EPSG:4326"
             "ows_title" "MapServer WMS Demo Map"
         END
-        # required if using &mode=browse&template=openlayers
-        IMAGEPATH "/tmp/"
     END
 
     LAYER

--- a/src/apps/mapserv.c
+++ b/src/apps/mapserv.c
@@ -34,6 +34,7 @@
 #include "mapserver-config.h"
 #include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef USE_FASTCGI
 #define NO_FCGI_DEFINES
@@ -341,8 +342,24 @@ int main(int argc, char *argv[]) {
         if (ms_index_dir != NULL) {
           // Try normal dispatch first
           if (msCGIDispatchRequest(mapserv) != MS_SUCCESS) {
-            // Fallback to landing page
-            if (msCGIDispatchMapIndexRequest(mapserv, config) != MS_SUCCESS) {
+            errorObj *ms_error = msGetErrorObj();
+            int show_index = MS_FALSE;
+            if (mapserv->request->NumParams == 0) {
+              show_index = MS_TRUE;
+            } else if (ms_error != NULL && ms_error->code == MS_WEBERR) {
+              if (strstr(ms_error->message, "No query information to decode") !=
+                      NULL ||
+                  strstr(ms_error->message,
+                         "Traditional BROWSE mode requires a TEMPLATE") !=
+                      NULL) {
+                // Fallback to landing page
+                show_index = MS_TRUE;
+              }
+            }
+
+            if (show_index &&
+                msCGIDispatchMapIndexRequest(mapserv, config) == MS_SUCCESS) {
+            } else {
               msCGIWriteError(mapserv);
               goto end_request;
             }


### PR DESCRIPTION
When the [MapServer Index Page](https://mapserver.org/output/index-page.html) is enabled, it currently displays on all errors. This is to allow it to be used wherever previously the following errors are thrown:

```
mapserv(): Web application error. Traditional BROWSE mode requires a TEMPLATE in the WEB section, but none was provided.

mapserv(): Web application error. Traditional BROWSE mode requires a TEMPLATE in the WEB section, but none was provided. loadParams(): Web application error. No query information to decode. QUERY_STRING is set, but empty.
```

However it also displays when other invalid requests are thrown, for example WFS/WMS/WCS server errors. This pull request ensures these errors are still returned, and the index page is only shown for the 2 error paths above. 