### PR TITLE
Fix memleak in mapogcsld

### DIFF
--- a/src/mapogcsld.cpp
+++ b/src/mapogcsld.cpp
@@ -663,6 +663,7 @@ layerObj *msSLDParseSLD(mapObj *map, const char *psSLDXML, int *pnLayers) {
   psSLD = CPLGetXMLNode(psRoot, "=StyledLayerDescriptor");
   if (!psSLD) {
     msSetError(MS_WMSERR, "Invalid SLD document : %s", "", psSLDXML);
+    CPLDestroyXMLNode(psRoot);
     return NULL;
   }
 
@@ -673,8 +674,10 @@ layerObj *msSLDParseSLD(mapObj *map, const char *psSLDXML, int *pnLayers) {
 
   if (nLayers > 0)
     pasLayers = (layerObj *)malloc(sizeof(layerObj) * nLayers);
-  else
+  else {
+    CPLDestroyXMLNode(psRoot);
     return NULL;
+  }
 
   LOOP_ON_CHILD_ELEMENT(psSLD, psNamedLayer, "NamedLayer") {
     CPLXMLNode *psName = CPLGetXMLNode(psNamedLayer, "Name");


### PR DESCRIPTION
In #7636, a new fuzzer targets sld is added and discover a possible memory leakage problem in the error paths of the msSLDParseSLD function. This PR fixes that by correctly adding the CPLDestroyXMLNode call to release the allocated memory.