### PR TITLE
mapkmlrenderer: bound coordinate and extent formatting with snprintf

### DIFF
--- a/msautotest/wxs/expected/wms_kml_bigcoord.kml
+++ b/msautotest/wxs/expected/wms_kml_bigcoord.kml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document>
+    <Style id="LayerFolder_check">
+      <ListStyle>
+        <listItemType>check</listItemType>
+      </ListStyle>
+    </Style>
+    <Style id="LayerFolder_checkHideChildren">
+      <ListStyle>
+        <listItemType>checkHideChildren</listItemType>
+      </ListStyle>
+    </Style>
+    <Style id="LayerFolder_checkOffOnly">
+      <ListStyle>
+        <listItemType>checkOffOnly</listItemType>
+      </ListStyle>
+    </Style>
+    <Style id="LayerFolder_radioFolder">
+      <ListStyle>
+        <listItemType>radioFolder</listItemType>
+      </ListStyle>
+    </Style>
+    <name>KML_BIGCOORD</name>
+    <Style id="style_line_ff0000dc_w1.0">
+      <LineStyle>
+        <color>ff0000dc</color>
+        <width>1.0</width>
+      </LineStyle>
+    </Style>
+    <Folder>
+      <name>bigline</name>
+      <visibility>1</visibility>
+      <styleUrl>#LayerFolder_check</styleUrl>
+      <Placemark>
+        <name>bigline.0</name>
+        <styleUrl>#style_line_ff0000dc_w1.0</styleUrl>
+        <LineString>
+          <coordinates>
+	0.00000000,0.00000000
+	100000000000000005250476025520442024870446858110815915491585411551180245798890819578637137508044786404370444383288387817694252	</coordinates>
+        </LineString>
+      </Placemark>
+    </Folder>
+  </Document>
+</kml>

--- a/msautotest/wxs/wms_kml_bigcoord.map
+++ b/msautotest/wxs/wms_kml_bigcoord.map
@@ -1,0 +1,57 @@
+#
+# Test KML output with an out-of-range coordinate.
+#
+# A vertex whose value does not fit the fixed coordinate buffer used by the
+# KML renderer must not overflow it. See addCoordsNode() in mapkmlrenderer.cpp.
+#
+# REQUIRES: INPUT=GDAL OUTPUT=KML SUPPORTS=WMS
+
+# RUN_PARMS: wms_kml_bigcoord.kml [MAPSERV] QUERY_STRING="map=[MAPFILE]&SERVICE=WMS&VERSION=1.1.0&REQUEST=GetMap&SRS=EPSG:4326&BBOX=-1e307,-1e307,1e307,1e307&FORMAT=kml&WIDTH=100&HEIGHT=100&STYLES=&LAYERS=bigline" > [RESULT_DEMIME]
+
+MAP
+  NAME KML_BIGCOORD
+  STATUS ON
+  SIZE 100 100
+  EXTENT -1e307 -1e307 1e307 1e307
+  UNITS DD
+  IMAGECOLOR 255 255 255
+
+  PROJECTION
+    "init=epsg:4326"
+  END
+
+  WEB
+    IMAGEPATH "/tmp/ms_tmp/"
+    IMAGEURL "/ms_tmp/"
+    METADATA
+      "ows_enable_request"   "*"
+      "wms_title"            "kml bigcoord"
+      "wms_onlineresource"   "http://localhost/?"
+      "wms_srs"             "EPSG:4326"
+    END
+  END
+
+  LAYER
+    NAME bigline
+    TYPE LINE
+    STATUS ON
+    PROJECTION
+      "init=epsg:4326"
+    END
+    METADATA
+      "wms_title" "bigline"
+    END
+    FEATURE
+      POINTS
+        0 0
+        1e300 1e300
+      END
+    END
+    CLASS
+      STYLE
+        COLOR 220 0 0
+        WIDTH 1
+      END
+    END
+  END
+END

