### PR TITLE
mapobject.c: clear cached reprojectors in msRemoveLayer() (fixes #7611)

### DIFF
--- a/msautotest/mspython/test_bug_check.py
+++ b/msautotest/mspython/test_bug_check.py
@@ -303,3 +303,65 @@ def test_bug_6896():
 
     os.unlink(ref_filename)
     os.unlink(test_filename)
+
+
+###############################################################################
+# Verify that a layer moved to another map no longer carries the cached
+# reprojector of the map it was removed from.
+#
+# https://github.com/MapServer/MapServer/issues/7611
+
+
+def test_bug_7611():
+    def add_polygon_layer(map):
+        layer = mapscript.layerObj(map)
+        layer.name = "poly"
+        layer.type = mapscript.MS_LAYER_POLYGON
+        layer.status = mapscript.MS_ON
+        layer.setProjection("init=epsg:4326")
+
+        shape = mapscript.shapeObj(mapscript.MS_SHAPE_POLYGON)
+        ring = mapscript.lineObj()
+        for x, y in [
+            (-117.4, 42.8),
+            (-116.6, 42.8),
+            (-116.6, 43.2),
+            (-117.4, 43.2),
+            (-117.4, 42.8),
+        ]:
+            ring.add(mapscript.pointObj(x, y))
+        shape.add(ring)
+        layer.addFeature(shape)
+
+        style = mapscript.styleObj(mapscript.classObj(layer))
+        style.color = mapscript.colorObj(255, 0, 0)
+        return layer
+
+    def renders(map, layer):
+        drawn = map.draw().getBytes()
+        layer.status = mapscript.MS_OFF
+        blank = map.draw().getBytes()
+        layer.status = mapscript.MS_ON
+        return drawn != blank
+
+    # Map A is Web Mercator, the layer is geographic. Drawing caches a
+    # reprojector on the layer whose "out" is map A's projection.
+    map_a = mapscript.mapObj()
+    map_a.setSize(100, 100)
+    map_a.setProjection("init=epsg:3857")
+    map_a.setExtent(-13100000, 5250000, -12950000, 5380000)
+    layer = add_polygon_layer(map_a)
+    assert renders(map_a, layer)
+
+    # Move the layer to a map that uses a different projection.
+    map_a.removeLayer(0)
+    map_b = mapscript.mapObj()
+    map_b.setSize(100, 100)
+    map_b.setProjection("init=epsg:32611")
+    map_b.setExtent(450000, 4720000, 560000, 4800000)
+    map_b.insertLayer(layer)
+
+    # If the cached reprojector survived removeLayer(), the polygon is still
+    # projected to map A's Web Mercator coordinates, lands outside map B's
+    # extent, and nothing is drawn.
+    assert renders(map_b, layer)

--- a/src/mapobject.c
+++ b/src/mapobject.c
@@ -635,6 +635,14 @@ layerObj *msRemoveLayer(mapObj *map, int nIndex) {
         map->layerorder[i]--;
     }
 
+    /* The cached reprojectors reference this map's projection; they become
+       stale once the layer is detached (and dangling if this map is freed
+       while the layer lives on in another map), so drop them here. */
+    msProjectDestroyReprojector(layer->reprojectorLayerToMap);
+    layer->reprojectorLayerToMap = NULL;
+    msProjectDestroyReprojector(layer->reprojectorMapToLayer);
+    layer->reprojectorMapToLayer = NULL;
+
     /* decrement number of layers and return copy of removed layer */
     map->numlayers--;
     layer->map = NULL;


### PR DESCRIPTION

## What does this PR do?

`msRemoveLayer()` detached a layer without clearing `layer->reprojectorLayerToMap` / `reprojectorMapToLayer`. Those cached reprojectors hold a raw pointer to the map the layer was removed from, which has two consequences:

- A layer moved to another map keeps reprojecting to the **old** map's projection, so it is drawn in the wrong place or not at all.
- If the old map is freed while the layer lives on, the next `msLayerGetReprojectorToMap()` reads `reprojector->out->generation_number` from freed memory (heap-use-after-free under ASan).

`freeLayer()` already destroys both cached reprojectors and `initLayer()` initialises them to NULL, so this brings `msRemoveLayer()` in line with the other two places that manage these fields.

The msautotest case moves a layer from a Web Mercator map to a UTM map and checks that it still renders. Without the fix the polygon is projected to the first map's coordinates, falls outside the second map's extent, and nothing is drawn.

## What are related issues/pull requests?

Fixes #7611

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://mapserver.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s) in `/msautotest` (follow steps in [Regression Testing](https://mapserver.org/development/tests/autotest.html))
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed