### PR TITLE
Option to add GDAL/OGR Feature Id field to LAYER attributes

### DIFF
--- a/msautotest/wxs/expected/wfs_filter_ogr_fid.xml
+++ b/msautotest/wxs/expected/wfs_filter_ogr_fid.xml
@@ -1,0 +1,51 @@
+Content-Type: text/xml; subtype="gml/3.2.1"; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml/3.2"
+   xmlns:wfs="http://www.opengis.net/wfs/2.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=popplace_gpkg&amp;OUTPUTFORMAT=application%2Fgml%2Bxml%3B%20version%3D3.2 http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+   timeStamp="" numberMatched="1" numberReturned="1">
+      <wfs:boundedBy>
+      	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+      		<gml:lowerCorner>46.980843 -64.052355</gml:lowerCorner>
+      		<gml:upperCorner>46.980843 -64.052355</gml:upperCorner>
+      	</gml:Envelope>
+      </wfs:boundedBy>
+    <wfs:member>
+      <ms:popplace_gpkg gml:id="popplace_gpkg.1">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>46.980843 -64.052355</gml:lowerCorner>
+        		<gml:upperCorner>46.980843 -64.052355</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id="popplace_gpkg.1.1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>46.980843 -64.052355</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>8</ms:POPPLACE_>
+        <ms:POPPLACE_I>1</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>BACMK</ms:UNIQUE_KEY>
+        <ms:NAME>&quot;Tignish</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>11</ms:REG_CODE>
+        <ms:NTS50>021I16</ms:NTS50>
+        <ms:LAT>465700</ms:LAT>
+        <ms:LONG>640200</ms:LONG>
+        <ms:SGC_CODE>0</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>1</ms:POP_RANGE>
+        <ms:fid>1</ms:fid>
+      </ms:popplace_gpkg>
+    </wfs:member>
+</wfs:FeatureCollection>
+

--- a/msautotest/wxs/expected/wfs_filter_ogr_fid_describe.xml
+++ b/msautotest/wxs/expected/wfs_filter_ogr_fid_describe.xml
@@ -1,0 +1,47 @@
+Content-Type: application/gml+xml; version=3.2; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" ?>
+<schema
+   targetNamespace="http://mapserver.gis.umn.edu/mapserver" 
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver" 
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   xmlns="http://www.w3.org/2001/XMLSchema"
+   xmlns:gml="http://www.opengis.net/gml/3.2"
+   elementFormDefault="qualified" version="0.1" >
+
+  <import namespace="http://www.opengis.net/gml/3.2"
+          schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd" />
+
+  <element name="popplace_gpkg" 
+           type="ms:popplace_gpkgType" 
+           substitutionGroup="gml:AbstractFeature" />
+
+  <complexType name="popplace_gpkgType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="msGeometry" type="gml:GeometryPropertyType" minOccurs="0" maxOccurs="1"/>
+          <element name="AREA" minOccurs="0" type="double"/>
+          <element name="PERIMETER" minOccurs="0" type="double"/>
+          <element name="POPPLACE_" minOccurs="0" type="long"/>
+          <element name="POPPLACE_I" minOccurs="0" type="long"/>
+          <element name="UNIQUE_KEY" minOccurs="0" type="string"/>
+          <element name="NAME" minOccurs="0" type="string"/>
+          <element name="NAME_E" minOccurs="0" type="string"/>
+          <element name="NAME_F" minOccurs="0" type="string"/>
+          <element name="UNIQUE_K_1" minOccurs="0" type="string"/>
+          <element name="UNIQUE_K_2" minOccurs="0" type="string"/>
+          <element name="REG_CODE" minOccurs="0" type="integer"/>
+          <element name="NTS50" minOccurs="0" type="string"/>
+          <element name="LAT" minOccurs="0" type="string"/>
+          <element name="LONG" minOccurs="0" type="string"/>
+          <element name="SGC_CODE" minOccurs="0" type="integer"/>
+          <element name="CAPITAL" minOccurs="0" type="integer"/>
+          <element name="POP_RANGE" minOccurs="0" type="integer"/>
+          <element name="fid" minOccurs="0" type="long"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+
+</schema>

