### PR TITLE
mappool.c: only raise connectionMax after a successful realloc (fixes #7614)

### DIFF
--- a/src/mappool.c
+++ b/src/mappool.c
@@ -205,16 +205,20 @@ void msConnPoolRegister(layerObj *layer, void *conn_handle,
   /* -------------------------------------------------------------------- */
   msAcquireLock(TLOCK_POOL);
 
-  if (connectionCount == connectionMax) {
-    connectionMax += 10;
+  if (connectionCount >= connectionMax) {
+    const int newConnectionMax = connectionMax + 10;
     connectionObj *newConnections = (connectionObj *)realloc(
-        connections, sizeof(connectionObj) * connectionMax);
+        connections, sizeof(connectionObj) * newConnectionMax);
     if (newConnections == NULL) {
+      /* Leave connectionMax matching the capacity we actually have, so a
+         later registration still takes this growth path instead of writing
+         past the end of the existing array. */
       msSetError(MS_MEMERR, NULL, "msConnPoolRegister()");
       msReleaseLock(TLOCK_POOL);
       return;
     }
     connections = newConnections;
+    connectionMax = newConnectionMax;
   }
 
   /* -------------------------------------------------------------------- */


### PR DESCRIPTION
## What does this PR do?

This moves the increment after the successful realloc and changes the guard to `>=`.

It completes f4286d624: that commit stopped the failed realloc from leaking and from nulling `connections`, but left the `connectionMax` desync in place, which turned the old near-NULL crash into a silent heap overflow.

## What are related issues/pull requests?

Fixes #7614

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://mapserver.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s) in `/msautotest` (follow steps in [Regression Testing](https://mapserver.org/development/tests/autotest.html))
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

I could not find a way to write this one as an msautotest case. Triggering it needs the pool array's `realloc()` to fail, and the suite has no way to inject an allocation failure; `msConnPoolRegister()` is also not exposed to MapScript, and its callers are the database drivers, so reaching it from the test suite would need a live backend as well. The C reproducer in the issue covers it instead. Glad to add a test if you see an angle I missed.