### PR TITLE
AGG: avoid Bezier subdivision hang on non-finite points (fixes #7310)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1234,4 +1234,7 @@ if(BUILD_DYNAMIC AND BUILD_TESTING)
     add_executable(unit_test tests/unit/test.cpp)
     target_link_libraries(unit_test PRIVATE mapserver)
     add_test(NAME unit_test COMMAND unit_test)
+    # Bounds the recursion-regression case (testAggCurvesNonFiniteControlPoints),
+    # which would otherwise spin if the guard in agg_curves.cpp is removed.
+    set_tests_properties(unit_test PROPERTIES TIMEOUT 60)
 endif()

--- a/src/renderers/agg/src/agg_curves.cpp
+++ b/src/renderers/agg/src/agg_curves.cpp
@@ -137,12 +137,21 @@ namespace mapserver
     }
 
     //------------------------------------------------------------------------
-    void curve3_div::recursive_bezier(double x1, double y1, 
-                                      double x2, double y2, 
+    void curve3_div::recursive_bezier(double x1, double y1,
+                                      double x2, double y2,
                                       double x3, double y3,
                                       unsigned level)
     {
-        if(level > curve_recursion_limit) 
+        if(level > curve_recursion_limit)
+        {
+            return;
+        }
+
+        // Non-finite control points defeat every early-exit test below, so the
+        // subdivision runs to the recursion limit on every branch (up to 2^32
+        // calls for a quadratic) and never converges (#7310).
+        if(!isfinite(x1) || !isfinite(y1) || !isfinite(x2) || !isfinite(y2) ||
+           !isfinite(x3) || !isfinite(y3))
         {
             return;
         }
@@ -385,13 +394,21 @@ namespace mapserver
     }
 
     //------------------------------------------------------------------------
-    void curve4_div::recursive_bezier(double x1, double y1, 
-                                      double x2, double y2, 
-                                      double x3, double y3, 
+    void curve4_div::recursive_bezier(double x1, double y1,
+                                      double x2, double y2,
+                                      double x3, double y3,
                                       double x4, double y4,
                                       unsigned level)
     {
-        if(level > curve_recursion_limit) 
+        if(level > curve_recursion_limit)
+        {
+            return;
+        }
+
+        // See curve3_div::recursive_bezier: non-finite control points make the
+        // subdivision never converge (#7310).
+        if(!isfinite(x1) || !isfinite(y1) || !isfinite(x2) || !isfinite(y2) ||
+           !isfinite(x3) || !isfinite(y3) || !isfinite(x4) || !isfinite(y4))
         {
             return;
         }

--- a/tests/unit/test.cpp
+++ b/tests/unit/test.cpp
@@ -1,5 +1,10 @@
 #include "../../src/mapserver.h"
 #include "../../src/maperror.h"
+#include "../../src/renderers/agg/include/agg_basics.h"
+#include "../../src/renderers/agg/include/agg_curves.h"
+
+#include <cmath>
+#include <limits>
 
 /* ----------------------------------------------------------------------- */
 
@@ -145,8 +150,64 @@ static void testToString() {
 
 /* ----------------------------------------------------------------------- */
 
+// Counts the vertices a curve3_div subdivision emits (capped so a runaway
+// recursion can never loop the test itself).
+static unsigned countCurve3Vertices(double x1, double y1, double x2, double y2,
+                                    double x3, double y3) {
+  mapserver::curve3_div c;
+  c.approximation_scale(1.0);
+  c.init(x1, y1, x2, y2, x3, y3);
+  unsigned n = 0;
+  double x, y;
+  while (c.vertex(&x, &y) != mapserver::path_cmd_stop) {
+    if (++n > 1000)
+      return n;
+  }
+  return n;
+}
+
+static unsigned countCurve4Vertices(double x1, double y1, double x2, double y2,
+                                    double x3, double y3, double x4,
+                                    double y4) {
+  mapserver::curve4_div c;
+  c.approximation_scale(1.0);
+  c.init(x1, y1, x2, y2, x3, y3, x4, y4);
+  unsigned n = 0;
+  double x, y;
+  while (c.vertex(&x, &y) != mapserver::path_cmd_stop) {
+    if (++n > 1000)
+      return n;
+  }
+  return n;
+}
+
+// Non-finite (inf/nan) Bezier control points used to defeat every early-exit
+// test in the recursive subdivision, so it ran to the level cap on every
+// branch (~2^32 calls for a quadratic) and never converged: a 100% CPU hang
+// (#7310). The subdivision must now bail out immediately, while a normal
+// finite curve still subdivides into several segments.
+static void testAggCurvesNonFiniteControlPoints() {
+  const double inf = std::numeric_limits<double>::infinity();
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+
+  // Normal finite curves still subdivide (the new guard must not trip).
+  EXPECT_TRUE(countCurve3Vertices(0, 0, 50, 100, 100, 0) > 2);
+  EXPECT_TRUE(countCurve4Vertices(0, 0, 25, 100, 75, 100, 100, 0) > 2);
+
+  // Non-finite control points must no longer blow the recursion up.
+  EXPECT_TRUE(countCurve3Vertices(inf, inf, inf, inf, inf, inf) < 1000);
+  EXPECT_TRUE(countCurve3Vertices(0, 0, inf, 1, 10, 10) < 1000);
+  EXPECT_TRUE(countCurve3Vertices(nan, 0, 1, 1, 2, 2) < 1000);
+  EXPECT_TRUE(countCurve4Vertices(inf, inf, inf, inf, inf, inf, inf, inf) <
+              1000);
+  EXPECT_TRUE(countCurve4Vertices(0, 0, 1, 1, inf, 1, 2, 2) < 1000);
+}
+
+/* ----------------------------------------------------------------------- */
+
 int main() {
   testRedactCredentials();
   testToString();
+  testAggCurvesNonFiniteControlPoints();
   return gTestRetCode;
 }


### PR DESCRIPTION
**Issue:** A degenerate WMS GetMap (`WIDTH=1&HEIGHT=2` with a reprojected search
extent) feeds `inf`/`-nan` into the AGG Bezier subdivision
(`curve3_div`/`curve4_div`). Non-finite control points defeat every early-exit
in `recursive_bezier`, so it recurses to the level cap on every branch and never
converges - the 100% CPU hang reported in #7310.

**Fix:** Add an `isfinite()` guard next to the existing recursion limit in both
`curve3_div` and `curve4_div`.

**Why:** A non-finite control point has no meaningful subdivision, so the only
correct action is to stop; all finite input takes the original path unchanged.

**Test:** `tests/unit/test.cpp` feeds inf/nan points into both subdividers and
asserts termination; without the guard `unit_test` hangs (caught by a
`ctest TIMEOUT 60`).

Fixes #7310