--- a/msautotest/wxs/expected/wfs_filter_ogr_fid_native.xml
+++ b/msautotest/wxs/expected/wfs_filter_ogr_fid_native.xml
@@ -1,0 +1,50 @@
+Content-Type: text/xml; subtype="gml/3.2.1"; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml/3.2"
+   xmlns:wfs="http://www.opengis.net/wfs/2.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=popplace_gpkg_nofid&amp;OUTPUTFORMAT=application%2Fgml%2Bxml%3B%20version%3D3.2 http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+   timeStamp="" numberMatched="1" numberReturned="1">
+      <wfs:boundedBy>
+      	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+      		<gml:lowerCorner>46.980843 -64.052355</gml:lowerCorner>
+      		<gml:upperCorner>46.980843 -64.052355</gml:upperCorner>
+      	</gml:Envelope>
+      </wfs:boundedBy>
+    <wfs:member>
+      <ms:popplace_gpkg_nofid gml:id="popplace_gpkg_nofid.1">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>46.980843 -64.052355</gml:lowerCorner>
+        		<gml:upperCorner>46.980843 -64.052355</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id="popplace_gpkg_nofid.1.1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>46.980843 -64.052355</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>8</ms:POPPLACE_>
+        <ms:POPPLACE_I>1</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>BACMK</ms:UNIQUE_KEY>
+        <ms:NAME>&quot;Tignish</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>11</ms:REG_CODE>
+        <ms:NTS50>021I16</ms:NTS50>
+        <ms:LAT>465700</ms:LAT>
+        <ms:LONG>640200</ms:LONG>
+        <ms:SGC_CODE>0</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>1</ms:POP_RANGE>
+      </ms:popplace_gpkg_nofid>
+    </wfs:member>
+</wfs:FeatureCollection>
+

--- a/msautotest/wxs/expected/wfs_filter_ogr_fid_native_describe.xml
+++ b/msautotest/wxs/expected/wfs_filter_ogr_fid_native_describe.xml
@@ -1,0 +1,46 @@
+Content-Type: application/gml+xml; version=3.2; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" ?>
+<schema
+   targetNamespace="http://mapserver.gis.umn.edu/mapserver" 
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver" 
+   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+   xmlns="http://www.w3.org/2001/XMLSchema"
+   xmlns:gml="http://www.opengis.net/gml/3.2"
+   elementFormDefault="qualified" version="0.1" >
+
+  <import namespace="http://www.opengis.net/gml/3.2"
+          schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd" />
+
+  <element name="popplace_gpkg_nofid" 
+           type="ms:popplace_gpkg_nofidType" 
+           substitutionGroup="gml:AbstractFeature" />
+
+  <complexType name="popplace_gpkg_nofidType">
+    <complexContent>
+      <extension base="gml:AbstractFeatureType">
+        <sequence>
+          <element name="msGeometry" type="gml:GeometryPropertyType" minOccurs="0" maxOccurs="1"/>
+          <element name="AREA" minOccurs="0" type="double"/>
+          <element name="PERIMETER" minOccurs="0" type="double"/>
+          <element name="POPPLACE_" minOccurs="0" type="long"/>
+          <element name="POPPLACE_I" minOccurs="0" type="long"/>
+          <element name="UNIQUE_KEY" minOccurs="0" type="string"/>
+          <element name="NAME" minOccurs="0" type="string"/>
+          <element name="NAME_E" minOccurs="0" type="string"/>
+          <element name="NAME_F" minOccurs="0" type="string"/>
+          <element name="UNIQUE_K_1" minOccurs="0" type="string"/>
+          <element name="UNIQUE_K_2" minOccurs="0" type="string"/>
+          <element name="REG_CODE" minOccurs="0" type="integer"/>
+          <element name="NTS50" minOccurs="0" type="string"/>
+          <element name="LAT" minOccurs="0" type="string"/>
+          <element name="LONG" minOccurs="0" type="string"/>
+          <element name="SGC_CODE" minOccurs="0" type="integer"/>
+          <element name="CAPITAL" minOccurs="0" type="integer"/>
+          <element name="POP_RANGE" minOccurs="0" type="integer"/>
+        </sequence>
+      </extension>
+    </complexContent>
+  </complexType>
+
+</schema>

--- a/msautotest/wxs/expected/wfs_filter_ogr_fid_native_range.xml
+++ b/msautotest/wxs/expected/wfs_filter_ogr_fid_native_range.xml
@@ -1,0 +1,178 @@
+Content-Type: text/xml; subtype="gml/3.2.1"; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml/3.2"
+   xmlns:wfs="http://www.opengis.net/wfs/2.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=popplace_gpkg_nofid&amp;OUTPUTFORMAT=application%2Fgml%2Bxml%3B%20version%3D3.2 http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+   timeStamp="" numberMatched="5" numberReturned="5">
+      <wfs:boundedBy>
+      	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+      		<gml:lowerCorner>44.911800 -64.052355</gml:lowerCorner>
+      		<gml:upperCorner>46.980843 -60.981038</gml:upperCorner>
+      	</gml:Envelope>
+      </wfs:boundedBy>
+    <wfs:member>
+      <ms:popplace_gpkg_nofid gml:id="popplace_gpkg_nofid.1">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>46.980843 -64.052355</gml:lowerCorner>
+        		<gml:upperCorner>46.980843 -64.052355</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id="popplace_gpkg_nofid.1.1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>46.980843 -64.052355</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>8</ms:POPPLACE_>
+        <ms:POPPLACE_I>1</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>BACMK</ms:UNIQUE_KEY>
+        <ms:NAME>&quot;Tignish</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>11</ms:REG_CODE>
+        <ms:NTS50>021I16</ms:NTS50>
+        <ms:LAT>465700</ms:LAT>
+        <ms:LONG>640200</ms:LONG>
+        <ms:SGC_CODE>0</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>1</ms:POP_RANGE>
+      </ms:popplace_gpkg_nofid>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace_gpkg_nofid gml:id="popplace_gpkg_nofid.2">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>46.689323 -60.981038</gml:lowerCorner>
+        		<gml:upperCorner>46.689323 -60.981038</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id="popplace_gpkg_nofid.2.1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>46.689323 -60.981038</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>9</ms:POPPLACE_>
+        <ms:POPPLACE_I>1</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CAGYX</ms:UNIQUE_KEY>
+        <ms:NAME>&#39;Cheticamp</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>011K11</ms:NTS50>
+        <ms:LAT>463800</ms:LAT>
+        <ms:LONG>610100</ms:LONG>
+        <ms:SGC_CODE>1215011</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+      </ms:popplace_gpkg_nofid>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace_gpkg_nofid gml:id="popplace_gpkg_nofid.3">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>44.911800 -62.513078</gml:lowerCorner>
+        		<gml:upperCorner>44.911800 -62.513078</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id="popplace_gpkg_nofid.3.1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>44.911800 -62.513078</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>10</ms:POPPLACE_>
+        <ms:POPPLACE_I>1</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CBIKA</ms:UNIQUE_KEY>
+        <ms:NAME>Sheet Harbour</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>011D15</ms:NTS50>
+        <ms:LAT>445500</ms:LAT>
+        <ms:LONG>623200</ms:LONG>
+        <ms:SGC_CODE>1209036</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+      </ms:popplace_gpkg_nofid>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace_gpkg_nofid gml:id="popplace_gpkg_nofid.4">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>46.373272 -62.272430</gml:lowerCorner>
+        		<gml:upperCorner>46.373272 -62.272430</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id="popplace_gpkg_nofid.4.1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>46.373272 -62.272430</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>109</ms:POPPLACE_>
+        <ms:POPPLACE_I>2</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>BACII</ms:UNIQUE_KEY>
+        <ms:NAME>&#39;Souris&#39;</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>11</ms:REG_CODE>
+        <ms:NTS50>011L08</ms:NTS50>
+        <ms:LAT>462100</ms:LAT>
+        <ms:LONG>621500</ms:LONG>
+        <ms:SGC_CODE>1101036</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+      </ms:popplace_gpkg_nofid>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace_gpkg_nofid gml:id="popplace_gpkg_nofid.5">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>45.311286 -61.038743</gml:lowerCorner>
+        		<gml:upperCorner>45.311286 -61.038743</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id="popplace_gpkg_nofid.5.1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>45.311286 -61.038743</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>110</ms:POPPLACE_>
+        <ms:POPPLACE_I>2</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CAGBW</ms:UNIQUE_KEY>
+        <ms:NAME>&quot;Canso&quot;</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>011F07</ms:NTS50>
+        <ms:LAT>452000</ms:LAT>
+        <ms:LONG>610000</ms:LONG>
+        <ms:SGC_CODE>1213006</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+      </ms:popplace_gpkg_nofid>
+    </wfs:member>
+</wfs:FeatureCollection>
+

--- a/msautotest/wxs/expected/wfs_filter_ogr_fid_range.xml
+++ b/msautotest/wxs/expected/wfs_filter_ogr_fid_range.xml
@@ -1,0 +1,183 @@
+Content-Type: text/xml; subtype="gml/3.2.1"; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:gml="http://www.opengis.net/gml/3.2"
+   xmlns:wfs="http://www.opengis.net/wfs/2.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=popplace_gpkg&amp;OUTPUTFORMAT=application%2Fgml%2Bxml%3B%20version%3D3.2 http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+   timeStamp="" numberMatched="5" numberReturned="5">
+      <wfs:boundedBy>
+      	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+      		<gml:lowerCorner>44.911800 -64.052355</gml:lowerCorner>
+      		<gml:upperCorner>46.980843 -60.981038</gml:upperCorner>
+      	</gml:Envelope>
+      </wfs:boundedBy>
+    <wfs:member>
+      <ms:popplace_gpkg gml:id="popplace_gpkg.1">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>46.980843 -64.052355</gml:lowerCorner>
+        		<gml:upperCorner>46.980843 -64.052355</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id="popplace_gpkg.1.1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>46.980843 -64.052355</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>8</ms:POPPLACE_>
+        <ms:POPPLACE_I>1</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>BACMK</ms:UNIQUE_KEY>
+        <ms:NAME>&quot;Tignish</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>11</ms:REG_CODE>
+        <ms:NTS50>021I16</ms:NTS50>
+        <ms:LAT>465700</ms:LAT>
+        <ms:LONG>640200</ms:LONG>
+        <ms:SGC_CODE>0</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>1</ms:POP_RANGE>
+        <ms:fid>1</ms:fid>
+      </ms:popplace_gpkg>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace_gpkg gml:id="popplace_gpkg.2">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>46.689323 -60.981038</gml:lowerCorner>
+        		<gml:upperCorner>46.689323 -60.981038</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id="popplace_gpkg.2.1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>46.689323 -60.981038</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>9</ms:POPPLACE_>
+        <ms:POPPLACE_I>1</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CAGYX</ms:UNIQUE_KEY>
+        <ms:NAME>&#39;Cheticamp</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>011K11</ms:NTS50>
+        <ms:LAT>463800</ms:LAT>
+        <ms:LONG>610100</ms:LONG>
+        <ms:SGC_CODE>1215011</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+        <ms:fid>2</ms:fid>
+      </ms:popplace_gpkg>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace_gpkg gml:id="popplace_gpkg.3">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>44.911800 -62.513078</gml:lowerCorner>
+        		<gml:upperCorner>44.911800 -62.513078</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id="popplace_gpkg.3.1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>44.911800 -62.513078</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>10</ms:POPPLACE_>
+        <ms:POPPLACE_I>1</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CBIKA</ms:UNIQUE_KEY>
+        <ms:NAME>Sheet Harbour</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>011D15</ms:NTS50>
+        <ms:LAT>445500</ms:LAT>
+        <ms:LONG>623200</ms:LONG>
+        <ms:SGC_CODE>1209036</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+        <ms:fid>3</ms:fid>
+      </ms:popplace_gpkg>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace_gpkg gml:id="popplace_gpkg.4">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>46.373272 -62.272430</gml:lowerCorner>
+        		<gml:upperCorner>46.373272 -62.272430</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id="popplace_gpkg.4.1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>46.373272 -62.272430</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>109</ms:POPPLACE_>
+        <ms:POPPLACE_I>2</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>BACII</ms:UNIQUE_KEY>
+        <ms:NAME>&#39;Souris&#39;</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>11</ms:REG_CODE>
+        <ms:NTS50>011L08</ms:NTS50>
+        <ms:LAT>462100</ms:LAT>
+        <ms:LONG>621500</ms:LONG>
+        <ms:SGC_CODE>1101036</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+        <ms:fid>4</ms:fid>
+      </ms:popplace_gpkg>
+    </wfs:member>
+    <wfs:member>
+      <ms:popplace_gpkg gml:id="popplace_gpkg.5">
+        <gml:boundedBy>
+        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
+        		<gml:lowerCorner>45.311286 -61.038743</gml:lowerCorner>
+        		<gml:upperCorner>45.311286 -61.038743</gml:upperCorner>
+        	</gml:Envelope>
+        </gml:boundedBy>
+        <ms:msGeometry>
+          <gml:Point gml:id="popplace_gpkg.5.1" srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>45.311286 -61.038743</gml:pos>
+          </gml:Point>
+        </ms:msGeometry>
+        <ms:AREA>0</ms:AREA>
+        <ms:PERIMETER>0</ms:PERIMETER>
+        <ms:POPPLACE_>110</ms:POPPLACE_>
+        <ms:POPPLACE_I>2</ms:POPPLACE_I>
+        <ms:UNIQUE_KEY>CAGBW</ms:UNIQUE_KEY>
+        <ms:NAME>&quot;Canso&quot;</ms:NAME>
+        <ms:NAME_E></ms:NAME_E>
+        <ms:NAME_F></ms:NAME_F>
+        <ms:UNIQUE_K_1></ms:UNIQUE_K_1>
+        <ms:UNIQUE_K_2></ms:UNIQUE_K_2>
+        <ms:REG_CODE>12</ms:REG_CODE>
+        <ms:NTS50>011F07</ms:NTS50>
+        <ms:LAT>452000</ms:LAT>
+        <ms:LONG>610000</ms:LONG>
+        <ms:SGC_CODE>1213006</ms:SGC_CODE>
+        <ms:CAPITAL>0</ms:CAPITAL>
+        <ms:POP_RANGE>2</ms:POP_RANGE>
+        <ms:fid>5</ms:fid>
+      </ms:popplace_gpkg>
+    </wfs:member>
+</wfs:FeatureCollection>
+

--- a/msautotest/wxs/expected/wfs_ogr_gpkg_expose_fid.xml
+++ b/msautotest/wxs/expected/wfs_ogr_gpkg_expose_fid.xml
@@ -1,0 +1,35 @@
+Content-Type: text/xml; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" ?>
+<wfs:FeatureCollection
+   xmlns:ms="http://mapserver.gis.umn.edu/mapserver"
+   xmlns:wfs="http://www.opengis.net/wfs"
+   xmlns:gml="http://www.opengis.net/gml"
+   xmlns:ogc="http://www.opengis.net/ogc"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.opengis.net/wfs http://schemas.opengis.net/wfs/1.0.0/WFS-basic.xsd 
+                       http://mapserver.gis.umn.edu/mapserver http://localhost/path/to/wfs_simple?SERVICE=WFS&amp;VERSION=1.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=test_expose_fid&amp;OUTPUTFORMAT=XMLSCHEMA">
+      <gml:boundedBy>
+      	<gml:Box srsName="EPSG:4326">
+      		<gml:coordinates>2.000000,49.000000 2.000000,49.000000</gml:coordinates>
+      	</gml:Box>
+      </gml:boundedBy>
+    <gml:featureMember>
+      <ms:test_expose_fid fid="test_expose_fid.1">
+        <gml:boundedBy>
+        	<gml:Box srsName="EPSG:4326">
+        		<gml:coordinates>2.000000,49.000000 2.000000,49.000000</gml:coordinates>
+        	</gml:Box>
+        </gml:boundedBy>
+        <ms:msGeometry>
+        <gml:Point srsName="EPSG:4326">
+          <gml:coordinates>2.000000,49.000000</gml:coordinates>
+        </gml:Point>
+        </ms:msGeometry>
+        <ms:id>1</ms:id>
+        <ms:name>some place in France</ms:name>
+        <ms:fid>1</ms:fid>
+      </ms:test_expose_fid>
+    </gml:featureMember>
+</wfs:FeatureCollection>
+

