### PR TITLE
Add guard against empty lines in `msLayoutTextSymbol`

### DIFF
--- a/src/textlayout.c
+++ b/src/textlayout.c
@@ -629,6 +629,12 @@ int msLayoutTextSymbol(mapObj *map, textSymbolObj *ts, textPathObj *tgret) {
     }
   }
 
+  /* add a guard against empty lines */
+  if (num_glyphs == 0) {
+    ret = MS_SUCCESS;
+    goto cleanup;
+  }
+
   if (ts->label->wrap || ts->label->maxlength > 0) {
     if (ts->label->wrap && ts->label->maxlength == 0) {
       for (i = 0; i < num_glyphs; i++) {
@@ -732,7 +738,7 @@ int msLayoutTextSymbol(mapObj *map, textSymbolObj *ts, textPathObj *tgret) {
                   (nruns - i - 2) * sizeof(text_run));
 
           i++;
-          /* new run inherints line number */
+          /* new run inherits line number */
           runs[i].line_number = runs[i - 1].line_number;
           runs[i].offset = original_offset + j;
           runs[i].length =
@@ -778,7 +784,7 @@ int msLayoutTextSymbol(mapObj *map, textSymbolObj *ts, textPathObj *tgret) {
                   (nruns - i - 2) * sizeof(text_run));
 
           i++;
-          /* new run inherints line number and rtl*/
+          /* new run inherits line number and rtl*/
           runs[i].line_number = runs[i - 1].line_number;
           runs[i].rtl = runs[i - 1].rtl;
           runs[i].offset = original_offset + j;


### PR DESCRIPTION
I am unable to recreate this locally, but I believe this issue happens when `VERSION=` is supplied with only line feed characters e.g. `\r`. On Windows `\r` can't be passed directly to mapserv. As the fuzzer is running through MapScript I think this is how the issue was raised. 

I did recreate by mocking the issue in the function, and `glyphs.unicodes[num_glyphs - 1]` is called later throwing an error, so adding a guard will prevent this. 

Should fix oss-fuzzer 551099259.

```
AddressSanitizer: stack-buffer-overflow on address 0x7b4c91bdaa1c at pc 0x5bf470cb9713 bp 0x7ffe49b17610 sp 0x7ffe49b17608
	READ of size 4 at 0x7b4c91bdaa1c thread T0
	    #0 0x5bf470cb9712 in msLayoutTextSymbol MapServer/src/textlayout.c:680:7
```