### PR TITLE
mapproject.c: check msProjectCreateReprojector() result in msProjectRect() (fixes #7613)

### DIFF
--- a/msautotest/mspython/test_bug_check.py
+++ b/msautotest/mspython/test_bug_check.py
@@ -365,3 +365,25 @@ def test_bug_7611():
     # projected to map A's Web Mercator coordinates, lands outside map B's
     # extent, and nothing is drawn.
     assert renders(map_b, layer)
+
+
+###############################################################################
+# msProjectRect() used the result of msProjectCreateReprojector() without
+# checking it for NULL, which segfaults when a transformation cannot be built.
+# The polar branch is selected because (0,0) in this CRS is the pole and the
+# rectangle encloses it.
+
+
+def test_msprojectrect_null_reprojector():
+
+    polar = mapscript.projectionObj(
+        "+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +k=1 +x_0=0 +y_0=0 "
+        "+datum=WGS84 +units=m +no_defs"
+    )
+    # Not a CRS, so no transformation can be built from it.
+    not_a_crs = mapscript.projectionObj("+proj=noop")
+
+    rect = mapscript.rectObj(-1000000, -1000000, 1000000, 1000000)
+
+    # Only has to return rather than crash.
+    rect.project(polar, not_a_crs)

--- a/src/mapproject.c
+++ b/src/mapproject.c
@@ -2052,6 +2052,8 @@ int msProjectRect(projectionObj *in, projectionObj *out, rectObj *rect) {
           fabs(p.y - 90) < 1e-8) {
         in->is_polar = 1;
         reprojector = msProjectCreateReprojector(in, out);
+        if (reprojector == NULL)
+          break;
         /* Is the pole in the rectangle ? */
         if (0 >= rect->minx && 0 >= rect->miny && 0 <= rect->maxx &&
             0 <= rect->maxy) {
@@ -2068,6 +2070,8 @@ int msProjectRect(projectionObj *in, projectionObj *out, rectObj *rect) {
           msProjectDestroyReprojector(reprojectorToLongLat);
           return ret;
         }
+        msProjectDestroyReprojector(reprojector);
+        reprojector = NULL;
       }
     }
     msProjectDestroyReprojector(reprojectorToLongLat);


### PR DESCRIPTION

## What does this PR do?

`msProjectRect()` passed the result of `msProjectCreateReprojector()` to `msProjectRectAsPolygon()` without checking it. `msProjectCreateReprojector()` returns NULL when a transformation cannot be built, and `msProjectRectAsPolygon()` dereferences `reprojector->out` immediately, so the process segfaults.

The six other calls to `msProjectCreateReprojector()` in this file all check the result; this one was the exception.

The same block also leaked the reprojector when neither rect condition matched, because it is created inside the `for (sign ...)` loop but destroyed only on the two `return` paths. This adds the missing destroy.

## What are related issues/pull requests?

Fixes #7613

## AI tool usage

 - [ ] AI supported my development of this PR. See our [policy about AI tool use](https://mapserver.org/community/ai_tool_policy.html). Use of AI tools, if any, *must* be indicated.


## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://mapserver.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s) in `/msautotest` (follow steps in [Regression Testing](https://mapserver.org/development/tests/autotest.html))
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