--- a/msautotest/wxs/wfs_200_fid.map
+++ b/msautotest/wxs/wfs_200_fid.map
@@ -1,0 +1,81 @@
+#
+# Test WFS 2.0 and FeatureId filtering
+#
+# REQUIRES: INPUT=OGR SUPPORTS=WFS
+#
+# Filter by FeatureId without OGR_EXPOSE_FID (native WFS FID filtering)
+# RUN_PARMS: wfs_filter_ogr_fid_native.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=popplace_gpkg_nofid&FILTER=<fes:Filter+xmlns:fes='http://www.opengis.net/fes/2.0'><fes:ResourceId+rid='popplace_gpkg_nofid.1'/></fes:Filter>" > [RESULT_DEVERSION]
+# RUN_PARMS: wfs_filter_ogr_fid_native_range.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=popplace_gpkg_nofid&FILTER=<fes:Filter+xmlns:fes='http://www.opengis.net/fes/2.0'><fes:ResourceId+rid='popplace_gpkg_nofid.1'/><fes:ResourceId+rid='popplace_gpkg_nofid.2'/><fes:ResourceId+rid='popplace_gpkg_nofid.3'/><fes:ResourceId+rid='popplace_gpkg_nofid.4'/><fes:ResourceId+rid='popplace_gpkg_nofid.5'/></fes:Filter>" > [RESULT_DEVERSION]
+# DescribeFeatureType for popplace_gpkg_nofid to verify fid is NOT exposed as a field
+# RUN_PARMS: wfs_filter_ogr_fid_native_describe.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAMES=popplace_gpkg_nofid" > [RESULT_DEVERSION]
+
+# Filter by FID using OGR_EXPOSE_FID
+# RUN_PARMS: wfs_filter_ogr_fid.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=popplace_gpkg&FILTER=<fes:Filter+xmlns:fes='http://www.opengis.net/fes/2.0'><fes:PropertyIsEqualTo><fes:ValueReference>fid</fes:ValueReference><fes:Literal>1</fes:Literal></fes:PropertyIsEqualTo></fes:Filter>" > [RESULT_DEVERSION]
+# RUN_PARMS: wfs_filter_ogr_fid_range.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=popplace_gpkg&FILTER=<fes:Filter+xmlns:fes='http://www.opengis.net/fes/2.0'><fes:PropertyIsBetween><fes:ValueReference>fid</fes:ValueReference><fes:LowerBoundary><fes:Literal>1</fes:Literal></fes:LowerBoundary><fes:UpperBoundary><fes:Literal>5</fes:Literal></fes:UpperBoundary></fes:PropertyIsBetween></fes:Filter>" > [RESULT_DEVERSION]
+# DescribeFeatureType for popplace_gpkg to verify fid is exposed as a field
+# RUN_PARMS: wfs_filter_ogr_fid_describe.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=2.0.0&REQUEST=DescribeFeatureType&TYPENAMES=popplace_gpkg" > [RESULT_DEVERSION]
+
+MAP
+  NAME WFS_FILTER
+  STATUS ON
+  SIZE 400 300
+  EXTENT -67.5725 42 -58.9275 48.5
+  UNITS DD
+  IMAGECOLOR 255 255 255
+  SHAPEPATH ./data
+
+  WEB
+
+   IMAGEPATH "/tmp/ms_tmp/"
+   IMAGEURL "/ms_tmp/"
+
+    METADATA
+      "wfs_title" "Test simple wfs"
+      "wfs_onlineresource"   "http://localhost/path/to/wfs_simple?"
+      "wfs_srs" "EPSG:4326 EPSG:4269"
+      "ows_enable_request" "*" 
+    END
+  END
+
+  PROJECTION
+    "init=epsg:4326"
+  END
+
+  LAYER
+    NAME popplace_gpkg_nofid
+    CONNECTIONTYPE OGR
+    CONNECTION "./data/popplace.gpkg"
+    METADATA
+      "wfs_title"         "popplace_gpkg_nofid"
+      "wfs_featureid"     "fid"
+      "wfs_description"   "Cities (GeoPackage without OGR_EXPOSE_FID)"
+      "gml_include_items" "all"
+      "gml_types"         "auto"
+    END
+    TYPE POINT
+    STATUS ON
+    PROJECTION
+      "epsg:3978"
+    END
+  END # Layer
+
+  LAYER
+    NAME popplace_gpkg
+    CONNECTIONTYPE OGR
+    CONNECTION "./data/popplace.gpkg"
+    PROCESSING "OGR_EXPOSE_FID=YES"
+    METADATA
+      "wfs_title"         "popplace_gpkg"
+      "wfs_description"   "Cities (GeoPackage with FID)"
+      "wfs_featureid"     "fid"
+      "gml_include_items" "all"
+      "gml_types"         "auto"
+    END
+    TYPE POINT
+    STATUS ON
+    PROJECTION
+      "epsg:3978"
+    END
+  END # Layer
+
+END # Map File

--- a/msautotest/wxs/wfs_ogr_gpkg.map
+++ b/msautotest/wxs/wfs_ogr_gpkg.map
@@ -24,6 +24,9 @@
 # PropertyIsNull
 # RUN_PARMS: wfs_ogr_gpkg_propertyisnull.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=test_6446&FILTER=<Filter><PropertyIsNull><PropertyName>fieldisnull</PropertyName></PropertyIsNull></Filter>" > [RESULT]
 #
+# OGR_EXPOSE_FID processing key
+# RUN_PARMS: wfs_ogr_gpkg_expose_fid.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=test_expose_fid&MAXFEATURES=1" > [RESULT]
+#
 
 MAP
 
@@ -127,6 +130,24 @@ LAYER
     "gml_include_items" "all"
     "gml_types"         "auto"
     "wfs_use_default_extent_for_getfeature" "no"
+  END
+  TYPE POINT
+  STATUS ON
+  PROJECTION
+    "init=epsg:4326"
+  END
+END # Layer
+
+LAYER
+  NAME "test_expose_fid"
+  CONNECTIONTYPE OGR
+  CONNECTION "./data/test.gpkg"
+  PROCESSING "OGR_EXPOSE_FID=YES"
+  METADATA
+    "ows_title"         "test_expose_fid"
+    "wfs_featureid"     "fid"
+    "gml_include_items" "all"
+    "gml_types"         "auto"
   END
   TYPE POINT
   STATUS ON