--- a/src/mapkmlrenderer.cpp
+++ b/src/mapkmlrenderer.cpp
@@ -668,12 +668,13 @@ void KmlRenderer::addCoordsNode(xmlNodePtr parentNode, pointObj *pts,
 
   for (int i = 0; i < numPts; i++) {
     if (mElevationFromAttribute) {
-      sprintf(lineBuf, "\t%.8f,%.8f,%.8f\n", pts[i].x, pts[i].y,
-              mCurrentElevationValue);
+      snprintf(lineBuf, sizeof(lineBuf), "\t%.8f,%.8f,%.8f\n", pts[i].x,
+               pts[i].y, mCurrentElevationValue);
     } else if (AltitudeMode == relativeToGround || AltitudeMode == absolute) {
-      sprintf(lineBuf, "\t%.8f,%.8f,%.8f\n", pts[i].x, pts[i].y, pts[i].z);
+      snprintf(lineBuf, sizeof(lineBuf), "\t%.8f,%.8f,%.8f\n", pts[i].x,
+               pts[i].y, pts[i].z);
     } else
-      sprintf(lineBuf, "\t%.8f,%.8f\n", pts[i].x, pts[i].y);
+      snprintf(lineBuf, sizeof(lineBuf), "\t%.8f,%.8f\n", pts[i].x, pts[i].y);
 
     xmlNodeAddContent(coordsNode, BAD_CAST lineBuf);
   }
@@ -869,16 +870,16 @@ xmlNodePtr KmlRenderer::createGroundOverlayNode(xmlNodePtr parentNode,
 
   xmlNodePtr latLonBoxNode =
       xmlNewChild(groundOverlayNode, NULL, BAD_CAST "LatLonBox", NULL);
-  sprintf(crdStr, "%.8f", mapextent.maxy);
+  snprintf(crdStr, sizeof(crdStr), "%.8f", mapextent.maxy);
   xmlNewChild(latLonBoxNode, NULL, BAD_CAST "north", BAD_CAST crdStr);
 
-  sprintf(crdStr, "%.8f", mapextent.miny);
+  snprintf(crdStr, sizeof(crdStr), "%.8f", mapextent.miny);
   xmlNewChild(latLonBoxNode, NULL, BAD_CAST "south", BAD_CAST crdStr);
 
-  sprintf(crdStr, "%.8f", mapextent.minx);
+  snprintf(crdStr, sizeof(crdStr), "%.8f", mapextent.minx);
   xmlNewChild(latLonBoxNode, NULL, BAD_CAST "west", BAD_CAST crdStr);
 
-  sprintf(crdStr, "%.8f", mapextent.maxx);
+  snprintf(crdStr, sizeof(crdStr), "%.8f", mapextent.maxx);
   xmlNewChild(latLonBoxNode, NULL, BAD_CAST "east", BAD_CAST crdStr);
 
   xmlNewChild(latLonBoxNode, NULL, BAD_CAST "rotation", BAD_CAST "0.0");
@@ -1152,7 +1153,7 @@ const char *KmlRenderer::lookupPlacemarkStyle() {
                     BAD_CAST lineHexColor);
 
         char width[16];
-        sprintf(width, "%.1f", LineStyle[i].width);
+        snprintf(width, sizeof(width), "%.1f", LineStyle[i].width);
         xmlNewChild(lineStyleNode, NULL, BAD_CAST "width", BAD_CAST width);
       }
     }


### PR DESCRIPTION
## What does this PR do?

KmlRenderer::addCoordsNode formats each vertex into a fixed 128-byte lineBuf with an unbounded sprintf. KML output runs with MS_TRANSFORM_NONE, so raw data-source coordinates and Z values reach the renderer without clipping, and the third value comes straight from atof() on a feature attribute when kml_elevation_attribute is set. A coordinate or elevation whose magnitude does not fit the buffer (a shapefile vertex or attribute on the order of 1e300) formats to a few hundred bytes and overruns the stack.

Switch that write, and the two sibling sprintf sites in the same file that format request- or attribute-controlled doubles into small buffers (the LatLonBox extent in createGroundOverlayNode, the line width in lookupPlacemarkStyle), to snprintf bounded by sizeof. Keeping the bound at the formatting site covers every caller of the renderer without reaching into the geometry paths.

## What are related issues/pull requests?

None; found while auditing the KML output path.

## AI tool usage

 - [ ] AI supported my development of this PR. See our [policy about AI tool use](https://mapserver.org/community/ai_tool_policy.html). Use of AI tools, if any, *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://mapserver.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s) in `/msautotest` (follow steps in [Regression Testing](https://mapserver.org/development/tests/autotest.html))
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed