### PR TITLE
Ignore LAYER TOLERANCE for OGC Feature requests

### DIFF
--- a/msautotest/api/ogcapi.map
+++ b/msautotest/api/ogcapi.map
@@ -230,6 +230,7 @@ MAP
     END
     PROJECTION "+init=epsg:32615" END
     TEMPLATE VOID
+    TOLERANCE 10000 # this should have no effect on OGC Features item requests with a bbox
   END
 
   LAYER

--- a/src/mapogcapi.cpp
+++ b/src/mapogcapi.cpp
@@ -1470,6 +1470,10 @@ static int processCollectionItemsRequest(mapObj *map, cgiRequestObj *request,
   layerObj *layer = map->layers[iLayer];
   layer->status = MS_ON; // force on (do we need to save and reset?)
 
+  /* No reason to handle tolerances feature queries, same as WFS GetFeature
+   * requests */
+  layer->tolerance = 0;
+
   if (!includeLayer(map, layer)) {
     msOGCAPIOutputError(OGCAPI_NOT_FOUND_ERROR, "Invalid collection.");
     return MS_SUCCESS;


### PR DESCRIPTION
Fix for #7540. Sets the tolerance to 0 similar to WFS requests: https://github.com/MapServer/MapServer/blob/abaa114c6973cc67cacd82e8a724f994a00eb785/src/mapwfs.cpp#L3016

The WFS code doesn't reset tolerance, and the layer status is not reset in the OGC Feature request (see line above `layer->status = MS_ON; // force on (do we need to save and reset?)`), so I have not reset tolerance either. 

I added a tolerance to one of the query layers - different results are returned without the change `layer->tolerance = 0;`. 

