### PR TITLE
flatgeobuf: bound geometry ring ends to the xy coordinate count

### DIFF
--- a/src/flatgeobuf/geometryreader.cpp
+++ b/src/flatgeobuf/geometryreader.cpp
@@ -5,14 +5,21 @@ using namespace FlatGeobuf;
 
 void GeometryReader::readPoint(shapeObj *shape)
 {
+    if (m_offset >= m_xy_count) {
+        msSetError(MS_FGBERR,
+                   "Corrupt FlatGeobuf geometry: point offset out of bounds",
+                   "GeometryReader::readPoint");
+        return;
+    }
+
     lineObj *l = (lineObj *) malloc(sizeof(lineObj));
     pointObj *p = (pointObj *) malloc(sizeof(pointObj));
 
-	p->x = m_xy[m_offset + 0];
-	p->y = m_xy[m_offset + 1];
-    if (m_has_z)
+	p->x = m_xy[m_offset * 2 + 0];
+	p->y = m_xy[m_offset * 2 + 1];
+    if (m_has_z && m_geometry->z() != nullptr && m_offset < m_geometry->z()->size())
         p->z = m_geometry->z()->data()[m_offset];
-    if (m_has_m)
+    if (m_has_m && m_geometry->m() != nullptr && m_offset < m_geometry->m()->size())
         p->m = m_geometry->m()->data()[m_offset];
 
     l[0].numpoints = 1;
@@ -24,8 +31,42 @@ void GeometryReader::readPoint(shapeObj *shape)
 
 void GeometryReader::readLineObj(lineObj *line)
 {
-    const double *z = m_has_z ? m_geometry->z()->data() : nullptr;
-    const double *m = m_has_m ? m_geometry->m()->data() : nullptr;
+    line->point = nullptr;
+    line->numpoints = 0;
+
+    /* m_offset and m_length are derived from the geometry part "ends" taken
+       from the (untrusted) file and are not validated by the flatbuffer
+       accessors. Reject a range that does not fit the xy array before any
+       read, so a crafted end index cannot walk off the coordinate buffer. */
+    if (m_offset > m_xy_count || m_length > m_xy_count - m_offset) {
+        msSetError(MS_FGBERR,
+                   "Corrupt FlatGeobuf geometry: coordinate range out of bounds",
+                   "GeometryReader::readLineObj");
+        return;
+    }
+
+    const double *z = nullptr;
+    const double *m = nullptr;
+    if (m_has_z) {
+        const auto zv = m_geometry->z();
+        if (zv == nullptr || m_offset + m_length > zv->size()) {
+            msSetError(MS_FGBERR,
+                       "Corrupt FlatGeobuf geometry: z range out of bounds",
+                       "GeometryReader::readLineObj");
+            return;
+        }
+        z = zv->data();
+    }
+    if (m_has_m) {
+        const auto mv = m_geometry->m();
+        if (mv == nullptr || m_offset + m_length > mv->size()) {
+            msSetError(MS_FGBERR,
+                       "Corrupt FlatGeobuf geometry: m range out of bounds",
+                       "GeometryReader::readLineObj");
+            return;
+        }
+        m = mv->data();
+    }
 
     line->point = (pointObj *) malloc(m_length * sizeof(pointObj));
     line->numpoints = m_length;
@@ -130,9 +171,12 @@ void GeometryReader::read(shapeObj *shape)
 
     // if not nested must have geometry data
     const auto pXy = m_geometry->xy();
+    if (pXy == nullptr)
+        return;
     const auto xySize = pXy->size();
     m_xy = pXy->data();
-    m_length = xySize / 2;
+    m_xy_count = xySize / 2;
+    m_length = m_xy_count;
 
     switch (m_geometry_type) {
         case GeometryType::Point: return readPoint(shape);

--- a/src/flatgeobuf/geometryreader.h
+++ b/src/flatgeobuf/geometryreader.h
@@ -19,6 +19,7 @@ class GeometryReader {
         bool m_has_m;
 
         const double *m_xy = nullptr;
+        uint32_t m_xy_count = 0;
         uint32_t m_length = 0;
         uint32_t m_offset = 0;
 

--- a/tests/unit/test.cpp
+++ b/tests/unit/test.cpp
@@ -1,6 +1,10 @@
 #include "../../src/mapserver.h"
 #include "../../src/maperror.h"
 
+#include "../../src/flatgeobuf/geometryreader.h"
+#include "../../src/flatgeobuf/feature_generated.h"
+#include <vector>
+
 /* ----------------------------------------------------------------------- */
 
 int gTestRetCode = 0;
@@ -197,9 +201,45 @@ static void testDBFFieldExtentValidation() {
 
 /* ----------------------------------------------------------------------- */
 
+static void testFlatGeobufGeometryBounds() {
+  /* A FlatGeobuf polygon carries its rings as "ends" (indices into the xy
+     coordinate array). The values come straight from the file and are not
+     validated by the flatbuffer accessors, so an end index past the number of
+     stored coordinates made GeometryReader read past the xy buffer. */
+  using namespace flatbuffers;
+  using namespace FlatGeobuf;
+
+  FlatBufferBuilder fbb;
+  std::vector<double> xy = {0.0, 0.0, 1.0, 1.0}; /* two coordinate pairs */
+  std::vector<uint32_t> ends = {2, 5}; /* second ring claims points up to 5 */
+  auto geom = CreateGeometryDirect(fbb, &ends, &xy, nullptr, nullptr, nullptr,
+                                   nullptr, GeometryType::Polygon, nullptr);
+  fbb.Finish(geom);
+
+  std::vector<uint8_t> buf(fbb.GetBufferPointer(),
+                           fbb.GetBufferPointer() + fbb.GetSize());
+  auto g = GetRoot<Geometry>(buf.data());
+
+  flatgeobuf_ctx ctx;
+  memset(&ctx, 0, sizeof(ctx));
+  ctx.geometry_type = (uint8_t)GeometryType::Polygon;
+
+  shapeObj shape;
+  msInitShape(&shape);
+  GeometryReader(&ctx, g).read(&shape);
+
+  /* The out-of-range ring must be dropped rather than read out of bounds. */
+  for (int i = 0; i < shape.numlines; i++)
+    EXPECT_TRUE(shape.line[i].numpoints <= 2);
+  msFreeShape(&shape);
+}
+
+/* ----------------------------------------------------------------------- */
+
 int main() {
   testRedactCredentials();
   testToString();
   testDBFFieldExtentValidation();
+  testFlatGeobufGeometryBounds();
   return gTestRetCode;
 }


### PR DESCRIPTION
## What does this PR do?

`GeometryReader` in `src/flatgeobuf/geometryreader.cpp` builds a `shapeObj` from an `.fgb` feature's coordinates. For a polygon the per-ring end indices come from the geometry's `ends()` array in the file, and `readLineObj()` used them to walk `m_xy` (and the parallel `z`/`m` arrays) without checking them against the number of coordinate pairs actually present in `xy()`. A ring end index past the coordinate count reads past the buffer; `readPoint()` had the same unchecked indexing. The flatbuffer is not verified, so those sizes are file-controlled.

The reader now records the available coordinate-pair count when `xy` is read and rejects any ring range that does not fit it (and any `z`/`m` array shorter than the requested points) before allocating or copying. Keeping the check in `readLineObj`/`readPoint` covers point, line, polygon and the multipoint/multiline/multipolygon variants that all funnel through the same code.

## What are related issues/pull requests?

Same neighbourhood as #7545, which bounded the property blob; this covers the geometry-decoding side.

## AI tool usage

 - [ ] AI supported my development of this PR. See our [policy about AI tool use](https://mapserver.org/community/ai_tool_policy.html). Use of AI tools, if any, *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://mapserver.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s) in `/msautotest` (follow steps in [Regression Testing](https://mapserver.org/development/tests/autotest.html))
 - [x] Add a regression test (`tests/unit/test.cpp`: decodes a polygon whose ring end exceeds its coordinate count; fails under ASan before the fix, passes after)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed
