### PR TITLE
Fix integer overflow in `msOWSParseVersionString`

### DIFF
--- a/msautotest/wxs/expected/wfs_default_version_110_caps_invalid2.xml
+++ b/msautotest/wxs/expected/wfs_default_version_110_caps_invalid2.xml
@@ -1,0 +1,8 @@
+Content-Type: text/xml; charset=UTF-8
+
+<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ows="http://www.opengis.net/ows" version="1.1.0" language="en-US" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd">
+  <ows:Exception exceptionCode="InvalidParameterValue" locator="version">
+    <ows:ExceptionText>msOWSParseVersionString(): OWS error. Invalid version (55550.). Each component must be between 0 and 255</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>

--- a/msautotest/wxs/wfs_default_version_110.map
+++ b/msautotest/wxs/wfs_default_version_110.map
@@ -9,6 +9,7 @@
 
 # Capabilities : invalid version
 # RUN_PARMS: wfs_default_version_110_caps_invalid.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=invalid&REQUEST=GetCapabilities" > [RESULT_DEVERSION]
+# RUN_PARMS: wfs_default_version_110_caps_invalid2.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=55550.&REQUEST=GetCapabilities" > [RESULT_DEVERSION]
 
 # Capabilities : test old-style negotiation
 # RUN_PARMS: wfs_default_version_110_caps_000.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WFS&VERSION=0.0.0&REQUEST=GetCapabilities" > [EXTRACT_SERVICE_VERSION]

--- a/src/mapows.cpp
+++ b/src/mapows.cpp
@@ -1071,6 +1071,18 @@ int msOWSParseVersionString(const char *pszVersion) {
       return OWS_VERSION_BADFORMAT;
     }
 
+    for (int i = 0; i < numDigits; i++) {
+      int v = atoi(digits[i]);
+      if (v < 0 || v > 255) {
+        msSetError(MS_OWSERR,
+                   "Invalid version (%s). Each component must be "
+                   "between 0 and 255",
+                   "msOWSParseVersionString()", pszVersion);
+        msFreeCharArray(digits, numDigits);
+        return OWS_VERSION_BADFORMAT;
+      }
+    }
+
     nVersion = atoi(digits[0]) * 0x010000;
     nVersion += atoi(digits[1]) * 0x0100;
     if (numDigits > 2)


### PR DESCRIPTION
Checks that any part of the OWS version numbers (e.g. 1.3.0) are between 0 and 255 to avoid integer overflows

```
nVersion = atoi("55550") * 0x010000;
55550 × 65536 = 3,641,753,600
> INT_MAX
```

Fixes oss-fuzz 4545217852932096