### PR TITLE
mapcontext: fix out-of-bounds read on short BoundingBox SRS

### DIFF
--- a/msautotest/wxs/expected/ows_context_bad_srs_caps.xml
+++ b/msautotest/wxs/expected/ows_context_bad_srs_caps.xml
@@ -1,0 +1,128 @@
+Content-Type: application/vnd.ogc.wms_xml; charset=UTF-8
+
+<?xml version='1.0' encoding="UTF-8" standalone="no" ?>
+<!DOCTYPE WMT_MS_Capabilities SYSTEM "http://schemas.opengis.net/wms/1.1.1/WMS_MS_Capabilities.dtd"
+ [
+ <!ELEMENT VendorSpecificCapabilities EMPTY>
+ ]>  <!-- end of DOCTYPE declaration -->
+
+<WMT_MS_Capabilities version="1.1.1">
+<Service>
+  <Name>OGC:WMS</Name>
+<!-- WARNING: Mandatory metadata "wms_title" or "ows_title" was missing in this context. -->
+  <Title>OWS_CONTEXT_TEST</Title>
+  <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/>
+  <ContactInformation>
+  </ContactInformation>
+</Service>
+
+<Capability>
+  <Request>
+    <GetCapabilities>
+      <Format>application/vnd.ogc.wms_xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetCapabilities>
+    <GetMap>
+      <Format>image/png</Format>
+      <Format>image/jpeg</Format>
+      <Format>image/png; mode=8bit</Format>
+      <Format>image/vnd.jpeg-png</Format>
+      <Format>image/vnd.jpeg-png8</Format>
+      <Format>application/x-pdf</Format>
+      <Format>image/svg+xml</Format>
+      <Format>image/tiff</Format>
+      <Format>application/vnd.google-earth.kml+xml</Format>
+      <Format>application/vnd.google-earth.kmz</Format>
+      <Format>application/vnd.mapbox-vector-tile</Format>
+      <Format>application/x-protobuf</Format>
+      <Format>application/json</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetMap>
+    <GetFeatureInfo>
+      <Format>text/plain</Format>
+      <Format>application/vnd.ogc.gml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetFeatureInfo>
+    <DescribeLayer>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </DescribeLayer>
+    <GetLegendGraphic>
+      <Format>image/png</Format>
+      <Format>image/jpeg</Format>
+      <Format>image/png; mode=8bit</Format>
+      <Format>image/vnd.jpeg-png</Format>
+      <Format>image/vnd.jpeg-png8</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetLegendGraphic>
+    <GetStyles>
+      <Format>text/xml</Format>
+      <DCPType>
+        <HTTP>
+          <Get><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/></Get>
+          <Post><OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;"/></Post>
+        </HTTP>
+      </DCPType>
+    </GetStyles>
+  </Request>
+  <Exception>
+    <Format>application/vnd.ogc.se_xml</Format>
+    <Format>application/vnd.ogc.se_inimage</Format>
+    <Format>application/vnd.ogc.se_blank</Format>
+  </Exception>
+  <VendorSpecificCapabilities />
+  <UserDefinedSymbolization SupportSLD="1" UserLayer="0" UserStyle="1" RemoteWFS="0"/>
+  <Layer>
+    <Name>OWS_CONTEXT_TEST</Name>
+<!-- WARNING: Mandatory metadata "wms_title" or "ows_title" was missing in this context. -->
+    <Title>OWS_CONTEXT_TEST</Title>
+    <Abstract>OWS_CONTEXT_TEST</Abstract>
+<!-- WARNING: Mandatory mapfile parameter '(at least one of) MAP.PROJECTION, LAYER.PROJECTION or wms_srs metadata' was missing in this context. -->
+    <SRS></SRS>
+    <LatLonBoundingBox minx="-67.572500" miny="42.000000" maxx="-58.927500" maxy="48.500000" />
+    <Layer queryable="0" opaque="0" cascaded="0">
+      <Name>province</Name>
+      <Title>province</Title>
+<!-- WARNING: Mandatory mapfile parameter '(at least one of) MAP.PROJECTION, LAYER.PROJECTION or wms_srs metadata' was missing in this context. -->
+      <LatLonBoundingBox minx="-66.724329" miny="41.770508" maxx="-57.721680" maxy="48.477314" />
+      <MetadataURL type="TC211">
+        <Format>text/xml</Format>
+        <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;request=GetMetadata&amp;layer=province"/>
+      </MetadataURL>
+        <Style>
+          <Name>default</Name>
+          <Title>default</Title>
+          <LegendURL width="85" height="20">
+             <Format>image/png</Format>
+             <OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="http://localhost/path/to/wfs_simple?myparam=something&amp;version=1.1.1&amp;service=WMS&amp;request=GetLegendGraphic&amp;layer=province&amp;format=image/png&amp;STYLE=default"/>
+          </LegendURL>
+        </Style>
+    </Layer>
+  </Layer>
+</Capability>
+</WMT_MS_Capabilities>

