### PR TITLE
WMS OpenLayers output: escape angle brackets in mapserv_onlineresource

### DIFF
--- a/msautotest/pymod/mstestlib.py
+++ b/msautotest/pymod/mstestlib.py
@@ -607,19 +607,19 @@ def _run(map, out_file, command, extra_args):
 
     os.environ["MS_PDF_CREATION_DATE"] = "dummy date"
 
-    # support for environment variable of type [ENV foo=bar]
-    begin = command.find("[ENV")
-    envirkey = ""
-    if begin != -1:
-        end = command[begin:].find("]")
-        equal = command[begin:].find("=")
-        # print("equal is %d"%equal)
-        envirkey = command[begin + len("[ENV ") : begin + equal]
+    # support for environment variables of type [ENV foo=bar] (repeatable)
+    envir_keys = []
+    while True:
+        begin = command.find("[ENV ")
+        if begin == -1:
+            break
+        end = command.find("]", begin)
+        equal = command.find("=", begin)
+        envirkey = command[begin + len("[ENV ") : equal]
         envirval = command[equal + 1 : end]
         os.environ[envirkey] = envirval
-        tmp = command
-        command = tmp[:begin] + tmp[end + 1 :]
-        # print('added environment variable (%s)=(%s); new command:%s' % (envirkey,envirval,command))
+        envir_keys.append(envirkey)
+        command = command[:begin] + command[end + 1 :]
 
     # support for POST request method
     begin = command.find("[POST]")
@@ -688,7 +688,7 @@ def _run(map, out_file, command, extra_args):
         del os.environ["REQUEST_METHOD"]
         del os.environ["MS_MAPFILE"]
 
-    if envirkey != "":
+    for envirkey in envir_keys:
         del os.environ[envirkey]
 
     if demime:

--- a/msautotest/wxs/expected/wms_openlayers_xss.txt
+++ b/msautotest/wxs/expected/wms_openlayers_xss.txt
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MapServer Simple Viewer</title>
+    <link rel="stylesheet" href="//mapserver.org/lib/10.5.0/ol-mapserver.css">
+    <link rel="shortcut icon" type="image/x-icon" href="//mapserver.org/_static/mapserver.ico" />
+    <style>
+        #map {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+        }
+    </style>
+</head>
+<body>
+    <div id="map"></div>
+    <script src="//mapserver.org/lib/10.5.0/ol-mapserver.js"></script>
+    <script>
+        if (!ol.proj.get('EPSG:4326')) {
+            ol.proj.addProjection(new ol.proj.Projection({ code: 'EPSG:4326' }));
+        }
+        const mslayer = new ol.layer.Image({
+            source: new ol.source.Image({
+                loader: ol.source.wms.createLoader({
+                    url: 'http://\u003c/script\u003e\u003cscript\u003ealert(document.domain)\u003c/script\u003e/mapserv?map=',
+                    params: {
+                        LAYERS: 'road',
+                        VERSION: '1.1.0',
+                        FORMAT: 'image/png'
+                    },
+                    projection: 'EPSG:4326',
+                    ratio: 1
+                })
+            })
+        });
+        const map = new ol.Map({
+            layers: [mslayer],
+            target: 'map',
+            view: new ol.View({
+                projection: 'EPSG:4326',
+                minResolution: 3.20978e-08,
+                maxResolution: 0.033657
+            })
+        });
+        map.getView().fit([-67.558092, 42.382704, -58.941908, 48.115596], { size: map.getSize() });
+    </script>
+</body>
+</html>

