### PR TITLE
OGC API Features: validate offset before rendering to fix reflected X…

### DIFF
--- a/msautotest/api/expected/ogcapi_collections_mn_counties_items_offset_xss.json.txt
+++ b/msautotest/api/expected/ogcapi_collections_mn_counties_items_offset_xss.json.txt
@@ -1,0 +1,4 @@
+Content-Type: application/json
+Status: 400
+
+{"code":"InvalidParameterValue","description":"Bad value for offset."}

--- a/msautotest/api/ogcapi.map
+++ b/msautotest/api/ogcapi.map
@@ -17,6 +17,7 @@
 # RUN_PARMS: ogcapi_collections_mn_counties_items_limit_1.json [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" "QUERY_STRING=f=json&limit=1" > [RESULT_DEMIME]
 # RUN_PARMS: ogcapi_collections_mn_counties_items_limit_1_offset_2.json [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" "QUERY_STRING=f=json&limit=1&offset=2" > [RESULT_DEMIME]
 # RUN_PARMS: ogcapi_collections_mn_counties_items_limit_bbox_empty_result.json [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" "QUERY_STRING=f=json&bbox=2,49,3,50" > [RESULT_DEMIME]
+# RUN_PARMS: ogcapi_collections_mn_counties_items_offset_xss.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items" "QUERY_STRING=f=html&bbox=2,49,3,50&offset=%3C%2Fscript%3E%3Cimg%20src%3Dx%20onerror%3Dalert(1)%3E" > [RESULT]
 # RUN_PARMS: ogcapi_collections_mn_counties_items_by_id.json [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items/35" "QUERY_STRING=f=json" > [RESULT_DEMIME]
 # RUN_PARMS: ogcapi_collections_mn_counties_items_by_id_not_found.json.txt [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_counties/items/12345678" "QUERY_STRING=f=json" > [RESULT_DEMIME]
 # RUN_PARMS: ogcapi_collections_mn_population_centers_items_by_id_no_extent.json [MAPSERV] "PATH_INFO=/[MAPFILE]/ogcapi/collections/mn_population_centers/items/2710700172" "QUERY_STRING=f=json" > [RESULT_DEMIME]

--- a/src/mapogcapi.cpp
+++ b/src/mapogcapi.cpp
@@ -1828,6 +1828,18 @@ static int processCollectionItemsRequest(mapObj *map, cgiRequestObj *request,
       return MS_SUCCESS;
     }
   } else { // bbox query
+    const char *offsetStr = getRequestParameter(request, "offset");
+    if (offsetStr) {
+      if (msStringToInt(offsetStr, &offset, 10) != MS_SUCCESS) {
+        msOGCAPIOutputError(OGCAPI_PARAM_ERROR, "Bad value for offset.");
+        return MS_SUCCESS;
+      }
+      if (offset < 0) {
+        msOGCAPIOutputError(OGCAPI_PARAM_ERROR, "Offset out of range.");
+        return MS_SUCCESS;
+      }
+    }
+
     map->query.type = MS_QUERY_BY_RECT;
     map->query.mode = MS_QUERY_MULTIPLE;
     map->query.layer = iLayer;
@@ -1862,14 +1874,8 @@ static int processCollectionItemsRequest(mapObj *map, cgiRequestObj *request,
 
       msOWSSetShapeCache(map, "AO");
 
-      const char *offsetStr = getRequestParameter(request, "offset");
       if (offsetStr) {
-        if (msStringToInt(offsetStr, &offset, 10) != MS_SUCCESS) {
-          msOGCAPIOutputError(OGCAPI_PARAM_ERROR, "Bad value for offset.");
-          return MS_SUCCESS;
-        }
-
-        if (offset < 0 || offset >= numberMatched) {
+        if (offset >= numberMatched) {
           msOGCAPIOutputError(OGCAPI_PARAM_ERROR, "Offset out of range.");
           return MS_SUCCESS;
         }


### PR DESCRIPTION
…SS (GHSA-288j-mhpj-gmmr)

The "offset" query parameter was only parsed and validated inside the numberMatched > 0 branch of processCollectionItemsRequest(). When a bbox query matched zero features, that validation was skipped and the raw, unescaped value flowed into template.params.offset, which the HTML collection-items template renders directly into a <script> block. A non-numeric offset (e.g. </script><img src=x onerror=alert(1)>) therefore produced reflected XSS on any zero-match OGC API Features items request.

Parse and validate offset (integer, non-negative) unconditionally at the start of the bbox query path, so bad values are rejected with a 400 "Bad value for offset." error before any template is rendered. The upper-bound (offset >= numberMatched) range check stays where numberMatched is known. Behaviour for valid offsets is unchanged.

Add an msautotest case that sends the XSS payload on a zero-match bbox with f=html and asserts the JSON 400 error, confirming the response is application/json rather than reflected text/html.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"PostGIS: make sure identifier value is numeric when the declared type is numeric too (#7516)

Fixes https://github.com/MapServer/MapServer/security/advisories/GHSA-xp29-8wp5-wc3p
"

The MapServer project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://mapserver.org/development/dev_practices.html#commit-hooks#commit-hooks)

More generally, consult [development practices](https://mapserver.org/development/dev_practices.html)
-->

## What does this PR do?

## What are related issues/pull requests?

## AI tool usage

 - [ ] AI supported my development of this PR. See our [policy about AI tool use](https://mapserver.org/community/ai_tool_policy.html). Use of AI tools, if any, *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://mapserver.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s) in `/msautotest` (follow steps in [Regression Testing](https://mapserver.org/development/tests/autotest.html))
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE
