### PR TITLE
Fix memory leak in mapows and mapwcs

### DIFF
--- a/src/mapows.cpp
+++ b/src/mapows.cpp
@@ -2795,6 +2795,7 @@ int msOWSGetLayerExtent(mapObj *map, layerObj *lp, const char *namespaces,
     if (tokens == NULL || n != 4) {
       msSetError(MS_WMSERR, "Wrong number of arguments for EXTENT metadata.",
                  "msOWSGetLayerExtent()");
+      msFreeCharArray(tokens, n);
       return MS_FAILURE;
     }
     ext->minx = atof(tokens[0]);

--- a/src/mapwcs.cpp
+++ b/src/mapwcs.cpp
@@ -607,6 +607,7 @@ static int msWCSParseRequest(cgiRequestObj *request, wcsParamsObj *params,
         if (tokens == NULL || n != 4) {
           msSetError(MS_WCSERR, "Wrong number of arguments for BBOX.",
                      "msWCSParseRequest()");
+          msFreeCharArray(tokens, n);
           return msWCSException(map, "InvalidParameterValue", "bbox",
                                 params->version);
         }


### PR DESCRIPTION
In both mapows and mapwcs when handling parsing request, the tokens are not freed in the error path before returning MS_FAILURE, creating a memory leak. This PR fix it by releasing the tokens properly with msFreeCharArray.

This memory leak is discovered by the new fuzzer introduced in https://github.com/MapServer/MapServer/pull/7525.