--- a/msautotest/wxs/ows_context.map
+++ b/msautotest/wxs/ows_context.map
@@ -6,6 +6,8 @@
 # Capabilities updatesequence (less than)
 # RUN_PARMS: ows_context_caps.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&CONTEXT=ows_context.xml&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities" > [RESULT_DEVERSION]
 # RUN_PARMS: ows_context_with_layer_list_caps.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&CONTEXT=ows_context_with_layer_list.xml&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities" > [RESULT_DEVERSION]
+# Context whose BoundingBox SRS is shorter than the "EPSG:" prefix (used to read out of bounds)
+# RUN_PARMS: ows_context_bad_srs_caps.xml [MAPSERV] QUERY_STRING="map=[MAPFILE]&CONTEXT=ows_context_bad_srs.xml&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetCapabilities" > [RESULT_DEVERSION]
 
 MAP
 

--- a/msautotest/wxs/ows_context_bad_srs.xml
+++ b/msautotest/wxs/ows_context_bad_srs.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding="ISO-8859-1" standalone="no" ?>
+<ViewContext version="1.1.0" id="mapcontext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.opengis.net/context" xmlns:sld="http://www.opengis.net/sld" xsi:schemaLocation="http://www.opengis.net/context http://schemas.opengis.net/context/1.1.0/context.xsd">
+  <General>
+    <Window width="400" height="300"/>
+    <!-- Malformed SRS shorter than the assumed 5-char "EPSG:" prefix -->
+    <BoundingBox SRS="X" minx="-180.000000" miny="-90.000000" maxx="180.000000" maxy="90.000000"/>
+    <Title>Map Context demo</Title>
+    <Abstract>Demo for map context document</Abstract>
+    <ContactInformation>
+    </ContactInformation>
+  </General>
+</ViewContext>

--- a/src/mapcontext.c
+++ b/src/mapcontext.c
@@ -637,9 +637,11 @@ int msLoadMapContextGeneral(mapObj *map, CPLXMLNode *psGeneral,
   if (pszValue != NULL && !EQUAL(pszValue, "(null)")) {
     if (strncasecmp(pszValue, "AUTO:", 5) == 0) {
       pszProj = msStrdup(pszValue);
-    } else {
+    } else if (strncasecmp(pszValue, "EPSG:", 5) == 0) {
       pszProj = (char *)malloc(sizeof(char) * (strlen(pszValue) + 10));
       sprintf(pszProj, "init=epsg:%s", pszValue + 5);
+    } else {
+      pszProj = msStrdup(pszValue);
     }
 
     msFreeProjection(&map->projection);


### PR DESCRIPTION
## What does this PR do?

`msLoadMapContextGeneral()` reads `General.BoundingBox.SRS` from a Web Map Context document, and after ruling out the `AUTO:` prefix it builds the projection with `sprintf(pszProj, "init=epsg:%s", pszValue + 5)`, assuming the value starts with a 5-character `EPSG:` prefix. The context document is untrusted (the CGI `context=` parameter loads a local or remote WMC, e.g. through `CGI_CONTEXT_URL`), so an SRS shorter than five characters such as `SRS="X"` makes `pszValue + 5` point past the end of the value and the copy reads out of bounds.

The strip now happens only when the value actually begins with `EPSG:`, mirroring the `AUTO:` branch right above it; anything else is passed through unchanged so an invalid SRS is rejected by the projection layer instead of walking off the buffer. Under AddressSanitizer a GetCapabilities request with a short-SRS context aborts with a heap-buffer-overflow at `mapcontext.c:642` before the change and runs clean after it.

## What are related issues/pull requests?

None; found while reading the context loader.

## AI tool usage

 - [ ] AI supported my development of this PR. See our [policy about AI tool use](https://mapserver.org/community/ai_tool_policy.html). Use of AI tools, if any, *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://mapserver.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s) in `/msautotest` (follow steps in [Regression Testing](https://mapserver.org/development/tests/autotest.html))
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
