### PR TITLE
Restore the missing first line of the licence grant in four headers

### DIFF
--- a/src/mapquery.h
+++ b/src/mapquery.h
@@ -6,6 +6,7 @@
  ******************************************************************************
  * Copyright (c) 2025 Even Rouault
  *
+ * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,

--- a/src/mapraster.h
+++ b/src/mapraster.h
@@ -8,6 +8,7 @@
  ******************************************************************************
  * Copyright (c) 2013 Regents of the University of Minnesota.
  *
+ * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,

--- a/src/maprendering.h
+++ b/src/maprendering.h
@@ -6,6 +6,7 @@
  ******************************************************************************
  * Copyright (c) 2025 Even Rouault
  *
+ * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,

--- a/src/mapserver.h
+++ b/src/mapserver.h
@@ -8,6 +8,7 @@
  ******************************************************************************
  * Copyright (c) 1996-2005 Regents of the University of Minnesota.
  *
+ * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,


### PR DESCRIPTION
Four headers in `src/` are missing the opening line of the MIT permission grant, so the notice begins mid-sentence:

```
 * Copyright (c) 1996-2005 Regents of the University of Minnesota.
 *
 * copy of this software and associated documentation files (the "Software"),
 * to deal in the Software without restriction, including without limitation
```

The line `Permission is hereby granted, free of charge, to any person obtaining a` appears to have been lost at some point. The affected files are `src/mapquery.h`, `src/mapraster.h`, `src/maprendering.h` and `src/mapserver.h`; the other 153 headers I checked in `src/` are intact.

This adds the missing line back, taking the wording verbatim from `src/mapshape.c`, where the grant is complete. Four insertions, comment text only.

To be clear, this is cosmetic — `LICENSE.md` states the licence correctly and completely, so nothing about MapServer's licensing is in doubt. I noticed it only because a downstream project vendors `mapserver.h` and reproduces its header in a third-party notices file.
