### PR TITLE
Build fixes for CMake 4.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,13 @@ else()
 endif()
 set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation directory for CMake files")
 
+# Keep a relative copy for install(EXPORT ...)
+if(IS_ABSOLUTE "${INSTALL_CMAKE_DIR}")
+  file(RELATIVE_PATH INSTALL_CMAKE_DIR_REL "${CMAKE_INSTALL_PREFIX}" "${INSTALL_CMAKE_DIR}")
+else()
+  set(INSTALL_CMAKE_DIR_REL "${INSTALL_CMAKE_DIR}")
+endif()
+
 # Make relative paths absolute (needed later on)
 foreach(p LIB BIN INCLUDE CMAKE)
   set(var INSTALL_${p}_DIR)
@@ -1144,12 +1151,12 @@ if(BUILD_DYNAMIC)
    # Install the mapserver-config.cmake and mapserver-config-version.cmake
    install(FILES "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/mapserver-config.cmake"
                  "${PROJECT_BINARY_DIR}/mapserver-config-version.cmake"
-           DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev
+           DESTINATION "${INSTALL_CMAKE_DIR_REL}" COMPONENT dev
    )
 
    # Install the export set for use with the install-tree
    install(EXPORT mapserverTargets
-           DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev
+           DESTINATION "${INSTALL_CMAKE_DIR_REL}" COMPONENT dev
    )
 endif(BUILD_DYNAMIC)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,12 +72,15 @@ else()
 endif()
 set(INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation directory for CMake files")
 
-# Keep a relative copy for install(EXPORT ...)
-if(IS_ABSOLUTE "${INSTALL_CMAKE_DIR}")
-  file(RELATIVE_PATH INSTALL_CMAKE_DIR_REL "${CMAKE_INSTALL_PREFIX}" "${INSTALL_CMAKE_DIR}")
-else()
-  set(INSTALL_CMAKE_DIR_REL "${INSTALL_CMAKE_DIR}")
-endif()
+# Keep a relative copy for install() DESTINATION arguments
+foreach(p LIB BIN INCLUDE CMAKE)
+  set(var INSTALL_${p}_DIR)
+  if(IS_ABSOLUTE "${${var}}")
+    file(RELATIVE_PATH ${var}_REL "${CMAKE_INSTALL_PREFIX}" "${${var}}")
+  else()
+    set(${var}_REL "${${var}}")
+  endif()
+endforeach()
 
 # Make relative paths absolute (needed later on)
 foreach(p LIB BIN INCLUDE CMAKE)
@@ -1094,11 +1097,11 @@ add_definitions(-D_USE_MATH_DEFINES)
 
 #INSTALL(FILES mapserver-api.h ${PROJECT_BINARY_DIR}/mapserver-version.h DESTINATION include)
 if(USE_ORACLE_PLUGIN)
-   INSTALL(TARGETS msplugin_oracle DESTINATION ${INSTALL_LIB_DIR})
+   INSTALL(TARGETS msplugin_oracle DESTINATION ${INSTALL_LIB_DIR_REL})
 endif(USE_ORACLE_PLUGIN)
 
 if(USE_MSSQL2008)
-   INSTALL(TARGETS msplugin_mssql2008 DESTINATION ${INSTALL_LIB_DIR})
+   INSTALL(TARGETS msplugin_mssql2008 DESTINATION ${INSTALL_LIB_DIR_REL})
 endif(USE_MSSQL2008)
 
 if(NOT FUZZER)
@@ -1109,14 +1112,14 @@ endif()
 
 if(BUILD_STATIC)
    INSTALL(TARGETS mapserver_static
-           DESTINATION ${INSTALL_LIB_DIR} COMPONENT staticlib
+           DESTINATION ${INSTALL_LIB_DIR_REL} COMPONENT staticlib
    )
 endif(BUILD_STATIC)
 if(BUILD_DYNAMIC)
    INSTALL(TARGETS mapserver
            EXPORT mapserverTargets
-           ARCHIVE DESTINATION ${INSTALL_LIB_DIR} COMPONENT shlib
-           LIBRARY DESTINATION ${INSTALL_LIB_DIR} COMPONENT shlib
+           ARCHIVE DESTINATION ${INSTALL_LIB_DIR_REL} COMPONENT shlib
+           LIBRARY DESTINATION ${INSTALL_LIB_DIR_REL} COMPONENT shlib
            PUBLIC_HEADER DESTINATION ${INSTALL_INCLUDE_DIR}/mapserver COMPONENT dev
    )
 

--- a/ci/ubuntu/build.sh
+++ b/ci/ubuntu/build.sh
@@ -4,8 +4,8 @@ set -eu
 export CC="ccache gcc"
 export CXX="ccache g++"
 
-# Turn CMake warnings as errors
-EXTRA_CMAKEFLAGS="-Werror=dev"
+# Turn CMake warnings as errors and ignore absolute paths in install() commands
+EXTRA_CMAKEFLAGS="-Werror=dev -Wno-error=install-absolute-destination"
 
 if [ "${WITH_ASAN:-}" = "true" ]; then
     # -DNDEBUG to avoid issues with cairo cleanup


### PR DESCRIPTION
Recent CI builds are failing due to an update to CMake from 4.3.4 to 4.4.0. 

```
2026-07-10T20:51:55.2129877Z cmake version 4.3.4
...
2026-07-20T09:55:31.8651477Z cmake version 4.4.0
```

This caused the following errors:

```
2026-07-20T09:56:55.2318365Z CMake Error (install-absolute-destination) at CMakeLists.txt:1151 (install):
2026-07-20T09:56:55.2319341Z   INSTALL command given absolute DESTINATION path:
```

Looking at the [release notes](https://cmake.org/cmake/help/latest/release/4.4.html#diagnostics):

> The CMD_INSTALL_ABSOLUTE_DESTINATION diagnostic category was added to diagnose install() commands that specify an absolute DESTINATION. 

And the [install](https://cmake.org/cmake/help/latest/command/install.html#command:install) command:

> Specify the directory on disk to which a file will be installed. <dir> should be a relative path. An absolute path is allowed, but not recommended.

The CMakeLists.txt has been updated to use a relative path rather than absolute. Using absolute can break some installs/packaging setups as it doesn't allow the install tree to be moved. In 4.3 this was allowed but throws the error in 4.4. 