### PR TITLE
Bug: Fix memory leak on param handling

### DIFF
--- a/msautotest/wxs/wcs_simple.map
+++ b/msautotest/wxs/wcs_simple.map
@@ -23,7 +23,8 @@
 #
 # Capabilities 1.0.0
 # RUN_PARMS: wcs_cap.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=1.0.0&REQUEST=GetCapabilities" > [RESULT_DEVERSION] [RESULT_DEMIME]
-# RUN_PARMS: wcs_cap.txt [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=1.0.0&REQUEST=GetCapabilities" > [RESULT_DEVERSION] [RESULT]
+# Also test duplicated parameter not to cause memory leak
+# RUN_PARMS: wcs_cap.txt [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=1.0.0&VERSION=1.0.0&REQUEST=GetCapabilities" > [RESULT_DEVERSION] [RESULT]
 #
 # RUN_PARMS: wcs10_caps_section_error.txt [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=1.0.0&REQUEST=GetCapabilities&SECTION=error" > [RESULT]
 #

--- a/src/mapwcs.cpp
+++ b/src/mapwcs.cpp
@@ -357,6 +357,23 @@ void msWCSSetDefaultBandsRangeSetInfo(wcsParamsObj *params,
 }
 
 /************************************************************************/
+/*                             msWCSSetParam                            */
+/************************************************************************/
+
+static int msWCSSetParam(char **ppszOut, cgiRequestObj *request, int i,
+                         const char *pszExpectedParamName) {
+  if (strcasecmp(request->ParamNames[i], pszExpectedParamName) == 0) {
+    /* Keep the first value supplied and ignore later duplicates. This avoids
+       leaking the previously allocated value when the same parameter appears
+       multiple times in a request (consistent with msWFSSetParam()). */
+    if (*ppszOut == NULL)
+      *ppszOut = msStrdup(request->ParamValues[i]);
+    return 1;
+  }
+  return 0;
+}
+
+/************************************************************************/
 /*                         msWCSParseRequest()                          */
 /************************************************************************/
 
@@ -540,31 +557,19 @@ static int msWCSParseRequest(cgiRequestObj *request, wcsParamsObj *params,
   if (request->NumParams > 0) {
     for (i = 0; i < request->NumParams; i++) {
 
-      if (strcasecmp(request->ParamNames[i], "VERSION") == 0) {
-        msFree(params->version);
-        params->version = msStrdup(request->ParamValues[i]);
-      }
-      if (strcasecmp(request->ParamNames[i], "UPDATESEQUENCE") == 0) {
-        msFree(params->updatesequence);
-        params->updatesequence = msStrdup(request->ParamValues[i]);
-      } else if (strcasecmp(request->ParamNames[i], "REQUEST") == 0) {
-        msFree(params->request);
-        params->request = msStrdup(request->ParamValues[i]);
-      } else if (strcasecmp(request->ParamNames[i], "INTERPOLATION") == 0) {
-        msFree(params->interpolation);
-        params->interpolation = msStrdup(request->ParamValues[i]);
-      } else if (strcasecmp(request->ParamNames[i], "SERVICE") == 0) {
-        msFree(params->service);
-        params->service = msStrdup(request->ParamValues[i]);
-      } else if (strcasecmp(request->ParamNames[i], "SECTION") == 0) { /* 1.0 */
-        msFree(params->section);
-        params->section =
-            msStrdup(request->ParamValues[i]); /* TODO: validate value here */
-      } else if (strcasecmp(request->ParamNames[i], "SECTIONS") ==
-                 0) { /* 1.1 */
-        msFree(params->section);
-        params->section =
-            msStrdup(request->ParamValues[i]); /* TODO: validate value here */
+      if (msWCSSetParam(&(params->version), request, i, "VERSION")) {
+      } else if (msWCSSetParam(&(params->updatesequence), request, i,
+                               "UPDATESEQUENCE")) {
+      } else if (msWCSSetParam(&(params->request), request, i, "REQUEST")) {
+      } else if (msWCSSetParam(&(params->interpolation), request, i,
+                               "INTERPOLATION")) {
+      } else if (msWCSSetParam(&(params->service), request, i, "SERVICE")) {
+      } else if (msWCSSetParam(&(params->section), request, i,
+                               "SECTION")) { /* 1.0 */
+        /* TODO: validate value here */
+      } else if (msWCSSetParam(&(params->section), request, i,
+                               "SECTIONS")) { /* 1.1 */
+        /* TODO: validate value here */
       }
 
       /* GetCoverage parameters. */
@@ -593,18 +598,11 @@ static int msWCSParseRequest(cgiRequestObj *request, wcsParamsObj *params,
       else if (strcasecmp(request->ParamNames[i], "COVERAGE") == 0)
         params->coverages =
             CSLAddString(params->coverages, request->ParamValues[i]);
-      else if (strcasecmp(request->ParamNames[i], "TIME") == 0) {
-        msFree(params->time);
-        params->time = msStrdup(request->ParamValues[i]);
-      } else if (strcasecmp(request->ParamNames[i], "FORMAT") == 0) {
-        msFree(params->format);
-        params->format = msStrdup(request->ParamValues[i]);
-      } else if (strcasecmp(request->ParamNames[i], "CRS") == 0) {
-        msFree(params->crs);
-        params->crs = msStrdup(request->ParamValues[i]);
-      } else if (strcasecmp(request->ParamNames[i], "RESPONSE_CRS") == 0) {
-        msFree(params->response_crs);
-        params->response_crs = msStrdup(request->ParamValues[i]);
+      else if (msWCSSetParam(&(params->time), request, i, "TIME")) {
+      } else if (msWCSSetParam(&(params->format), request, i, "FORMAT")) {
+      } else if (msWCSSetParam(&(params->crs), request, i, "CRS")) {
+      } else if (msWCSSetParam(&(params->response_crs), request, i,
+                               "RESPONSE_CRS")) {
       }
 
       /* WCS 1.1 DescribeCoverage and GetCoverage ... */
@@ -633,6 +631,7 @@ static int msWCSParseRequest(cgiRequestObj *request, wcsParamsObj *params,
         params->bbox.maxx = atof(tokens[2]);
         params->bbox.maxy = atof(tokens[3]);
 
+        msFree(params->crs);
         params->crs = msStrdup(tokens[4]);
         msFreeCharArray(tokens, n);
         /* normalize imageCRS urns to simply "imageCRS" */

--- a/src/mapwcs.cpp
+++ b/src/mapwcs.cpp
@@ -560,7 +560,8 @@ static int msWCSParseRequest(cgiRequestObj *request, wcsParamsObj *params,
         msFree(params->section);
         params->section =
             msStrdup(request->ParamValues[i]); /* TODO: validate value here */
-      } else if (strcasecmp(request->ParamNames[i], "SECTIONS") == 0) { /* 1.1 */
+      } else if (strcasecmp(request->ParamNames[i], "SECTIONS") ==
+                 0) { /* 1.1 */
         msFree(params->section);
         params->section =
             msStrdup(request->ParamValues[i]); /* TODO: validate value here */

--- a/src/mapwcs.cpp
+++ b/src/mapwcs.cpp
@@ -540,22 +540,31 @@ static int msWCSParseRequest(cgiRequestObj *request, wcsParamsObj *params,
   if (request->NumParams > 0) {
     for (i = 0; i < request->NumParams; i++) {
 
-      if (strcasecmp(request->ParamNames[i], "VERSION") == 0)
+      if (strcasecmp(request->ParamNames[i], "VERSION") == 0) {
+        msFree(params->version);
         params->version = msStrdup(request->ParamValues[i]);
-      if (strcasecmp(request->ParamNames[i], "UPDATESEQUENCE") == 0)
+      }
+      if (strcasecmp(request->ParamNames[i], "UPDATESEQUENCE") == 0) {
+        msFree(params->updatesequence);
         params->updatesequence = msStrdup(request->ParamValues[i]);
-      else if (strcasecmp(request->ParamNames[i], "REQUEST") == 0)
+      } else if (strcasecmp(request->ParamNames[i], "REQUEST") == 0) {
+        msFree(params->request);
         params->request = msStrdup(request->ParamValues[i]);
-      else if (strcasecmp(request->ParamNames[i], "INTERPOLATION") == 0)
+      } else if (strcasecmp(request->ParamNames[i], "INTERPOLATION") == 0) {
+        msFree(params->interpolation);
         params->interpolation = msStrdup(request->ParamValues[i]);
-      else if (strcasecmp(request->ParamNames[i], "SERVICE") == 0)
+      } else if (strcasecmp(request->ParamNames[i], "SERVICE") == 0) {
+        msFree(params->service);
         params->service = msStrdup(request->ParamValues[i]);
-      else if (strcasecmp(request->ParamNames[i], "SECTION") == 0) /* 1.0 */
+      } else if (strcasecmp(request->ParamNames[i], "SECTION") == 0) { /* 1.0 */
+        msFree(params->section);
         params->section =
             msStrdup(request->ParamValues[i]); /* TODO: validate value here */
-      else if (strcasecmp(request->ParamNames[i], "SECTIONS") == 0) /* 1.1 */
+      } else if (strcasecmp(request->ParamNames[i], "SECTIONS") == 0) { /* 1.1 */
+        msFree(params->section);
         params->section =
             msStrdup(request->ParamValues[i]); /* TODO: validate value here */
+      }
 
       /* GetCoverage parameters. */
       else if (strcasecmp(request->ParamNames[i], "BBOX") == 0) {
@@ -583,14 +592,19 @@ static int msWCSParseRequest(cgiRequestObj *request, wcsParamsObj *params,
       else if (strcasecmp(request->ParamNames[i], "COVERAGE") == 0)
         params->coverages =
             CSLAddString(params->coverages, request->ParamValues[i]);
-      else if (strcasecmp(request->ParamNames[i], "TIME") == 0)
+      else if (strcasecmp(request->ParamNames[i], "TIME") == 0) {
+        msFree(params->time);
         params->time = msStrdup(request->ParamValues[i]);
-      else if (strcasecmp(request->ParamNames[i], "FORMAT") == 0)
+      } else if (strcasecmp(request->ParamNames[i], "FORMAT") == 0) {
+        msFree(params->format);
         params->format = msStrdup(request->ParamValues[i]);
-      else if (strcasecmp(request->ParamNames[i], "CRS") == 0)
+      } else if (strcasecmp(request->ParamNames[i], "CRS") == 0) {
+        msFree(params->crs);
         params->crs = msStrdup(request->ParamValues[i]);
-      else if (strcasecmp(request->ParamNames[i], "RESPONSE_CRS") == 0)
+      } else if (strcasecmp(request->ParamNames[i], "RESPONSE_CRS") == 0) {
+        msFree(params->response_crs);
         params->response_crs = msStrdup(request->ParamValues[i]);
+      }
 
       /* WCS 1.1 DescribeCoverage and GetCoverage ... */
       else if (strcasecmp(request->ParamNames[i], "IDENTIFIER") == 0 ||


### PR DESCRIPTION
When a parameter is matched, its value is duplicated and stored in the param object, overwriting any existing value without first freeing the previously allocated pointer. This causes a direct memory leak whenever the same parameter name appears more than once in a request.

This PR fixes the leak by always clearing the target pointer before assigning the new value during each parameter's processing. The change is safe even for null pointers, as msFree() accepts a null pointer and is a no-op in that case.

This memory leak is discovered by the new fuzzer introduced in #7525.