### PR TITLE
Fix WCS 2.0 GetCoverage DoS from non-positive RESOLUTION (GHSA-6jr5-rc9c-p3cj)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,11 @@ https://mapserver.org/development/changelog/
 
 The online Migration Guide can be found at https://mapserver.org/MIGRATION_GUIDE.html
 
+8.6.6 development
+-----------------
+
+- security: WCS 2.0 GetCoverage: reject non-positive RESOLUTION values to prevent denial of service (GHSA-6jr5-rc9c-p3cj)
+
 8.6.5 release (2026-07-10)
 --------------------------
 

--- a/msautotest/wxs/expected/wcs_20_exception_neg_resolution.xml
+++ b/msautotest/wxs/expected/wcs_20_exception_neg_resolution.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.1" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/2.0 http://schemas.opengis.net/ows/2.0/owsExceptionReport.xsd">
+  <ows:Exception exceptionCode="InvalidParameterValue" locator="request">
+    <ows:ExceptionText>msWCSParseSize20(): WCS server error. Invalid resolution parameter value : -1. Resolution must be a positive number.</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>

--- a/msautotest/wxs/expected/wcs_20_exception_zero_resolution.xml
+++ b/msautotest/wxs/expected/wcs_20_exception_zero_resolution.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.1" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/2.0 http://schemas.opengis.net/ows/2.0/owsExceptionReport.xsd">
+  <ows:Exception exceptionCode="InvalidParameterValue" locator="request">
+    <ows:ExceptionText>msWCSParseSize20(): WCS server error. Invalid resolution parameter value : 0. Resolution must be a positive number.</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>

--- a/msautotest/wxs/wcs_simple.map
+++ b/msautotest/wxs/wcs_simple.map
@@ -264,6 +264,11 @@
 # Generate error if requested coverage exceeds maxsize
 # RUN_PARMS: wcs_20_exception_exceed_maxsize.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=2.0.1&REQUEST=GetCoverage&size=x(5001)&size=y(5001)&FORMAT=image/tiff&COVERAGEID=grey" > [RESULT_DEMIME]
 #
+# Reject negative RESOLUTION (denial-of-service prevention, GHSA-6jr5-rc9c-p3cj)
+# RUN_PARMS: wcs_20_exception_neg_resolution.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=2.0.1&REQUEST=GetCoverage&COVERAGEID=grey&FORMAT=image/tiff&RESOLUTION=x(-1)&RESOLUTION=y(-1)" > [RESULT_DEMIME]
+# Reject zero RESOLUTION (denial-of-service prevention, GHSA-6jr5-rc9c-p3cj)
+# RUN_PARMS: wcs_20_exception_zero_resolution.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=2.0.1&REQUEST=GetCoverage&COVERAGEID=grey&FORMAT=image/tiff&RESOLUTION=x(0)&RESOLUTION=y(0)" > [RESULT_DEMIME]
+#
 MAP
 
 NAME TEST

--- a/src/mapwcs20.cpp
+++ b/src/mapwcs20.cpp
@@ -593,6 +593,19 @@ static int msWCSParseResolutionString20(char *string, char *outAxis,
     return MS_FAILURE;
   }
 
+  /* Reject non-finite or non-positive resolution values to prevent
+   * denial-of-service via negative/zero/nan resolution that would
+   * produce non-positive image dimensions and trigger exit(1) in
+   * msSmallMalloc/msSmallCalloc. */
+  if (!std::isfinite(*outResolution) || *outResolution <= 0.0) {
+    *outResolution = MS_WCS20_UNBOUNDED;
+    msSetError(MS_WCSERR,
+               "Invalid resolution parameter value : %s. "
+               "Resolution must be a positive number.",
+               "msWCSParseSize20()", number);
+    return MS_FAILURE;
+  }
+
   return MS_SUCCESS;
 }
 
@@ -4818,6 +4831,16 @@ this request. Check wcs/ows_enable_request settings.",
   map->height = params->height;
 
   /* Are we exceeding the MAXSIZE limit on result size? */
+  if (map->width <= 0 || map->height <= 0) {
+    msWCSClearCoverageMetadata20(&cm);
+    msSetError(MS_WCSERR,
+               "Raster size out of range, width and height of "
+               "resulting coverage must be positive.",
+               "msWCSGetCoverage20()");
+
+    return msWCSException(map, "InvalidParameterValue", "size",
+                          params->version);
+  }
   if (map->width > map->maxsize || map->height > map->maxsize) {
     msWCSClearCoverageMetadata20(&cm);
     msSetError(MS_WCSERR,


### PR DESCRIPTION
## What does this PR do?
Fix:
1. msWCSParseResolutionString20(): After parsing, reject non-finite values and values <= 0 with InvalidParameterValue. This mirrors the existing validation in msWCSParseScaleString20() which already rejects scale <= 0.
2. msWCSGetCoverage20(): Add a defensive guard that rejects width <= 0 or height <= 0 before the existing MAXSIZE check. This catches any edge case where a non-positive dimension reaches this point.

Tests added in msautotest/wxs/wcs_simple.map:
- Negative RESOLUTION → InvalidParameterValue (was exit(1))
- Zero RESOLUTION → InvalidParameterValue (was raw alloc error)

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"PostGIS: make sure identifier value is numeric when the declared type is numeric too (#7516)

Fixes https://github.com/MapServer/MapServer/security/advisories/GHSA-xp29-8wp5-wc3p
"

The MapServer project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://mapserver.org/development/dev_practices.html#commit-hooks#commit-hooks)

More generally, consult [development practices](https://mapserver.org/development/dev_practices.html)
-->

## What are related issues/pull requests?
https://github.com/MapServer/MapServer/security/advisories/GHSA-6jr5-rc9c-p3cj
## AI tool usage

 - [x] AI supported my development of this PR. See our [policy about AI tool use](https://mapserver.org/community/ai_tool_policy.html). Use of AI tools, if any, *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://mapserver.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s) in `/msautotest` (follow steps in [Regression Testing](https://mapserver.org/development/tests/autotest.html))
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE
