### PR TITLE
CI: upgrade PCRE2 to 10.48 release

### DIFF
--- a/ci/ubuntu/setup.sh
+++ b/ci/ubuntu/setup.sh
@@ -45,7 +45,7 @@ else
 fi
 
 cd swig-git-master
-wget -nc https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.gz
+wget -nc https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.48/pcre2-10.48.tar.gz
 ./Tools/pcre-build.sh
 ./autogen.sh
 ./configure --prefix=/usr

--- a/msautotest/php/README.md
+++ b/msautotest/php/README.md
@@ -14,11 +14,11 @@ You can run a single test such as: `phpunit classObjTest.php`
 # Configuring the test environment
 
 This folder includes a `phpunit.xml` configuration file for these tests.  More 
-info about these settings: https://docs.phpunit.de/en/10.1/configuration.html
+info about these settings: https://docs.phpunit.de/en/13.3/configuration.html
 
 # PHPNG (SWIG) MapScript API documentation
 
-Follow: https://mapserver.org/mapscript/mapscript.html
+Follow: https://mapserver.org/mapscript/mapscript-api/
 
 
 

--- a/src/mapscript/README.md
+++ b/src/mapscript/README.md
@@ -42,13 +42,13 @@ This is not a JavaScript version of MapScript, but provides support for the use 
 in [STYLEITEM](https://mapserver.org/mapfile/styleitem.html#styleitemjs) and 
 [GEOTRANSFORM](https://mapserver.org/mapfile/geomtransform.html#geomtransformjs). 
 
-API Documentation can be found at the [Shared SWIG MapScript Documentation](https://mapserver.org/mapscript/index.html) 
+API Documentation can be found at the [Shared SWIG MapScript Documentation](https://mapserver.org/mapscript/mapscript-api/) 
 page. 
 
 PHPNG (SWIG) MapScript
 ----------------------
 
-PHP support ("PHPNG") is included in the [SWIG API](https://mapserver.org/mapscript/index.html) 
+PHP support ("PHPNG") is included in the [SWIG API](https://mapserver.org/mapscript/mapscript-api/) 
 since the MapServer 7.4.0 release.  You can specify `WITH_PHPNG=ON` at your 
 CMake commandline, to compile PHPNG support for MapServer.
 

--- a/src/mapscript/php/README.md
+++ b/src/mapscript/php/README.md
@@ -1,4 +1,4 @@
 Old native (and unmaintained) PHP MapScript was removed for the 
-MapServer 8.0 release.  Please see the /mapscript/phpng/ folder 
+MapServer 8.0 release.  Please see the /src/mapscript/phpng/ folder 
 for the maintained PHP MapScript support through SWIG, or the 
-documentation at https://mapserver.org/mapscript/mapscript.html .
+documentation at https://mapserver.org/mapscript/mapscript-api/ .


### PR DESCRIPTION
- used in the SWIG compile step
- also fixes broken links to PHP SWIG API