--- a/msautotest/wxs/wms_openlayers_xss.map
+++ b/msautotest/wxs/wms_openlayers_xss.map
@@ -1,0 +1,53 @@
+#
+# Test that the OpenLayers GetMap output (FORMAT=application/openlayers) does
+# not let a request-controlled header break out of the <script> block.
+# See https://github.com/MapServer/MapServer/security/advisories/GHSA-xqj6-vjqr-33vv
+#
+# The mapserv_onlineresource is built from X-Forwarded-Host / SCRIPT_NAME /
+# SERVER_PORT and inlined in a single-quoted JS string. A '</script>' in the
+# header must be neutralized (encoded as </>), otherwise it closes
+# the script element at the HTML parsing layer and runs attacker JavaScript.
+#
+# RUN_PARMS: wms_openlayers_xss.txt [MAPSERV] [ENV HTTP_X_FORWARDED_HOST=</script><script>alert(document.domain)</script>] [ENV SCRIPT_NAME=/mapserv] [ENV SERVER_PORT=80] -conf ../etc/mapserv.conf QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.1.0&REQUEST=GetMap&SRS=EPSG:4326&BBOX=-67.5725,42.3683,-58.9275,48.13&FORMAT=application/openlayers&WIDTH=300&HEIGHT=200&STYLES=&LAYERS=road" > [RESULT_DEMIME]
+
+MAP
+
+NAME WMS_OPENLAYERS_XSS_TEST
+STATUS ON
+SIZE 400 300
+EXTENT -67.5725 42 -58.9275 48.5
+UNITS DD
+IMAGECOLOR 255 255 255
+
+PROJECTION
+  "init=epsg:4326"
+END
+
+OUTPUTFORMAT
+  NAME png
+  DRIVER "AGG/PNG8"
+  MIMETYPE "image/png"
+  EXTENSION "png"
+END
+
+WEB
+  METADATA
+    "wms_title"          "test"
+    "wms_srs"            "EPSG:4326"
+    "ows_enable_request" "*"
+  END
+END
+
+LAYER
+  NAME road
+  TYPE LINE
+  STATUS ON
+  PROJECTION
+    "init=epsg:4326"
+  END
+  METADATA
+    "wms_title" "road"
+  END
+END
+
+END # Map File

--- a/src/maptemplate.c
+++ b/src/maptemplate.c
@@ -4106,7 +4106,13 @@ static char *processLine(mapservObj *mapserv, const char *instr, FILE *stream,
     if (strstr(outstr, "'[mapserv_onlineresource]'")) {
       // Fix
       // https://github.com/MapServer/MapServer/security/advisories/GHSA-xqj6-vjqr-33vv
+      // The value is inside a single-quoted JS string in a <script> element.
+      // Escaping the quote is not enough: a literal "</script>" in the value
+      // still closes the element. Encode '<' and '>' as JS unicode escapes so
+      // they cannot break out of the script block.
       char *pszEscaped = msEscapeJSonLikeString(ol, '\'');
+      pszEscaped = msReplaceSubstring(pszEscaped, "<", "\\u003c");
+      pszEscaped = msReplaceSubstring(pszEscaped, ">", "\\u003e");
       const size_t nLen = 1 + strlen(pszEscaped) + 1 + 1;
       char *pszEscapedWithSingleQuotes = (char *)msSmallMalloc(nLen);
       snprintf(pszEscapedWithSingleQuotes, nLen, "'%s'", pszEscaped);


### PR DESCRIPTION
GHSA-52rr-p4x5-2x6x：

The OpenLayers GetMap page (FORMAT=application/openlayers) inlines mapserv_onlineresource into a single-quoted JS string inside a <script> element. The fix for GHSA-xqj6-vjqr-33vv (edc1033) escaped only the JS single-quote, so a literal </script> in a request-controlled value (e.g. X-Forwarded-Host) still closes the script element at the HTML-parsing layer.

This encodes < and > as \u003c / \u003e after the existing JSON-string escaping, so the value cannot break out of the script block.

Adds an msautotest case (wxs/wms_openlayers_xss.map) that drives the OpenLayers output with a </script>-bearing X-Forwarded-Host and asserts the brackets come out encoded. Also extends mstestlib.py so a test can set multiple [ENV ...] variables.