### PR TITLE
bound quadtree shape ids to the shapefile record count

### DIFF
--- a/src/maptree.c
+++ b/src/maptree.c
@@ -380,7 +380,7 @@ static int treeAddShapeId(treeObj *tree, int id, rectObj rect) {
   return (treeNodeAddShapeId(tree->root, id, rect, tree->maxdepth));
 }
 
-static void treeCollectShapeIds(treeNodeObj *node, rectObj aoi,
+static void treeCollectShapeIds(treeNodeObj *node, rectObj aoi, int numshapes,
                                 ms_bitarray status) {
   int i;
 
@@ -395,14 +395,15 @@ static void treeCollectShapeIds(treeNodeObj *node, rectObj aoi,
   /*      Add the local nodes shapeids to the list.                       */
   /* -------------------------------------------------------------------- */
   for (i = 0; i < node->numshapes; i++)
-    msSetBit(status, node->ids[i], 1);
+    if (node->ids[i] >= 0 && node->ids[i] < numshapes)
+      msSetBit(status, node->ids[i], 1);
 
   /* -------------------------------------------------------------------- */
   /*      Recurse to subnodes if they exist.                              */
   /* -------------------------------------------------------------------- */
   for (i = 0; i < node->numsubnodes; i++) {
     if (node->subnode[i])
-      treeCollectShapeIds(node->subnode[i], aoi, status);
+      treeCollectShapeIds(node->subnode[i], aoi, numshapes, status);
   }
 }
 
@@ -415,7 +416,7 @@ ms_bitarray msSearchTree(const treeObj *tree, rectObj aoi) {
     return (NULL);
   }
 
-  treeCollectShapeIds(tree->root, aoi, status);
+  treeCollectShapeIds(tree->root, aoi, tree->numshapes, status);
 
   return (status);
 }
@@ -507,11 +508,13 @@ static void searchDiskTreeNode(SHPTreeHandle disktree, rectObj aoi,
     if (disktree->needswap) {
       for (i = 0; i < numshapes; i++) {
         SwapWord(4, &ids[i]);
-        msSetBit(status, ids[i], 1);
+        if (ids[i] >= 0 && ids[i] < disktree->nShapes)
+          msSetBit(status, ids[i], 1);
       }
     } else {
       for (i = 0; i < numshapes; i++)
-        msSetBit(status, ids[i], 1);
+        if (ids[i] >= 0 && ids[i] < disktree->nShapes)
+          msSetBit(status, ids[i], 1);
     }
     free(ids);
     ids = NULL;


### PR DESCRIPTION
searchDiskTreeNode() in maptree.c reads the shape ids for each node straight from the .qix spatial index and passes them to msSetBit(status, ids[i], 1). The only check on that data is that the per-node count stays in 0..INT_MAX/4; the id values themselves are never compared against nShapes. status is a bitarray sized to the shapefile record count, and msSetBit does array[index/32] |= ... with no bound, so a .qix whose nShapes matches the real shapefile but whose node ids exceed it writes bits at an attacker-chosen offset past the allocation. This is reached from msSearchDiskTree() during a spatial query.

Clamp each id to 0..nShapes before the msSetBit call at both consumer sites (the disk search and the in-memory treeCollectShapeIds path fed by readTreeNode). Keeping the guard next to the write matches how the ids enter, and skipping an out-of-range id mirrors treating the record as corrupt rather than trusting the index blindly.