### PR TITLE
CQL2: reject invalid characters in timestamp/date values (master only)

### DIFF
--- a/msautotest/api/expected/ogcapi_cql2_json_timestamp_with_backtick.json.txt
+++ b/msautotest/api/expected/ogcapi_cql2_json_timestamp_with_backtick.json.txt
@@ -1,0 +1,4 @@
+Content-Type: application/json
+Status: 400
+
+{"code":"InvalidParameterValue","description":"Cannot translate CQL2 filter to MapServer expression: Invalid characters in TIMESTAMP() argument"}

--- a/msautotest/api/ogcapi.map
+++ b/msautotest/api/ogcapi.map
@@ -152,6 +152,7 @@
 
 # RUN_PARMS: ogcapi_cql2_json_timestamp.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" 'QUERY_STRING=f=json&filter={"op":"=","args":[{"property":"LASTMOD"},{"timestamp":"2003-01-01T01:10:00Z"}]}&filter-lang=cql2-json' > [RESULT]
 # RUN_PARMS: ogcapi_cql2_json_date.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" 'QUERY_STRING=f=json&filter={"op":"=","args":[{"property":"LASTMOD"},{"date":"2003-01-01"}]}&filter-lang=cql2-json' > [RESULT]
+# RUN_PARMS: ogcapi_cql2_json_timestamp_with_backtick.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" 'QUERY_STRING=f=json&filter={"op":"=","args":[{"property":"LASTMOD"},{"timestamp":"with`backtick"}]}&filter-lang=cql2-json' > [RESULT]
 
 # RUN_PARMS: ogcapi_cql2_json_s_intersects_bbox.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" 'QUERY_STRING=f=json&filter={"op":"s_intersects","args":[{"property":"geom"},{"bbox":[-180,-90,180,90]}]}&filter-lang=cql2-json&limit=1' > [RESULT]
 # RUN_PARMS: ogcapi_cql2_json_s_intersects_bbox_3D.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" 'QUERY_STRING=f=json&filter={"op":"s_intersects","args":[{"property":"geom"},{"bbox":[-90,-180,-1000,90,180,1000]}]}&filter-lang=cql2-json&filter-crs=http://www.opengis.net/def/crs/EPSG/0/4326&limit=1' > [RESULT]

--- a/src/cql2.cpp
+++ b/src/cql2.cpp
@@ -602,9 +602,13 @@ std::string cql2_expr_node::ToMapServerFilter(
       if (m_osVal == "TIMESTAMP" || m_osVal == "DATE") {
         if (m_apoChildren.size() == 1 &&
             m_apoChildren[0]->m_field_type == CQL2_STRING) {
-          return std::string("`")
-              .append(msStdStringEscape(m_apoChildren[0]->m_osVal.c_str()))
-              .append("`");
+          const std::string &val = m_apoChildren[0]->m_osVal;
+          // Reject anything that isn't a valid RFC 3339 timestamp/date
+          if (val.find_first_of("`'\"\\") != std::string::npos) {
+            errorMsg = "Invalid characters in " + m_osVal + "() argument";
+            break;
+          }
+          return std::string("`").append(val).append("`");
         } else {
           errorMsg = "Unhandled syntax for function ";
           errorMsg += m_osVal;


### PR DESCRIPTION
that could cause later SQL injections.

Fixes https://github.com/MapServer/MapServer/security/advisories/GHSA-v8f6-9cpv-p7jv