### PR TITLE
fix out-of-bounds read in SLD arithmetic operator parsing

### DIFF
--- a/src/mapogcsld.cpp
+++ b/src/mapogcsld.cpp
@@ -1594,8 +1594,11 @@ int msSLDParseOgcExpression(CPLXMLNode *psRoot, void *psObj, int binding,
       exprBindings[binding].type = MS_EXPRESSION;
       (*nexprbindings)++;
       status = MS_SUCCESS;
-    } else if (strstr(ops, psRoot->pszValue) && psRoot->psChild &&
-               psRoot->psChild->psNext) {
+    } else if (psRoot->psChild && psRoot->psChild->psNext &&
+               (strcmp(psRoot->pszValue, "Add") == 0 ||
+                strcmp(psRoot->pszValue, "Sub") == 0 ||
+                strcmp(psRoot->pszValue, "Mul") == 0 ||
+                strcmp(psRoot->pszValue, "Div") == 0)) {
       // Parse an arithmetic element <ogc:Add>, <ogc:Sub>, <ogc:Mul>, <ogc:Div>
       const char op[2] = {*(strstr(ops, psRoot->pszValue) + 3), '\0'};
       msStringBuffer *expression = msStringBufferAlloc();

--- a/src/mapogcsld.cpp
+++ b/src/mapogcsld.cpp
@@ -1412,7 +1412,6 @@ int msSLDParseStroke(CPLXMLNode *psStroke, styleObj *psStyle, mapObj *map,
 int msSLDParseOgcExpression(CPLXMLNode *psRoot, void *psObj, int binding,
                             enum objType objtype) {
   int status = MS_FAILURE;
-  const char *ops = "Add+Sub-Mul*Div/";
   styleObj *psStyle = static_cast<styleObj *>(psObj);
   labelObj *psLabel = static_cast<labelObj *>(psObj);
   int lbinding;
@@ -1595,12 +1594,16 @@ int msSLDParseOgcExpression(CPLXMLNode *psRoot, void *psObj, int binding,
       (*nexprbindings)++;
       status = MS_SUCCESS;
     } else if (psRoot->psChild && psRoot->psChild->psNext &&
-               (strcmp(psRoot->pszValue, "Add") == 0 ||
-                strcmp(psRoot->pszValue, "Sub") == 0 ||
-                strcmp(psRoot->pszValue, "Mul") == 0 ||
-                strcmp(psRoot->pszValue, "Div") == 0)) {
+               (strcasecmp(psRoot->pszValue, "Add") == 0 ||
+                strcasecmp(psRoot->pszValue, "Sub") == 0 ||
+                strcasecmp(psRoot->pszValue, "Mul") == 0 ||
+                strcasecmp(psRoot->pszValue, "Div") == 0)) {
       // Parse an arithmetic element <ogc:Add>, <ogc:Sub>, <ogc:Mul>, <ogc:Div>
-      const char op[2] = {*(strstr(ops, psRoot->pszValue) + 3), '\0'};
+      const char op[2] = {strcasecmp(psRoot->pszValue, "Add") == 0   ? '+'
+                          : strcasecmp(psRoot->pszValue, "Sub") == 0 ? '-'
+                          : strcasecmp(psRoot->pszValue, "Mul") == 0 ? '*'
+                                                                     : '/',
+                          '\0'};
       msStringBuffer *expression = msStringBufferAlloc();
 
       // Parse first operand


### PR DESCRIPTION
msSLDParseOgcExpression() classifies an OGC element as an arithmetic operator with strstr(ops, psRoot->pszValue), where ops is the literal "Add+Sub-Mul*Div/" and pszValue is the element name from an untrusted SLD document (SLD= / SLD_BODY= on a WMS/WFS request). Since the untrusted name is the strstr needle, any substring match qualifies, and the following *(strstr(...) + 3) assumes the match is one of the three-letter names sitting at a fixed offset. An element like <ogc:v> matches near the end of ops, so the +3 reads one byte past the literal (AddressSanitizer reports a global-buffer-overflow read).

Match the element name against the four operator names exactly before deriving the operator character, so strstr only lands on Add/Sub/Mul/Div and the +3 stays in bounds. This also keeps unrelated names such as <ogc:ub-> from being misread as operators. Doing the check where the operator is resolved covers every SLD path that reaches this parser.