### PR TITLE
bound WMS exception response copy to result_size in msDrawWMSLayerLow

### DIFF
--- a/src/mapwmslayer.c
+++ b/src/mapwmslayer.c
@@ -1416,8 +1416,12 @@ int msDrawWMSLayerLow(int nLayerId, httpRequestObj *pasReqInfo, int numRequests,
       } else {
         strlcpy(szBuf, "(Failed to open exception response)", sizeof(szBuf));
       }
+    } else if (pasReqInfo[iReq].result_data) {
+      int nSize = MS_MIN(pasReqInfo[iReq].result_size, MS_BUFFER_LENGTH - 1);
+      memcpy(szBuf, pasReqInfo[iReq].result_data, nSize);
+      szBuf[nSize] = '\0';
     } else {
-      strlcpy(szBuf, pasReqInfo[iReq].result_data, MS_BUFFER_LENGTH);
+      szBuf[0] = '\0';
     }
 
     if (lp->debug)


### PR DESCRIPTION
When a cascaded WMS server returns an XML exception, msDrawWMSLayerLow copies the response into a fixed szBuf with strlcpy(szBuf, result_data, MS_BUFFER_LENGTH). result_data is assembled in msHTTPWriteFct by memcpy of exactly result_size bytes and is never NUL-terminated (the +10000 slack from msSmallMalloc is uninitialized heap). strlcpy scans the source for a NUL to compute its length, so it walks past result_size into uninitialized or adjacent heap, and those bytes then land in the msSetError/msDebug message. A malicious or compromised upstream server sending a NUL-free text/xml body on the default in-memory path triggers it.

Copy result_size bytes and terminate explicitly, the way the sibling result_data consumers a few lines down already do. Keeping the length bound at the copy site is the only place that knows the real byte count, since the buffer past result_size is not part of the response.