### PR TITLE
Minor fixes to Bootstrap HTML Templates

### DIFF
--- a/share/ogcapi/templates/html-bootstrap/collection-queryables.html
+++ b/share/ogcapi/templates/html-bootstrap/collection-queryables.html
@@ -14,6 +14,7 @@
 
 <div class="row">
   <div class="col-sm">
+    <ul>
     {% for key, value in response.properties %}
       <li>{{ key }}:
       {% if existsIn(value, "type") %}
@@ -27,6 +28,7 @@
       {% endif %}
       </li>
     {% endfor %}
+    </ul>
   </div>
 </div>
 

--- a/share/ogcapi/templates/html-bootstrap/collection-schema.html
+++ b/share/ogcapi/templates/html-bootstrap/collection-schema.html
@@ -14,6 +14,7 @@
 
 <div class="row">
   <div class="col-sm">
+    <ul>
     {% for key, value in response.properties %}
       <li>{{ key }}:
       {% if existsIn(value, "type") %}
@@ -27,6 +28,7 @@
       {% endif %}
       </li>
     {% endfor %}
+    </ul>
   </div>
 </div>
 

--- a/share/ogcapi/templates/html-bootstrap/collection-sortables.html
+++ b/share/ogcapi/templates/html-bootstrap/collection-sortables.html
@@ -14,6 +14,7 @@
 
 <div class="row">
   <div class="col-sm">
+    <ul>
     {% for key, value in response.properties %}
       <li>{{ key }}:
       {% if existsIn(value, "type") %}
@@ -27,6 +28,7 @@
       {% endif %}
       </li>
     {% endfor %}
+    </ul>
   </div>
 </div>
 

--- a/share/ogcapi/templates/html-bootstrap/collections.html
+++ b/share/ogcapi/templates/html-bootstrap/collections.html
@@ -24,9 +24,7 @@
 {%- for collection in response.collections %}
       <tr>
         <td>{{ loop.index1 }}</td>
-        <td>
         <td><a href="{{ template.api_root }}/collections/{{ collection.id }}?f=html{{ template.extra_params }}">{{ collection.title }}</a></td>
-        </td>
         <td>{{ collection.itemType }}</td>
         <td>{{ collection.description }}</td>
       </tr>


### PR DESCRIPTION
- Remove erroneous `<td>`
- Ensure list items are in a `<ul>` block. 

Note we test the plain and JSON outputs (the Bootstrap files are much larger), so no tests needed modifying. 