### PR TITLE
Apply runtime substitutions before applying SLD files

### DIFF
--- a/src/apps/map2img.c
+++ b/src/apps/map2img.c
@@ -198,6 +198,7 @@ int main(int argc, char *argv[]) {
           exit(1);
         }
         msApplyDefaultSubstitutions(map);
+        msApplyStyleItemsToLayers(map);
       }
     }
 

--- a/src/mapfile.c
+++ b/src/mapfile.c
@@ -6956,7 +6956,7 @@ static bool msGetCWD(char *szBuffer, size_t nBufferSize,
 /*
  * Apply any SLD styles referenced in a LAYER's STYLEITEM
  */
-static void msApplyStyleItemToLayer(mapObj *map) {
+void msApplyStyleItemToLayer(mapObj *map) {
 
   // applying SLD can create cloned layers so store the original layer count
   int layerCount = map->numlayers;

--- a/src/mapfile.c
+++ b/src/mapfile.c
@@ -6956,7 +6956,7 @@ static bool msGetCWD(char *szBuffer, size_t nBufferSize,
 /*
  * Apply any SLD styles referenced in a LAYER's STYLEITEM
  */
-static void applyStyleItemToLayer(mapObj *map) {
+static void msApplyStyleItemToLayer(mapObj *map) {
 
   // applying SLD can create cloned layers so store the original layer count
   int layerCount = map->numlayers;
@@ -6970,8 +6970,7 @@ static void applyStyleItemToLayer(mapObj *map) {
       if (*filename == '\0') {
         msSetErrorWithStatus(MS_IOERR, MS_HTTP_500_INTERNAL_SERVER_ERROR,
                              "Empty SLD filename: \"%s\".",
-                             "applyLayerDefaultSubstitutions()",
-                             layer->styleitem);
+                             "msApplyStyleItemToLayer()", layer->styleitem);
       } else {
         msSLDApplyFromFile(map, layer, filename);
       }
@@ -7053,7 +7052,7 @@ mapObj *msLoadMapFromString(char *buffer, char *new_mappath,
 
   msReleaseLock(TLOCK_PARSER);
 
-  applyStyleItemToLayer(map);
+  msApplyStyleItemToLayer(map);
 
   if (debuglevel >= MS_DEBUGLEVEL_TUNING) {
     /* In debug mode, report time spent loading/parsing mapfile. */
@@ -7186,8 +7185,6 @@ mapObj *msLoadMap(const char *filename, const char *new_mappath,
     return NULL;
   }
   msReleaseLock(TLOCK_PARSER);
-
-  applyStyleItemToLayer(map);
 
   if (debuglevel >= MS_DEBUGLEVEL_TUNING) {
     /* In debug mode, report time spent loading/parsing mapfile. */

--- a/src/mapfile.c
+++ b/src/mapfile.c
@@ -6956,7 +6956,7 @@ static bool msGetCWD(char *szBuffer, size_t nBufferSize,
 /*
  * Apply any SLD styles referenced in a LAYER's STYLEITEM
  */
-void msApplyStyleItemToLayer(mapObj *map) {
+void msApplyStyleItemsToLayers(mapObj *map) {
 
   // applying SLD can create cloned layers so store the original layer count
   int layerCount = map->numlayers;
@@ -6970,7 +6970,7 @@ void msApplyStyleItemToLayer(mapObj *map) {
       if (*filename == '\0') {
         msSetErrorWithStatus(MS_IOERR, MS_HTTP_500_INTERNAL_SERVER_ERROR,
                              "Empty SLD filename: \"%s\".",
-                             "msApplyStyleItemToLayer()", layer->styleitem);
+                             "msApplyStyleItemsToLayers()", layer->styleitem);
       } else {
         msSLDApplyFromFile(map, layer, filename);
       }
@@ -7052,7 +7052,7 @@ mapObj *msLoadMapFromString(char *buffer, char *new_mappath,
 
   msReleaseLock(TLOCK_PARSER);
 
-  msApplyStyleItemToLayer(map);
+  msApplyStyleItemsToLayers(map);
 
   if (debuglevel >= MS_DEBUGLEVEL_TUNING) {
     /* In debug mode, report time spent loading/parsing mapfile. */

--- a/src/mapserver.h
+++ b/src/mapserver.h
@@ -2722,7 +2722,7 @@ MS_DLL_EXPORT int msMapLoadOWSParameters(mapObj *map, cgiRequestObj *request,
 MS_DLL_EXPORT int msMapIgnoreMissingData(mapObj *map);
 
 /* mapfile.c */
-MS_DLL_EXPORT void msApplyStyleItemToLayer(mapObj *map);
+MS_DLL_EXPORT void msApplyStyleItemsToLayers(mapObj *map);
 MS_DLL_EXPORT int msValidateParameter(const char *value, const char *pattern1,
                                       const char *pattern2,
                                       const char *pattern3,

--- a/src/mapserver.h
+++ b/src/mapserver.h
@@ -2722,7 +2722,7 @@ MS_DLL_EXPORT int msMapLoadOWSParameters(mapObj *map, cgiRequestObj *request,
 MS_DLL_EXPORT int msMapIgnoreMissingData(mapObj *map);
 
 /* mapfile.c */
-
+MS_DLL_EXPORT void msApplyStyleItemToLayer(mapObj *map);
 MS_DLL_EXPORT int msValidateParameter(const char *value, const char *pattern1,
                                       const char *pattern2,
                                       const char *pattern3,

--- a/src/mapservutil.c
+++ b/src/mapservutil.c
@@ -355,6 +355,10 @@ mapObj *msCGILoadMap(mapservObj *mapserv, configObj *config) {
                       mapserv->request->httpcookiedata);
   }
 
+  // apply any SLD files to layers - this has to be done after any
+  // runtime substitutions have been applied to the mapfile
+  msApplyStyleItemToLayer(map);
+
   return map;
 }
 

--- a/src/mapservutil.c
+++ b/src/mapservutil.c
@@ -357,7 +357,7 @@ mapObj *msCGILoadMap(mapservObj *mapserv, configObj *config) {
 
   // apply any SLD files to layers - this has to be done after any
   // runtime substitutions have been applied to the mapfile
-  msApplyStyleItemToLayer(map);
+  msApplyStyleItemsToLayers(map);
 
   return map;
 }


### PR DESCRIPTION
Fixes a bug where if a `DATA` clause contains a runtime substitution variable, then it is set by the querystring parameters (or a default value if missing) prior to a database layer info object being populated.

```
    DATA "Geomfrom (
            SELECT Id, Geom
            FROM mytable
            WHERE MyVariable = %MyVariable %
        )
        as tbl USING UNIQUE Id USING SRID=4326"
```

This was discovered when using the MSSQL Server driver. The layer is cloned before `msApplySubstitutions` and `msApplyDefaultSubstitutions` are called, and then the geom_table property of `ms_MSSQL2008_layer_info_t is` set [here](https://github.com/MapServer/MapServer/blob/e5be2b227d1bab649516b48249a60f51f8959586/src/mapogcsld.cpp#L311) causing invalid SQL to be stored. This is then not updated before drawing a map image, causing an error. 

Ensuring the function is called after substitutions means it is required in a couple of places and so is no longer `static` and has been added to the header file. 
