### PR TITLE
Fix integer overflows in WCS SCALEEXTENT parsing

### DIFF
--- a/msautotest/wxs/expected/wcs_20_exception_scaleextent.xml
+++ b/msautotest/wxs/expected/wcs_20_exception_scaleextent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.1" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/2.0 http://schemas.opengis.net/ows/2.0/owsExceptionReport.xsd">
+  <ows:Exception exceptionCode="InvalidParameterValue" locator="request">
+    <ows:ExceptionText>msWCSParseScaleExtentString20(): WCS server error. Invalid min parameter value : 6666611106</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>

--- a/msautotest/wxs/expected/wcs_20_exception_scaleextent2.xml
+++ b/msautotest/wxs/expected/wcs_20_exception_scaleextent2.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.0.1" xml:lang="en-US" xsi:schemaLocation="http://www.opengis.net/ows/2.0 http://schemas.opengis.net/ows/2.0/owsExceptionReport.xsd">
+  <ows:Exception exceptionCode="InvalidParameterValue" locator="request">
+    <ows:ExceptionText>msWCSParseScaleExtentString20(): WCS server error. Invalid extent: the extent is too large.</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>

--- a/msautotest/wxs/wcs_simple.map
+++ b/msautotest/wxs/wcs_simple.map
@@ -261,6 +261,10 @@
 # ScalingError
 # RUN_PARMS: wcs_20_exception_scaling.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=2.0.1&REQUEST=GetCoverage&COVERAGEID=grey&FORMAT=image/tiff&RESOLUTION=x(5)&SIZE=x(10)" > [RESULT_DEMIME]
 #
+# ScaleExtent exceptions
+# RUN_PARMS: wcs_20_exception_scaleextent.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=2.0.1&REQUEST=GetCoverage&COVERAGEID=grey&SCALEEXTENT=x(6666611106:366666666)" > [RESULT_DEMIME]
+# RUN_PARMS: wcs_20_exception_scaleextent2.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=2.0.1&REQUEST=GetCoverage&COVERAGEID=grey&SCALEEXTENT=x(-2000000000:2000000000)" > [RESULT_DEMIME]
+#
 # Generate error if requested coverage exceeds maxsize
 # RUN_PARMS: wcs_20_exception_exceed_maxsize.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WCS&VERSION=2.0.1&REQUEST=GetCoverage&size=x(5001)&size=y(5001)&FORMAT=image/tiff&COVERAGEID=grey" > [RESULT_DEMIME]
 #

--- a/src/mapwcs20.cpp
+++ b/src/mapwcs20.cpp
@@ -82,21 +82,25 @@ static void msXMLStripIndentation(char *ptr) {
 /************************************************************************/
 /*                   msStringParseInteger()                             */
 /*                                                                      */
-/*      Tries to parse a string as a integer value. If not possible     */
-/*      the value MS_WCS20_UNBOUNDED is stored as value.                */
-/*      If no characters could be parsed, MS_FAILURE is returned. If at */
-/*      least some characters could be parsed, MS_DONE is returned and  */
-/*      only if all characters could be parsed, MS_SUCCESS is returned. */
+/*      Parses a string as an int. Returns MS_SUCCESS only if the       */
+/*      entire string was consumed and the value fits in an int,        */
+/*      otherwise stores 0 and returns MS_FAILURE.                      */
 /************************************************************************/
 
 static int msStringParseInteger(const char *string, int *dest) {
   char *parse_check;
-  *dest = (int)strtol(string, &parse_check, 0);
-  if (parse_check == string) {
+  long value;
+
+  errno = 0;
+  value = strtol(string, &parse_check, 0);
+
+  if (parse_check == string || *parse_check != '\0' || errno == ERANGE ||
+      value < INT_MIN || value > INT_MAX) {
+    *dest = 0;
     return MS_FAILURE;
-  } else if (parse_check - strlen(string) != string) {
-    return MS_DONE;
   }
+
+  *dest = (int)value;
   return MS_SUCCESS;
 }
 
@@ -673,7 +677,7 @@ static int msWCSParseScaleExtentString20(char *string, char *outAxis,
   number = strchr(string, '(');
 
   if (NULL == number) {
-    msSetError(MS_WCSERR, "Invalid extent parameter value : %s.",
+    msSetError(MS_WCSERR, "Invalid extent parameter value : %s",
                "msWCSParseScaleExtentString20()", string);
     return MS_FAILURE;
   }
@@ -682,7 +686,7 @@ static int msWCSParseScaleExtentString20(char *string, char *outAxis,
   colon = strchr(string, ':');
 
   if (NULL == colon || colon < number) {
-    msSetError(MS_WCSERR, "Invalid extent parameter value : %s.",
+    msSetError(MS_WCSERR, "Invalid extent parameter value : %s",
                "msWCSParseScaleExtentString20()", string);
     return MS_FAILURE;
   }
@@ -706,12 +710,12 @@ static int msWCSParseScaleExtentString20(char *string, char *outAxis,
 
   if (msStringParseInteger(number, outMin) != MS_SUCCESS) {
     *outMin = 0;
-    msSetError(MS_WCSERR, "Invalid min parameter value : %s.",
+    msSetError(MS_WCSERR, "Invalid min parameter value : %s",
                "msWCSParseScaleExtentString20()", number);
     return MS_FAILURE;
   } else if (msStringParseInteger(colon, outMax) != MS_SUCCESS) {
     *outMax = 0;
-    msSetError(MS_WCSERR, "Invalid resolution parameter value : %s.",
+    msSetError(MS_WCSERR, "Invalid max parameter value : %s",
                "msWCSParseScaleExtentString20()", colon);
     return MS_FAILURE;
   }
@@ -719,6 +723,15 @@ static int msWCSParseScaleExtentString20(char *string, char *outAxis,
   if (*outMin > *outMax) {
     msSetError(MS_WCSERR,
                "Invalid extent: lower part is higher than upper part.",
+               "msWCSParseScaleExtentString20()");
+    return MS_FAILURE;
+  }
+
+  /* Axis size is (max - min), but the value must fit into an int */
+  if (*outMin < 0 && *outMax > INT_MAX + *outMin) {
+    *outMin = 0;
+    *outMax = 0;
+    msSetError(MS_WCSERR, "Invalid extent: the extent is too large.",
                "msWCSParseScaleExtentString20()");
     return MS_FAILURE;
   }
@@ -1318,6 +1331,13 @@ static int msWCSParseRequest20_XMLGetCoverage(mapObj *map, xmlNodePtr root,
 
               if (high <= low) {
                 msSetError(MS_WCSERR, "Invalid extent, high is lower than low.",
+                           "msWCSParseRequest20_XMLGetCoverage()");
+                return MS_FAILURE;
+              }
+
+              if (low < 0 && high > INT_MAX + low) {
+                msSetError(MS_WCSERR,
+                           "Invalid extent, the extent is too large.",
                            "msWCSParseRequest20_XMLGetCoverage()");
                 return MS_FAILURE;
               }


### PR DESCRIPTION
Fix for mapserver:owsfuzzer: Integer-overflow in msWCSParseRequest20 553179917

- Handle integer overflows for `SCALEEXTENT` parameters
- Also fixes for the same issue when using POST/XML
- Update `msStringParseInteger` function. This previously had a `MS_DONE` return parameter, but it was never used so I have removed it. The docstring comment also referred to setting the return value to `MS_WCS20_UNBOUNDED` but this was never implemented. The function now checks the value is in a valid integer range. There are probably GDAL CPL functions we could use for much of these value conversions. This is a local function so the impact is restricted to `mapwcs20.cpp`.
- Fixed an incorrect copied and pasted error message. 
- Removed `.` from the integer error messages as it made the values look like messed-up floats 
- Added tests for the new error paths