--- a/src/mapgml.c
+++ b/src/mapgml.c
@@ -2408,7 +2408,7 @@ gmlItemListObj *msGMLGetItems(layerObj *layer,
                                    "default_items")) != NULL)
     defaultitems = msStringSplit(value, ',', &numdefaultitems);
 
-  /* allocate memory and iinitialize the item collection */
+  /* allocate memory and initialize the item collection */
   itemList = (gmlItemListObj *)malloc(sizeof(gmlItemListObj));
   if (itemList == NULL) {
     msSetError(MS_MEMERR, "Error allocating a collection GML item structures.",

--- a/src/mapogcfilter.cpp
+++ b/src/mapogcfilter.cpp
@@ -598,7 +598,7 @@ FilterEncodingNode *FLTParseFilterEncoding(const char *szXMLString) {
   if (psRoot == NULL)
     return NULL;
 
-  /* strip namespaces. We srtip all name spaces (#1350)*/
+  /* strip namespaces. We strip all name spaces (#1350)*/
   CPLStripXMLNamespace(psRoot, NULL, 1);
 
   /* -------------------------------------------------------------------- */

--- a/src/mapogr.cpp
+++ b/src/mapogr.cpp
@@ -2681,7 +2681,7 @@ static void msOGRPassThroughFieldDefinitions(layerObj *layer,
   if (exposeFID != NULL && CSLTestBoolean(exposeFID)) {
     const char *fidColumn = OGR_L_GetFIDColumn(psInfo->hLayer);
     if (fidColumn != NULL && fidColumn[0] != '\0')
-      +msUpdateGMLFieldMetadata(layer, fidColumn, "Long", "", "", 0);
+      msUpdateGMLFieldMetadata(layer, fidColumn, "Long", "", "", 0);
   }
 
   /* Should we try to address style items, or other special items? */

--- a/src/mapogr.cpp
+++ b/src/mapogr.cpp
@@ -2709,7 +2709,7 @@ static char **msOGRFileGetItems(layerObj *layer, msOGRFileInfo *psInfo) {
   const char *fidColumn = OGR_L_GetFIDColumn(psInfo->hLayer);
   const char *exposeFID = msLayerGetProcessingKey(layer, "OGR_EXPOSE_FID");
   const bool hasFID = (fidColumn != NULL && fidColumn[0] != '\0') &&
-               (exposeFID != NULL && CSLTestBoolean(exposeFID));
+                      (exposeFID != NULL && CSLTestBoolean(exposeFID));
 
   totalnumitems = numitems = OGR_FD_GetFieldCount(hDefn);
 

--- a/src/mapogr.cpp
+++ b/src/mapogr.cpp
@@ -2676,6 +2676,12 @@ static void msOGRPassThroughFieldDefinitions(layerObj *layer,
                              0);
   }
 
+  // FID columns in OGR are 64-bit integers so set type to Long
+  const char *fidColumn = OGR_L_GetFIDColumn(psInfo->hLayer);
+  if (fidColumn != NULL && fidColumn[0] != '\0') {
+    msUpdateGMLFieldMetadata(layer, fidColumn, "Long", "", "", 0);
+  }
+
   /* Should we try to address style items, or other special items? */
 }
 
@@ -2698,7 +2704,14 @@ static char **msOGRFileGetItems(layerObj *layer, msOGRFileInfo *psInfo) {
     return NULL;
   }
 
+  const char *fidColumn = OGR_L_GetFIDColumn(psInfo->hLayer);
+  int hasFID = (fidColumn != NULL && fidColumn[0] != '\0');
+
   totalnumitems = numitems = OGR_FD_GetFieldCount(hDefn);
+
+  if (hasFID) {
+    totalnumitems++;
+  }
 
   getShapeStyleItems = msLayerGetProcessingKey(layer, "GETSHAPE_STYLE_ITEMS");
   if (getShapeStyleItems && EQUAL(getShapeStyleItems, "all"))
@@ -2712,6 +2725,10 @@ static char **msOGRFileGetItems(layerObj *layer, msOGRFileInfo *psInfo) {
   for (i = 0; i < numitems; i++) {
     OGRFieldDefnH hField = OGR_FD_GetFieldDefn(hDefn, i);
     items[i] = msStrdup(OGR_Fld_GetNameRef(hField));
+  }
+
+  if (hasFID) {
+    items[i++] = msStrdup(fidColumn);
   }
 
   if (getShapeStyleItems && EQUAL(getShapeStyleItems, "all")) {

--- a/src/mapogr.cpp
+++ b/src/mapogr.cpp
@@ -2677,9 +2677,11 @@ static void msOGRPassThroughFieldDefinitions(layerObj *layer,
   }
 
   // FID columns in OGR are 64-bit integers so set type to Long
-  const char *fidColumn = OGR_L_GetFIDColumn(psInfo->hLayer);
-  if (fidColumn != NULL && fidColumn[0] != '\0') {
-    msUpdateGMLFieldMetadata(layer, fidColumn, "Long", "", "", 0);
+  const char *exposeFID = msLayerGetProcessingKey(layer, "OGR_EXPOSE_FID");
+  if (exposeFID != NULL && CSLTestBoolean(exposeFID)) {
+    const char *fidColumn = OGR_L_GetFIDColumn(psInfo->hLayer);
+    if (fidColumn != NULL && fidColumn[0] != '\0')
+      +msUpdateGMLFieldMetadata(layer, fidColumn, "Long", "", "", 0);
   }
 
   /* Should we try to address style items, or other special items? */
@@ -2705,7 +2707,9 @@ static char **msOGRFileGetItems(layerObj *layer, msOGRFileInfo *psInfo) {
   }
 
   const char *fidColumn = OGR_L_GetFIDColumn(psInfo->hLayer);
-  int hasFID = (fidColumn != NULL && fidColumn[0] != '\0');
+  const char *exposeFID = msLayerGetProcessingKey(layer, "OGR_EXPOSE_FID");
+  int hasFID = (fidColumn != NULL && fidColumn[0] != '\0') &&
+               (exposeFID != NULL && CSLTestBoolean(exposeFID));
 
   totalnumitems = numitems = OGR_FD_GetFieldCount(hDefn);
 

--- a/src/mapogr.cpp
+++ b/src/mapogr.cpp
@@ -2708,7 +2708,7 @@ static char **msOGRFileGetItems(layerObj *layer, msOGRFileInfo *psInfo) {
 
   const char *fidColumn = OGR_L_GetFIDColumn(psInfo->hLayer);
   const char *exposeFID = msLayerGetProcessingKey(layer, "OGR_EXPOSE_FID");
-  int hasFID = (fidColumn != NULL && fidColumn[0] != '\0') &&
+  const bool hasFID = (fidColumn != NULL && fidColumn[0] != '\0') &&
                (exposeFID != NULL && CSLTestBoolean(exposeFID));
 
   totalnumitems = numitems = OGR_FD_GetFieldCount(hDefn);


### PR DESCRIPTION
Both GDAL and QGIS show the FID column when opening through GDAL. For example the *fid* column below:

```bash
gdal info .\buildings.gpkg
INFO: Open of `.\buildings.gpkg'
      using driver `GPKG' successful.
Layer name: buildings
Geometry: Multi Polygon
...
FID Column = fid
Geometry Column = geom
osm_id: String (0.0)
name: String (0.0)
building: String (0.0)
```

MapServer however does not make this field available as an attribute. For example:

```
LAYER
  NAME "buildings"
  # interestingly adding fid below also makes the field available, but the "all" option cannot then be used
  # PROCESSING "ITEMS=fid,building"
  # new PROCESSING  keyword added in this pull request
  PROCESSING "OGR_EXPOSE_FID=TRUE"
  CONNECTIONTYPE OGR
  CONNECTION "data/osm/timisoara/buildings.gpkg"
  METADATA
    "ows_title" "Buildings"
    "gml_include_items" "all"
    "gml_featureid" "fid"
    "gml_types" "auto"
    "oga_queryable_items" "all"
END
```

Without the changes in this pull request a query such as http://localhost:7000//timisoara/ogcapi/collections/buildings/items?f=json

will return the following error (as `"gml_featureid" "fid"` is not found):

```
{"code":"ServerError","description":"Error getting feature. Feature id not found."}
```

With the new `PROCESSING "OGR_EXPOSE_FID=TRUE"` the FID is now available, and can be used as the unique Id field, as labels, expressions etc. 

I'm not a fan of adding more and more processing keywords, but adding the FID by default breaks 100s of tests, and therefore possibly live MapServer deployments. 

As I understand it FID columns in OGR are always 64-bit integers, so "Long" can be set as the default type. 

I had a look through the code and I don't think there is an existing way to add these feature Ids so they are available to MapServer  apart from manually adding the field name in `PROCESSING "ITEMS=fid,building"` as shown in the example above. 


